### PR TITLE
[RW-12] Base nodes and vocabularies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,8 @@
         "drupal/imageapi_optimize_binaries": "^1.0-alpha2",
         "drupal/maintenance200": "^1.1",
         "drupal/metatag": "^1.16",
+        "drupal/migrate_plus": "^5.1",
+        "drupal/migrate_tools": "^5.0",
         "drupal/paragraphs": "^1.12",
         "drupal/paragraphs_viewmode": "^1.0",
         "drupal/pathauto": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "drupal/core-dev": "^9.1",
         "drupal/core-recommended": "^9.1",
         "drupal/core-composer-scaffold": "^9.1",
+        "drupal/geofield": "^1.22",
         "drupal/google_tag": "^1.4",
         "drupal/imageapi_optimize_binaries": "^1.0-alpha2",
         "drupal/maintenance200": "^1.1",
@@ -48,12 +49,10 @@
         "drupal/coder": "^8.3.12",
         "drupal/console": "^1.9.7",
         "drupal/devel": "^4.1.1",
-        "drupal/yaml_content": "^1.0@alpha",
         "mikey179/vfsstream": "^1.6.8",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "phpmd/phpmd": "^2.9.1",
-        "phpunit/phpunit": "^9.5.4",
-        "weitzman/drupal-test-traits": "^1.5"
+        "phpunit/phpunit": "^9.5.4"
     },
     "conflict": {
         "drupal/drupal": "*",

--- a/composer.json
+++ b/composer.json
@@ -102,9 +102,6 @@
     "extra": {
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
-        "patchLevel": {
-            "drupal/core": "-p2"
-        },
         "patches-file": "composer.patches.json",
         "installer-paths": {
             "html/core": ["type:drupal-core"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "225b639e1f48a189cf97dedc0e9d3214",
+    "content-hash": "ee524184825dc48a02df5716fbdc1e5d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -442,20 +442,21 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.0.12",
+            "version": "2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "6c12ce263da71641903e399c3ce8ecb08fd375fb"
+                "reference": "986e8b86b7b570632ad0a905c3726c33dd4c0efb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/6c12ce263da71641903e399c3ce8ecb08fd375fb",
-                "reference": "6c12ce263da71641903e399c3ce8ecb08fd375fb",
+                "url": "https://api.github.com/repos/composer/composer/zipball/986e8b86b7b570632ad0a905c3726c33dd4c0efb",
+                "reference": "986e8b86b7b570632ad0a905c3726c33dd4c0efb",
                 "shasum": ""
             },
             "require": {
                 "composer/ca-bundle": "^1.0",
+                "composer/metadata-minifier": "^1.0",
                 "composer/semver": "^3.0",
                 "composer/spdx-licenses": "^1.2",
                 "composer/xdebug-handler": "^1.1",
@@ -519,7 +520,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.0.12"
+                "source": "https://github.com/composer/composer/tree/2.0.13"
             },
             "funding": [
                 {
@@ -535,7 +536,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-01T08:14:59+00:00"
+            "time": "2021-04-27T11:11:08+00:00"
         },
         {
             "name": "composer/installers",
@@ -684,6 +685,75 @@
                 }
             ],
             "time": "2021-01-14T11:07:16+00:00"
+        },
+        {
+            "name": "composer/metadata-minifier",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/metadata-minifier.git",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/c549d23829536f0d0e984aaabbf02af91f443207",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2",
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\MetadataMinifier\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Small utility library that handles metadata minification and expansion.",
+            "keywords": [
+                "composer",
+                "compression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/metadata-minifier/issues",
+                "source": "https://github.com/composer/metadata-minifier/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-07T13:37:33+00:00"
         },
         {
             "name": "composer/semver",
@@ -3182,6 +3252,130 @@
                 "source": "https://git.drupalcode.org/project/metatag",
                 "issues": "https://www.drupal.org/project/issues/metatag",
                 "docs": "https://www.drupal.org/docs/8/modules/metatag"
+            }
+        },
+        {
+            "name": "drupal/migrate_plus",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/migrate_plus.git",
+                "reference": "8.x-5.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/migrate_plus-8.x-5.1.zip",
+                "reference": "8.x-5.1",
+                "shasum": "1257427ab0c64459c3c1e42bb2a98d3114b77163"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "drupal/migrate_example_advanced_setup": "*",
+                "drupal/migrate_example_setup": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "sainsburys/guzzle-oauth2-plugin": "3.0 required for the OAuth2 authentication plugin"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-5.1",
+                    "datestamp": "1588261060",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mike Ryan",
+                    "homepage": "https://www.drupal.org/u/mikeryan",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Lucas Hedding",
+                    "homepage": "https://www.drupal.org/u/heddn",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Enhancements to core migration support.",
+            "homepage": "https://www.drupal.org/project/migrate_plus",
+            "support": {
+                "source": "https://git.drupalcode.org/project/migrate_plus",
+                "issues": "https://www.drupal.org/project/issues/migrate_plus",
+                "slack": "#migrate"
+            }
+        },
+        {
+            "name": "drupal/migrate_tools",
+            "version": "dev-5.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/migrate_tools.git",
+                "reference": "9d9c02f1cb8fcd7afa83e8eb2eaf7def75673a4e"
+            },
+            "require": {
+                "drupal/core": "^8.8 | ^9",
+                "drupal/migrate_plus": "^5",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "drupal/migrate_source_csv": "^3.0",
+                "drush/drush": "^10"
+            },
+            "suggest": {
+                "drush/drush": "^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.x": "5.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-5.0+12-dev",
+                    "datestamp": "1609779021",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mike Ryan",
+                    "homepage": "https://www.drupal.org/u/mikeryan",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Lucas Hedding",
+                    "homepage": "https://www.drupal.org/u/heddn",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Tools to assist in developing and running migrations.",
+            "homepage": "http://drupal.org/project/migrate_tools",
+            "support": {
+                "source": "https://git.drupalcode.org/project/migrate_tools",
+                "issues": "https://www.drupal.org/project/issues/migrate_tools",
+                "slack": "#migrate"
             }
         },
         {
@@ -11164,16 +11358,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v4.0.0",
+            "version": "v4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "8a8860c52baf4d104eadad93235da6924c16f849"
+                "reference": "f3c0961766d62e9b95893ca83386f55cc396c7d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/8a8860c52baf4d104eadad93235da6924c16f849",
-                "reference": "8a8860c52baf4d104eadad93235da6924c16f849",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/f3c0961766d62e9b95893ca83386f55cc396c7d3",
+                "reference": "f3c0961766d62e9b95893ca83386f55cc396c7d3",
                 "shasum": ""
             },
             "require": {
@@ -11187,9 +11381,9 @@
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v4.0.0"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v4.0.2"
             },
-            "time": "2021-04-22T07:54:50+00:00"
+            "time": "2021-04-26T09:56:32+00:00"
         },
         {
             "name": "webflo/drupal-finder",
@@ -12626,22 +12820,22 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.9.1",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "ce10831d4ddc2686c1348a98069771dd314534a8"
+                "reference": "58ef9e746a1ab50ad3360d5d301e1229ed2612cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/ce10831d4ddc2686c1348a98069771dd314534a8",
-                "reference": "ce10831d4ddc2686c1348a98069771dd314534a8",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/58ef9e746a1ab50ad3360d5d301e1229ed2612cb",
+                "reference": "58ef9e746a1ab50ad3360d5d301e1229ed2612cb",
                 "shasum": ""
             },
             "require": {
                 "composer/xdebug-handler": "^1.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.7.1",
+                "pdepend/pdepend": "^2.9.1",
                 "php": ">=5.3.9"
             },
             "require-dev": {
@@ -12649,7 +12843,7 @@
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "gregwar/rst": "^1.0",
-                "mikey179/vfsstream": "^1.6.4",
+                "mikey179/vfsstream": "^1.6.8",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.27",
                 "squizlabs/php_codesniffer": "^2.0"
             },
@@ -12697,7 +12891,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/phpmd",
                 "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.9.1"
+                "source": "https://github.com/phpmd/phpmd/tree/2.10.0"
             },
             "funding": [
                 {
@@ -12705,7 +12899,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-23T22:06:32+00:00"
+            "time": "2021-04-26T18:44:44+00:00"
         },
         {
             "name": "stecman/symfony-console-completion",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "364fc78e2a5301c7bbbdf303c05b8161",
+    "content-hash": "efd7a236794ae063e519cfcf77428bf4",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee524184825dc48a02df5716fbdc1e5d",
+    "content-hash": "364fc78e2a5301c7bbbdf303c05b8161",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -540,16 +540,16 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d"
+                "reference": "ae03311f45dfe194412081526be2e003960df74b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
-                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
+                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b",
                 "shasum": ""
             },
             "require": {
@@ -643,6 +643,7 @@
                 "majima",
                 "mako",
                 "mediawiki",
+                "miaoxing",
                 "modulework",
                 "modx",
                 "moodle",
@@ -660,6 +661,7 @@
                 "sydes",
                 "sylius",
                 "symfony",
+                "tastyigniter",
                 "typo3",
                 "wordpress",
                 "yawik",
@@ -668,7 +670,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.10.0"
+                "source": "https://github.com/composer/installers/tree/v1.11.0"
             },
             "funding": [
                 {
@@ -684,7 +686,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-14T11:07:16+00:00"
+            "time": "2021-04-28T06:42:17+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -2411,16 +2413,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.1.7",
+            "version": "9.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "0cbed9e7b0243ccc89a3735853eedb40becf8095"
+                "reference": "487661aa08e9474ef234074844e7b1b8fa6e3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/0cbed9e7b0243ccc89a3735853eedb40becf8095",
-                "reference": "0cbed9e7b0243ccc89a3735853eedb40becf8095",
+                "url": "https://api.github.com/repos/drupal/core/zipball/487661aa08e9474ef234074844e7b1b8fa6e3c3c",
+                "reference": "487661aa08e9474ef234074844e7b1b8fa6e3c3c",
                 "shasum": ""
             },
             "require": {
@@ -2657,13 +2659,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/9.1.7"
+                "source": "https://github.com/drupal/core/tree/9.1.8"
             },
-            "time": "2021-04-20T23:05:22+00:00"
+            "time": "2021-05-05T11:09:15+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "9.1.7",
+            "version": "9.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -2707,13 +2709,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.1.7"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.1.8"
             },
             "time": "2020-08-07T22:30:13+00:00"
         },
         {
             "name": "drupal/core-dev",
-            "version": "9.1.7",
+            "version": "9.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-dev.git",
@@ -2756,22 +2758,22 @@
             ],
             "description": "require-dev dependencies from drupal/drupal; use in addition to drupal/core-recommended to run tests from drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-dev/tree/9.1.7"
+                "source": "https://github.com/drupal/core-dev/tree/9.1.8"
             },
             "time": "2020-10-28T08:13:15+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "9.1.7",
+            "version": "9.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "ced38da112867c8fff15d5079926c95e5bcdca5b"
+                "reference": "1cacf0f150d64ca03785c4f9dddfa5d8788da1f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/ced38da112867c8fff15d5079926c95e5bcdca5b",
-                "reference": "ced38da112867c8fff15d5079926c95e5bcdca5b",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/1cacf0f150d64ca03785c4f9dddfa5d8788da1f2",
+                "reference": "1cacf0f150d64ca03785c4f9dddfa5d8788da1f2",
                 "shasum": ""
             },
             "require": {
@@ -2780,7 +2782,7 @@
                 "doctrine/annotations": "1.11.1",
                 "doctrine/lexer": "1.2.1",
                 "doctrine/reflection": "1.2.2",
-                "drupal/core": "9.1.7",
+                "drupal/core": "9.1.8",
                 "egulias/email-validator": "2.1.22",
                 "guzzlehttp/guzzle": "6.5.5",
                 "guzzlehttp/promises": "1.4.0",
@@ -2802,32 +2804,32 @@
                 "ralouphie/getallheaders": "3.0.3",
                 "stack/builder": "v1.0.6",
                 "symfony-cmf/routing": "2.3.3",
-                "symfony/console": "v4.4.16",
-                "symfony/debug": "v4.4.16",
-                "symfony/dependency-injection": "v4.4.16",
-                "symfony/error-handler": "v4.4.16",
-                "symfony/event-dispatcher": "v4.4.16",
+                "symfony/console": "v4.4.19",
+                "symfony/debug": "v4.4.19",
+                "symfony/dependency-injection": "v4.4.19",
+                "symfony/error-handler": "v4.4.19",
+                "symfony/event-dispatcher": "v4.4.19",
                 "symfony/event-dispatcher-contracts": "v1.1.9",
                 "symfony/http-client-contracts": "v2.3.1",
-                "symfony/http-foundation": "v4.4.16",
-                "symfony/http-kernel": "v4.4.16",
-                "symfony/mime": "v5.1.8",
+                "symfony/http-foundation": "v4.4.19",
+                "symfony/http-kernel": "v4.4.19",
+                "symfony/mime": "v5.1.11",
                 "symfony/polyfill-ctype": "v1.20.0",
                 "symfony/polyfill-iconv": "v1.20.0",
                 "symfony/polyfill-intl-idn": "v1.20.0",
                 "symfony/polyfill-intl-normalizer": "v1.20.0",
                 "symfony/polyfill-mbstring": "v1.20.0",
                 "symfony/polyfill-php80": "v1.20.0",
-                "symfony/process": "v4.4.16",
+                "symfony/process": "v4.4.19",
                 "symfony/psr-http-message-bridge": "v2.0.2",
-                "symfony/routing": "v4.4.16",
-                "symfony/serializer": "v4.4.16",
+                "symfony/routing": "v4.4.19",
+                "symfony/serializer": "v4.4.19",
                 "symfony/service-contracts": "v2.2.0",
-                "symfony/translation": "v4.4.16",
+                "symfony/translation": "v4.4.19",
                 "symfony/translation-contracts": "v2.3.0",
-                "symfony/validator": "v4.4.16",
-                "symfony/var-dumper": "v5.1.8",
-                "symfony/yaml": "v4.4.16",
+                "symfony/validator": "v4.4.19",
+                "symfony/var-dumper": "v5.1.11",
+                "symfony/yaml": "v4.4.19",
                 "twig/twig": "v2.14.1",
                 "typo3/phar-stream-wrapper": "v3.1.6"
             },
@@ -2841,9 +2843,9 @@
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/9.1.7"
+                "source": "https://github.com/drupal/core-recommended/tree/9.1.8"
             },
-            "time": "2021-04-20T23:05:22+00:00"
+            "time": "2021-05-05T11:09:15+00:00"
         },
         {
             "name": "drupal/ctools",
@@ -2995,6 +2997,84 @@
             "homepage": "https://www.drupal.org/project/entity_reference_revisions",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_reference_revisions"
+            }
+        },
+        {
+            "name": "drupal/geofield",
+            "version": "1.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/geofield.git",
+                "reference": "8.x-1.22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/geofield-8.x-1.22.zip",
+                "reference": "8.x-1.22",
+                "shasum": "6fd9299863cf1bbda8747772febf4b90399f6580"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9",
+                "phayes/geophp": "^1.2"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.22",
+                    "datestamp": "1617652199",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Brandon Morrison",
+                    "homepage": "https://www.drupal.org/u/brandonian",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Pablo López",
+                    "homepage": "https://www.drupal.org/u/plopesc",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Italo Mairo",
+                    "homepage": "https://www.drupal.org/u/itamair",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "davidseth",
+                    "homepage": "https://www.drupal.org/user/254857"
+                },
+                {
+                    "name": "itamair",
+                    "homepage": "https://www.drupal.org/user/1179076"
+                },
+                {
+                    "name": "phayes",
+                    "homepage": "https://www.drupal.org/user/47098"
+                },
+                {
+                    "name": "plopesc",
+                    "homepage": "https://www.drupal.org/user/282415"
+                },
+                {
+                    "name": "zzolo",
+                    "homepage": "https://www.drupal.org/user/147331"
+                }
+            ],
+            "description": "Stores geographic and location data (points, lines, and polygons).",
+            "homepage": "https://www.drupal.org/project/geofield",
+            "support": {
+                "source": "https://git.drupalcode.org/project/geofield",
+                "issues": "https://www.drupal.org/project/issues/geofield",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {
@@ -5493,16 +5573,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.4",
+            "version": "v4.10.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
+                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4432ba399e47c66624bc73c8c0f811e5c109576f",
+                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f",
                 "shasum": ""
             },
             "require": {
@@ -5543,9 +5623,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.5"
             },
-            "time": "2020-12-20T10:01:03+00:00"
+            "time": "2021-05-03T19:11:20+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -5945,6 +6025,46 @@
                 "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
             "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "phayes/geophp",
+            "version": "1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phayes/geoPHP.git",
+                "reference": "015404e85b602e0df1f91441f8db0f9e98f7e567"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phayes/geoPHP/zipball/015404e85b602e0df1f91441f8db0f9e98f7e567",
+                "reference": "015404e85b602e0df1f91441f8db0f9e98f7e567",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "geoPHP.inc"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2 or New-BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Patrick Hayes"
+                }
+            ],
+            "description": "GeoPHP is a open-source native PHP library for doing geometry operations. It is written entirely in PHP and can therefore run on shared hosts. It can read and write a wide variety of formats: WKT (including EWKT), WKB (including EWKB), GeoJSON, KML, GPX, GeoRSS). It works with all Simple-Feature geometries (Point, LineString, Polygon, GeometryCollection etc.) and can be used to get centroids, bounding-boxes, area, and a wide variety of other useful information.",
+            "homepage": "https://github.com/phayes/geoPHP",
+            "support": {
+                "issues": "https://github.com/phayes/geoPHP/issues",
+                "source": "https://github.com/phayes/geoPHP/tree/master"
+            },
+            "time": "2014-12-02T06:11:22+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -8275,16 +8395,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v4.4.20",
+            "version": "v4.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "cfa8d92f95294747e3abc04969efee51ed374424"
+                "reference": "4c8b42b4aae93517e8f67d68c5cbe69413e3e3c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/cfa8d92f95294747e3abc04969efee51ed374424",
-                "reference": "cfa8d92f95294747e3abc04969efee51ed374424",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/4c8b42b4aae93517e8f67d68c5cbe69413e3e3c1",
+                "reference": "4c8b42b4aae93517e8f67d68c5cbe69413e3e3c1",
                 "shasum": ""
             },
             "require": {
@@ -8326,7 +8446,7 @@
             "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/browser-kit/tree/v4.4.20"
+                "source": "https://github.com/symfony/browser-kit/tree/v4.4.22"
             },
             "funding": [
                 {
@@ -8342,20 +8462,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-18T10:52:56+00:00"
+            "time": "2021-04-08T07:40:10+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "20f73dd143a5815d475e0838ff867bce1eebd9d5"
+                "reference": "24026c44fc37099fa145707fecd43672831b837a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/20f73dd143a5815d475e0838ff867bce1eebd9d5",
-                "reference": "20f73dd143a5815d475e0838ff867bce1eebd9d5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/24026c44fc37099fa145707fecd43672831b837a",
+                "reference": "24026c44fc37099fa145707fecd43672831b837a",
                 "shasum": ""
             },
             "require": {
@@ -8412,10 +8532,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/console/tree/v4.4.16"
+                "source": "https://github.com/symfony/console/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -8431,20 +8551,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.4.20",
+            "version": "v4.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "f907d3e53ecb2a5fad8609eb2f30525287a734c8"
+                "reference": "01c77324d1d47efbfd7891f62a7c256c69330115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f907d3e53ecb2a5fad8609eb2f30525287a734c8",
-                "reference": "f907d3e53ecb2a5fad8609eb2f30525287a734c8",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/01c77324d1d47efbfd7891f62a7c256c69330115",
+                "reference": "01c77324d1d47efbfd7891f62a7c256c69330115",
                 "shasum": ""
             },
             "require": {
@@ -8480,7 +8600,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v4.4.20"
+                "source": "https://github.com/symfony/css-selector/tree/v4.4.22"
             },
             "funding": [
                 {
@@ -8496,20 +8616,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T09:09:26+00:00"
+            "time": "2021-04-07T15:47:03+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "c87adf3fc1cd0bf4758316a3a150d50a8f957ef4"
+                "reference": "af4987aa4a5630e9615be9d9c3ed1b0f24ca449c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/c87adf3fc1cd0bf4758316a3a150d50a8f957ef4",
-                "reference": "c87adf3fc1cd0bf4758316a3a150d50a8f957ef4",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/af4987aa4a5630e9615be9d9c3ed1b0f24ca449c",
+                "reference": "af4987aa4a5630e9615be9d9c3ed1b0f24ca449c",
                 "shasum": ""
             },
             "require": {
@@ -8546,10 +8666,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Debug Component",
+            "description": "Provides tools to ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/debug/tree/v4.4.16"
+                "source": "https://github.com/symfony/debug/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -8565,20 +8685,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "4c41ad68924fd8f9e55e1cd77fd6bc28daa3fe89"
+                "reference": "2468b95d869c872c6fb1b93b395a7fcd5331f2b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4c41ad68924fd8f9e55e1cd77fd6bc28daa3fe89",
-                "reference": "4c41ad68924fd8f9e55e1cd77fd6bc28daa3fe89",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2468b95d869c872c6fb1b93b395a7fcd5331f2b9",
+                "reference": "2468b95d869c872c6fb1b93b395a7fcd5331f2b9",
                 "shasum": ""
             },
             "require": {
@@ -8631,10 +8751,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony DependencyInjection Component",
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v4.4.16"
+                "source": "https://github.com/symfony/dependency-injection/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -8650,7 +8770,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-27T10:05:40+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -8727,16 +8847,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "363cca01cabf98e4f1c447b14d0a68617f003613"
+                "reference": "d603654eaeb713503bba3e308b9e748e5a6d3f2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/363cca01cabf98e4f1c447b14d0a68617f003613",
-                "reference": "363cca01cabf98e4f1c447b14d0a68617f003613",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/d603654eaeb713503bba3e308b9e748e5a6d3f2e",
+                "reference": "d603654eaeb713503bba3e308b9e748e5a6d3f2e",
                 "shasum": ""
             },
             "require": {
@@ -8773,10 +8893,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony ErrorHandler Component",
+            "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v4.4.16"
+                "source": "https://github.com/symfony/error-handler/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -8792,20 +8912,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "4204f13d2d0b7ad09454f221bb2195fccdf1fe98"
+                "reference": "c352647244bd376bf7d31efbd5401f13f50dad0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4204f13d2d0b7ad09454f221bb2195fccdf1fe98",
-                "reference": "4204f13d2d0b7ad09454f221bb2195fccdf1fe98",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c352647244bd376bf7d31efbd5401f13f50dad0c",
+                "reference": "c352647244bd376bf7d31efbd5401f13f50dad0c",
                 "shasum": ""
             },
             "require": {
@@ -8856,10 +8976,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony EventDispatcher Component",
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v4.4.16"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -8875,7 +8995,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -8958,16 +9078,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.4.21",
+            "version": "v4.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "940826c465be2690c9fae91b2793481e5cbd6834"
+                "reference": "f0f06656a18304cdeacb2c4c0113a2b78a2b4c2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/940826c465be2690c9fae91b2793481e5cbd6834",
-                "reference": "940826c465be2690c9fae91b2793481e5cbd6834",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f0f06656a18304cdeacb2c4c0113a2b78a2b4c2a",
+                "reference": "f0f06656a18304cdeacb2c4c0113a2b78a2b4c2a",
                 "shasum": ""
             },
             "require": {
@@ -9000,7 +9120,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v4.4.21"
+                "source": "https://github.com/symfony/filesystem/tree/v4.4.22"
             },
             "funding": [
                 {
@@ -9016,7 +9136,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-28T09:59:32+00:00"
+            "time": "2021-04-01T10:24:12+00:00"
         },
         {
             "name": "symfony/finder",
@@ -9228,22 +9348,23 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "827a00811ef699e809a201ceafac0b2b246bf38a"
+                "reference": "8888741b633f6c3d1e572b7735ad2cae3e03f9c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/827a00811ef699e809a201ceafac0b2b246bf38a",
-                "reference": "827a00811ef699e809a201ceafac0b2b246bf38a",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8888741b633f6c3d1e572b7735ad2cae3e03f9c5",
+                "reference": "8888741b633f6c3d1e572b7735ad2cae3e03f9c5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.3",
                 "symfony/mime": "^4.3|^5.0",
-                "symfony/polyfill-mbstring": "~1.1"
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php80": "^1.15"
             },
             "require-dev": {
                 "predis/predis": "~1.0",
@@ -9272,10 +9393,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony HttpFoundation Component",
+            "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v4.4.16"
+                "source": "https://github.com/symfony/http-foundation/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -9291,20 +9412,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "109b2a46e470a487ec8b0ffea4b0bb993aaf42ed"
+                "reference": "07ea794a327d7c8c5d76e3058fde9fec6a711cb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/109b2a46e470a487ec8b0ffea4b0bb993aaf42ed",
-                "reference": "109b2a46e470a487ec8b0ffea4b0bb993aaf42ed",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/07ea794a327d7c8c5d76e3058fde9fec6a711cb4",
+                "reference": "07ea794a327d7c8c5d76e3058fde9fec6a711cb4",
                 "shasum": ""
             },
             "require": {
@@ -9324,7 +9445,7 @@
                 "symfony/console": ">=5",
                 "symfony/dependency-injection": "<4.3",
                 "symfony/translation": "<4.2",
-                "twig/twig": "<1.34|<2.4,>=2"
+                "twig/twig": "<1.43|<2.13,>=2"
             },
             "provide": {
                 "psr/log-implementation": "1.0"
@@ -9345,7 +9466,7 @@
                 "symfony/templating": "^3.4|^4.0|^5.0",
                 "symfony/translation": "^4.2|^5.0",
                 "symfony/translation-contracts": "^1.1|^2",
-                "twig/twig": "^1.34|^2.4|^3.0"
+                "twig/twig": "^1.43|^2.13|^3.0.4"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -9376,10 +9497,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony HttpKernel Component",
+            "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v4.4.16"
+                "source": "https://github.com/symfony/http-kernel/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -9395,7 +9516,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-28T05:50:56+00:00"
+            "time": "2021-01-27T13:50:53+00:00"
         },
         {
             "name": "symfony/lock",
@@ -9476,16 +9597,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v5.1.8",
+            "version": "v5.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "f5485a92c24d4bcfc2f3fc648744fb398482ff1b"
+                "reference": "d7d899822da1fa89bcf658e8e8d836f5578e6f7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/f5485a92c24d4bcfc2f3fc648744fb398482ff1b",
-                "reference": "f5485a92c24d4bcfc2f3fc648744fb398482ff1b",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/d7d899822da1fa89bcf658e8e8d836f5578e6f7a",
+                "reference": "d7d899822da1fa89bcf658e8e8d836f5578e6f7a",
                 "shasum": ""
             },
             "require": {
@@ -9524,14 +9645,14 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "A library to manipulate MIME messages",
+            "description": "Allows manipulating MIME messages",
             "homepage": "https://symfony.com",
             "keywords": [
                 "mime",
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.1.8"
+                "source": "https://github.com/symfony/mime/tree/v5.1.11"
             },
             "funding": [
                 {
@@ -9547,20 +9668,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2021-01-27T10:01:46+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v5.2.6",
+            "version": "v5.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "f2f94fd78379cdcdef09dd5025af791301913968"
+                "reference": "f530f0153f4a871b2c65dd6b295d7b8d03a16eac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/f2f94fd78379cdcdef09dd5025af791301913968",
-                "reference": "f2f94fd78379cdcdef09dd5025af791301913968",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/f530f0153f4a871b2c65dd6b295d7b8d03a16eac",
+                "reference": "f530f0153f4a871b2c65dd6b295d7b8d03a16eac",
                 "shasum": ""
             },
             "require": {
@@ -9614,7 +9735,7 @@
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v5.2.6"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v5.2.7"
             },
             "funding": [
                 {
@@ -9630,7 +9751,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T20:42:04+00:00"
+            "time": "2021-04-11T22:55:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -10282,16 +10403,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "2f4b049fb80ca5e9874615a2a85dc2a502090f05"
+                "reference": "7e950b6366d4da90292c2e7fa820b3c1842b965a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2f4b049fb80ca5e9874615a2a85dc2a502090f05",
-                "reference": "2f4b049fb80ca5e9874615a2a85dc2a502090f05",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7e950b6366d4da90292c2e7fa820b3c1842b965a",
+                "reference": "7e950b6366d4da90292c2e7fa820b3c1842b965a",
                 "shasum": ""
             },
             "require": {
@@ -10320,10 +10441,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Process Component",
+            "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v4.4.16"
+                "source": "https://github.com/symfony/process/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -10339,7 +10460,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -10425,16 +10546,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "826794f2e9305fe73cba859c60d2a336851bd202"
+                "reference": "87529f6e305c7acb162840d1ea57922038072425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/826794f2e9305fe73cba859c60d2a336851bd202",
-                "reference": "826794f2e9305fe73cba859c60d2a336851bd202",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/87529f6e305c7acb162840d1ea57922038072425",
+                "reference": "87529f6e305c7acb162840d1ea57922038072425",
                 "shasum": ""
             },
             "require": {
@@ -10446,7 +10567,7 @@
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.2",
+                "doctrine/annotations": "^1.10.4",
                 "psr/log": "~1.0",
                 "symfony/config": "^4.2|^5.0",
                 "symfony/dependency-injection": "^3.4|^4.0|^5.0",
@@ -10484,7 +10605,7 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Routing Component",
+            "description": "Maps an HTTP request to a set of configuration variables",
             "homepage": "https://symfony.com",
             "keywords": [
                 "router",
@@ -10493,7 +10614,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v4.4.16"
+                "source": "https://github.com/symfony/routing/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -10509,20 +10630,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "2af7e86db04ee65fdf1991b17ee0b3e955c93de9"
+                "reference": "6b383bc45777d14857b634e9f8fa2b8a2e69b66d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/2af7e86db04ee65fdf1991b17ee0b3e955c93de9",
-                "reference": "2af7e86db04ee65fdf1991b17ee0b3e955c93de9",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/6b383bc45777d14857b634e9f8fa2b8a2e69b66d",
+                "reference": "6b383bc45777d14857b634e9f8fa2b8a2e69b66d",
                 "shasum": ""
             },
             "require": {
@@ -10530,23 +10651,24 @@
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "phpdocumentor/type-resolver": "<0.2.1",
+                "phpdocumentor/reflection-docblock": "<3.0|>=3.2.0,<3.2.2",
+                "phpdocumentor/type-resolver": "<0.3.0|1.3.*",
                 "symfony/dependency-injection": "<3.4",
                 "symfony/property-access": "<3.4",
                 "symfony/property-info": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
+                "doctrine/annotations": "^1.10.4",
                 "doctrine/cache": "~1.0",
-                "phpdocumentor/reflection-docblock": "^3.2|^4.0",
+                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
                 "symfony/cache": "^3.4|^4.0|^5.0",
                 "symfony/config": "^3.4|^4.0|^5.0",
                 "symfony/dependency-injection": "^3.4|^4.0|^5.0",
                 "symfony/error-handler": "^4.4|^5.0",
                 "symfony/http-foundation": "^3.4|^4.0|^5.0",
                 "symfony/mime": "^4.4|^5.0",
-                "symfony/property-access": "^3.4|^4.0|^5.0",
+                "symfony/property-access": "^3.4.41|^4.4.9|^5.0.9",
                 "symfony/property-info": "^3.4.13|~4.0|^5.0",
                 "symfony/validator": "^3.4|^4.0|^5.0",
                 "symfony/yaml": "^3.4|^4.0|^5.0"
@@ -10584,10 +10706,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Serializer Component",
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v4.4.16"
+                "source": "https://github.com/symfony/serializer/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -10603,7 +10725,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -10686,16 +10808,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "73095716af79f610f3b6338b911357393fdd10ab"
+                "reference": "e1d0c67167a553556d9f974b5fa79c2448df317a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/73095716af79f610f3b6338b911357393fdd10ab",
-                "reference": "73095716af79f610f3b6338b911357393fdd10ab",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e1d0c67167a553556d9f974b5fa79c2448df317a",
+                "reference": "e1d0c67167a553556d9f974b5fa79c2448df317a",
                 "shasum": ""
             },
             "require": {
@@ -10751,10 +10873,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Translation Component",
+            "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v4.4.16"
+                "source": "https://github.com/symfony/translation/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -10770,7 +10892,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -10852,16 +10974,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "1d214a3aaa0753b19f94cf0479d8c315d957a10d"
+                "reference": "039479123c8d824f23efba9bb413b85dc3f42e43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/1d214a3aaa0753b19f94cf0479d8c315d957a10d",
-                "reference": "1d214a3aaa0753b19f94cf0479d8c315d957a10d",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/039479123c8d824f23efba9bb413b85dc3f42e43",
+                "reference": "039479123c8d824f23efba9bb413b85dc3f42e43",
                 "shasum": ""
             },
             "require": {
@@ -10880,7 +11002,7 @@
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.7",
+                "doctrine/annotations": "^1.10.4",
                 "doctrine/cache": "~1.0",
                 "egulias/email-validator": "^2.1.10",
                 "symfony/cache": "^3.4|^4.0|^5.0",
@@ -10934,10 +11056,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Validator Component",
+            "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v4.4.16"
+                "source": "https://github.com/symfony/validator/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -10953,20 +11075,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-28T05:25:24+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.1.8",
+            "version": "v5.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a"
+                "reference": "cee600a1248b423330375c869812bdd61a085cd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
-                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cee600a1248b423330375c869812bdd61a085cd0",
+                "reference": "cee600a1248b423330375c869812bdd61a085cd0",
                 "shasum": ""
             },
             "require": {
@@ -10982,7 +11104,7 @@
                 "ext-iconv": "*",
                 "symfony/console": "^4.4|^5.0",
                 "symfony/process": "^4.4|^5.0",
-                "twig/twig": "^2.4|^3.0"
+                "twig/twig": "^2.13|^3.0.4"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
@@ -11018,14 +11140,14 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
             "homepage": "https://symfony.com",
             "keywords": [
                 "debug",
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.1.8"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.1.11"
             },
             "funding": [
                 {
@@ -11041,20 +11163,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-27T10:11:13+00:00"
+            "time": "2021-01-27T10:01:46+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "543cb4dbd45ed803f08a9a65f27fb149b5dd20c2"
+                "reference": "17ed9f14c1aa05b1a5cf2e2c5ef2d0be28058ef9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/543cb4dbd45ed803f08a9a65f27fb149b5dd20c2",
-                "reference": "543cb4dbd45ed803f08a9a65f27fb149b5dd20c2",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/17ed9f14c1aa05b1a5cf2e2c5ef2d0be28058ef9",
+                "reference": "17ed9f14c1aa05b1a5cf2e2c5ef2d0be28058ef9",
                 "shasum": ""
             },
             "require": {
@@ -11093,10 +11215,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v4.4.16"
+                "source": "https://github.com/symfony/yaml/tree/v4.4.19"
             },
             "funding": [
                 {
@@ -11112,7 +11234,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -11358,16 +11480,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v4.0.2",
+            "version": "v4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "f3c0961766d62e9b95893ca83386f55cc396c7d3"
+                "reference": "58c2bcb96eaab0ee298e95224237c1f277c00370"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/f3c0961766d62e9b95893ca83386f55cc396c7d3",
-                "reference": "f3c0961766d62e9b95893ca83386f55cc396c7d3",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/58c2bcb96eaab0ee298e95224237c1f277c00370",
+                "reference": "58c2bcb96eaab0ee298e95224237c1f277c00370",
                 "shasum": ""
             },
             "require": {
@@ -11381,9 +11503,9 @@
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v4.0.2"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v4.0.4"
             },
-            "time": "2021-04-26T09:56:32+00:00"
+            "time": "2021-05-03T11:41:26+00:00"
         },
         {
             "name": "webflo/drupal-finder",
@@ -12640,66 +12762,6 @@
             }
         },
         {
-            "name": "drupal/yaml_content",
-            "version": "1.0.0-alpha7",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/yaml_content.git",
-                "reference": "8.x-1.0-alpha7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/yaml_content-8.x-1.0-alpha7.zip",
-                "reference": "8.x-1.0-alpha7",
-                "shasum": "9aaf271446a64c9bffc5639589d5c8e6dc40c06c"
-            },
-            "require": {
-                "drupal/core": "^8.7.7 || ^9"
-            },
-            "require-dev": {
-                "mikey179/vfsstream": "^1.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.0-alpha7",
-                    "datestamp": "1588173300",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
-                },
-                "drush": {
-                    "services": {
-                        "drush.services.yml": "^9"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "DamienMcKenna",
-                    "homepage": "https://www.drupal.org/user/108450"
-                },
-                {
-                    "name": "shrop",
-                    "homepage": "https://www.drupal.org/user/14767"
-                },
-                {
-                    "name": "slucero",
-                    "homepage": "https://www.drupal.org/user/1612534"
-                }
-            ],
-            "description": "Demo content generator using yaml content templates.",
-            "homepage": "https://www.drupal.org/project/yaml_content",
-            "support": {
-                "source": "https://git.drupalcode.org/project/yaml_content"
-            }
-        },
-        {
             "name": "pdepend/pdepend",
             "version": "2.9.1",
             "source": {
@@ -12952,16 +13014,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.4.20",
+            "version": "v4.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "98606c6fa1a8f55ff964ccdd704275bf5b9f71b3"
+                "reference": "f6d8318c14e4be81525ae47b30e618f0bed4c7b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/98606c6fa1a8f55ff964ccdd704275bf5b9f71b3",
-                "reference": "98606c6fa1a8f55ff964ccdd704275bf5b9f71b3",
+                "url": "https://api.github.com/repos/symfony/config/zipball/f6d8318c14e4be81525ae47b30e618f0bed4c7b3",
+                "reference": "f6d8318c14e4be81525ae47b30e618f0bed4c7b3",
                 "shasum": ""
             },
             "require": {
@@ -13008,7 +13070,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v4.4.20"
+                "source": "https://github.com/symfony/config/tree/v4.4.22"
             },
             "funding": [
                 {
@@ -13024,86 +13086,13 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-22T15:36:50+00:00"
-        },
-        {
-            "name": "weitzman/drupal-test-traits",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://gitlab.com/weitzman/drupal-test-traits.git",
-                "reference": "039104658adeb6a1691db788b53eb02b21a32487"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/weitzman%2Fdrupal-test-traits/repository/archive.zip?sha=039104658adeb6a1691db788b53eb02b21a32487",
-                "reference": "039104658adeb6a1691db788b53eb02b21a32487",
-                "shasum": ""
-            },
-            "require": {
-                "behat/mink": "^1.8 | 1.7.1 | 1.7.x-dev",
-                "behat/mink-goutte-driver": "^1.2",
-                "php": ">=7.0.8",
-                "phpunit/phpunit": ">=6.5",
-                "webflo/drupal-finder": "^1.1"
-            },
-            "require-dev": {
-                "behat/mink-selenium2-driver": "1.4.0 | 1.3.1 | 1.3.x-dev",
-                "composer/installers": "^1.2",
-                "dmore/chrome-mink-driver": "^2.6",
-                "drupal/core-composer-scaffold": "^9",
-                "drupal/core-dev": "^9",
-                "drupal/core-recommended": "^9",
-                "drush/drush": "^10",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "squizlabs/php_codesniffer": "^3.2",
-                "zaporylie/composer-drupal-optimizations": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "installer-paths": {
-                    "web/core": [
-                        "type:drupal-core"
-                    ]
-                },
-                "drupal-scaffold": {
-                    "locations": {
-                        "web-root": "web/"
-                    },
-                    "file-mapping": {
-                        "[project-root]/.editorconfig": false,
-                        "[project-root]/.gitattributes": false,
-                        "[project-root]/.gitignore": false
-                    }
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "weitzman\\DrupalTestTraits\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Moshe Weitzman",
-                    "email": "weitzman@tejasa.com"
-                }
-            ],
-            "description": "Traits for testing Drupal sites that have user content (versus unpopulated sites).",
-            "support": {
-                "issues": "https://gitlab.com/api/v4/projects/6878188/issues"
-            },
-            "time": "2020-06-21T13:47:52+00:00"
+            "time": "2021-04-07T15:47:03+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "drupal/social_auth_hid": 20,
-        "drupal/yaml_content": 15
+        "drupal/social_auth_hid": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4037,16 +4037,16 @@
         },
         {
             "name": "drush/drush",
-            "version": "10.4.3",
+            "version": "10.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "472ce3e0ac48b418f8168a053b3bcb4c8582bf99"
+                "reference": "3fd9f7e62ffb7f221e4be8151a738529345d22d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/472ce3e0ac48b418f8168a053b3bcb4c8582bf99",
-                "reference": "472ce3e0ac48b418f8168a053b3bcb4c8582bf99",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/3fd9f7e62ffb7f221e4be8151a738529345d22d5",
+                "reference": "3fd9f7e62ffb7f221e4be8151a738529345d22d5",
                 "shasum": ""
             },
             "require": {
@@ -4170,7 +4170,7 @@
                 "irc": "irc://irc.freenode.org/drush",
                 "issues": "https://github.com/drush-ops/drush/issues",
                 "slack": "https://drupal.slack.com/messages/C62H9CWQM",
-                "source": "https://github.com/drush-ops/drush/tree/10.4.3"
+                "source": "https://github.com/drush-ops/drush/tree/10.5.0"
             },
             "funding": [
                 {
@@ -4178,7 +4178,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-04-14T14:08:05+00:00"
+            "time": "2021-05-08T15:49:30+00:00"
         },
         {
             "name": "easyrdf/easyrdf",
@@ -4319,16 +4319,16 @@
         },
         {
             "name": "enlightn/security-checker",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/enlightn/security-checker.git",
-                "reference": "2054fbce2f8df681c8f71b36656222bcd241b77f"
+                "reference": "dc5bce653fa4d9c792e9dcffa728c0642847c1e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/2054fbce2f8df681c8f71b36656222bcd241b77f",
-                "reference": "2054fbce2f8df681c8f71b36656222bcd241b77f",
+                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/dc5bce653fa4d9c792e9dcffa728c0642847c1e1",
+                "reference": "dc5bce653fa4d9c792e9dcffa728c0642847c1e1",
                 "shasum": ""
             },
             "require": {
@@ -4379,9 +4379,9 @@
             ],
             "support": {
                 "issues": "https://github.com/enlightn/security-checker/issues",
-                "source": "https://github.com/enlightn/security-checker/tree/v1.8.0"
+                "source": "https://github.com/enlightn/security-checker/tree/v1.9.0"
             },
-            "time": "2021-04-19T07:13:16+00:00"
+            "time": "2021-05-06T09:03:35+00:00"
         },
         {
             "name": "fabpot/goutte",
@@ -11480,16 +11480,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v4.0.4",
+            "version": "v4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "58c2bcb96eaab0ee298e95224237c1f277c00370"
+                "reference": "d15c29cce2459a817446e9f37c73feab27a7e8d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/58c2bcb96eaab0ee298e95224237c1f277c00370",
-                "reference": "58c2bcb96eaab0ee298e95224237c1f277c00370",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/d15c29cce2459a817446e9f37c73feab27a7e8d8",
+                "reference": "d15c29cce2459a817446e9f37c73feab27a7e8d8",
                 "shasum": ""
             },
             "require": {
@@ -11503,9 +11503,9 @@
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v4.0.4"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v4.0.5"
             },
-            "time": "2021-05-03T11:41:26+00:00"
+            "time": "2021-05-11T12:00:48+00:00"
         },
         {
             "name": "webflo/drupal-finder",
@@ -12882,20 +12882,20 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.10.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "58ef9e746a1ab50ad3360d5d301e1229ed2612cb"
+                "reference": "bd5ef43d1dcaf7272605027c959c1c5ff3761f7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/58ef9e746a1ab50ad3360d5d301e1229ed2612cb",
-                "reference": "58ef9e746a1ab50ad3360d5d301e1229ed2612cb",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/bd5ef43d1dcaf7272605027c959c1c5ff3761f7a",
+                "reference": "bd5ef43d1dcaf7272605027c959c1c5ff3761f7a",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.0",
+                "composer/xdebug-handler": "^1.0 || ^2.0",
                 "ext-xml": "*",
                 "pdepend/pdepend": "^2.9.1",
                 "php": ">=5.3.9"
@@ -12953,7 +12953,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/phpmd",
                 "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.10.0"
+                "source": "https://github.com/phpmd/phpmd/tree/2.10.1"
             },
             "funding": [
                 {
@@ -12961,7 +12961,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-26T18:44:44+00:00"
+            "time": "2021-05-11T17:16:16+00:00"
         },
         {
             "name": "stecman/symfony-console-completion",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,4 +1,7 @@
 {
     "patches": {
+        "drupal/core" : {
+            "https://www.drupal.org/project/drupal/issues/2570593": "patches/core--drupal--2570593-bundle-entity-class.patch"
+        }
     }
 }

--- a/config-dev/config_split.config_split.development.yml
+++ b/config-dev/config_split.config_split.development.yml
@@ -10,6 +10,7 @@ module:
   config_filter: 0
   config_split: 0
   dblog: 0
+  devel: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config-dev/devel.settings.yml
+++ b/config-dev/devel.settings.yml
@@ -1,0 +1,12 @@
+page_alter: false
+raw_names: false
+error_handlers:
+  1: 1
+rebuild_theme: false
+debug_mail_file_format: '%to-%subject-%datetime.mail.txt'
+debug_mail_directory: 'temporary://devel-mails'
+devel_dumper: var_dumper
+debug_logfile: 'temporary://drupal_debug.txt'
+debug_pre: true
+_core:
+  default_config_hash: Aqx6J0yYT6mVqT0fbjeP4JkoL-700nmudVF5d6Pq2Yo

--- a/config-dev/devel.toolbar.settings.yml
+++ b/config-dev/devel.toolbar.settings.yml
@@ -1,0 +1,10 @@
+toolbar_items:
+  - devel.admin_settings_link
+  - devel.cache_clear
+  - devel.container_info.service
+  - devel.menu_rebuild
+  - devel.reinstall
+  - devel.route_info
+  - devel.run_cron
+_core:
+  default_config_hash: IQjf_ytthngZTAk_MU8-74VecArWD3G5g0oEH6PM6GA

--- a/config-dev/system.menu.devel.yml
+++ b/config-dev/system.menu.devel.yml
@@ -1,0 +1,13 @@
+uuid: 4f2be4a3-5635-4dcb-b0f7-18965f51fe0b
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - devel
+_core:
+  default_config_hash: 3V-l1uuTcyirYOGLPZV5HWaDfr02uEbWZJIwc8Byz-c
+id: devel
+label: Development
+description: 'Links related to Devel module.'
+locked: true

--- a/config/book.settings.yml
+++ b/config/book.settings.yml
@@ -1,0 +1,8 @@
+allowed_types:
+  - book
+block:
+  navigation:
+    mode: 'all pages'
+child_type: book
+_core:
+  default_config_hash: i-_2TVi6FUEAqBgNRJkt6aaYmiw1k_LTrXzJS6wlZ4U

--- a/config/core.base_field_override.node.announcement.promote.yml
+++ b/config/core.base_field_override.node.announcement.promote.yml
@@ -1,0 +1,22 @@
+uuid: f8c505b6-8323-4b63-9051-d138fc5688b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+id: node.announcement.promote
+field_name: promote
+entity_type: node
+bundle: announcement
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.announcement.status.yml
+++ b/config/core.base_field_override.node.announcement.status.yml
@@ -1,0 +1,22 @@
+uuid: 937883b1-2b4b-49fc-b2a8-bbabde5ce1e0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+id: node.announcement.status
+field_name: status
+entity_type: node
+bundle: announcement
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.blog_post.promote.yml
+++ b/config/core.base_field_override.node.blog_post.promote.yml
@@ -1,0 +1,22 @@
+uuid: 06bef658-5090-41a4-a80e-84c3fc16944d
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog_post
+id: node.blog_post.promote
+field_name: promote
+entity_type: node
+bundle: blog_post
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.blog_post.status.yml
+++ b/config/core.base_field_override.node.blog_post.status.yml
@@ -1,0 +1,22 @@
+uuid: 6364d6dd-67e8-438a-86b4-744dd2bd3d7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog_post
+id: node.blog_post.status
+field_name: status
+entity_type: node
+bundle: blog_post
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.book.promote.yml
+++ b/config/core.base_field_override.node.book.promote.yml
@@ -1,0 +1,24 @@
+uuid: 48941c1d-595c-4436-a7df-ae6cbf0be863
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.book
+_core:
+  default_config_hash: rYbAZX1eKDo7CVRnBnpYgdmk8HQo5IcKhzePCx9LCZY
+id: node.book.promote
+field_name: promote
+entity_type: node
+bundle: book
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.book.status.yml
+++ b/config/core.base_field_override.node.book.status.yml
@@ -1,0 +1,22 @@
+uuid: 71067cce-88da-4192-ae58-8b98ea676820
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.book
+id: node.book.status
+field_name: status
+entity_type: node
+bundle: book
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.job.promote.yml
+++ b/config/core.base_field_override.node.job.promote.yml
@@ -1,0 +1,22 @@
+uuid: 04cdb435-0a9a-4b4c-a826-abada5a2a034
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.job
+id: node.job.promote
+field_name: promote
+entity_type: node
+bundle: job
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.job.status.yml
+++ b/config/core.base_field_override.node.job.status.yml
@@ -1,0 +1,22 @@
+uuid: 23cd2a15-29f2-402a-ac3e-3f7024316ce8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.job
+id: node.job.status
+field_name: status
+entity_type: node
+bundle: job
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.report.promote.yml
+++ b/config/core.base_field_override.node.report.promote.yml
@@ -1,0 +1,22 @@
+uuid: 7363862b-55d3-45ba-9a33-24726b4f1982
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.report
+id: node.report.promote
+field_name: promote
+entity_type: node
+bundle: report
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.report.status.yml
+++ b/config/core.base_field_override.node.report.status.yml
@@ -1,0 +1,22 @@
+uuid: cdb2ee79-f404-4560-876d-52819eca5240
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.report
+id: node.report.status
+field_name: status
+entity_type: node
+bundle: report
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.topic.promote.yml
+++ b/config/core.base_field_override.node.topic.promote.yml
@@ -1,0 +1,22 @@
+uuid: d50e87b7-2801-4b70-8138-a1592809b146
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.topic
+id: node.topic.promote
+field_name: promote
+entity_type: node
+bundle: topic
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.topic.status.yml
+++ b/config/core.base_field_override.node.topic.status.yml
@@ -1,0 +1,22 @@
+uuid: 73a606a9-af64-4ef4-a33a-35d7cecde06e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.topic
+id: node.topic.status
+field_name: status
+entity_type: node
+bundle: topic
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.training.promote.yml
+++ b/config/core.base_field_override.node.training.promote.yml
@@ -1,0 +1,22 @@
+uuid: 105ec7f2-243b-43c4-a68f-e676e533bc31
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.training
+id: node.training.promote
+field_name: promote
+entity_type: node
+bundle: training
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.training.status.yml
+++ b/config/core.base_field_override.node.training.status.yml
@@ -1,0 +1,22 @@
+uuid: 47b67853-75b9-45ed-b7af-74d40a1e21b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.training
+id: node.training.status
+field_name: status
+entity_type: node
+bundle: training
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.date_format.date_short.yml
+++ b/config/core.date_format.date_short.yml
@@ -1,0 +1,8 @@
+uuid: e79daee4-0702-45d0-8505-1765572969a7
+langcode: en
+status: true
+dependencies: {  }
+id: date_short
+label: 'Date - Short'
+locked: false
+pattern: 'j F Y'

--- a/config/core.entity_form_display.media.file_report.default.yml
+++ b/config/core.entity_form_display.media.file_report.default.yml
@@ -1,0 +1,57 @@
+uuid: 73a00834-e218-4830-86b4-787ea12e6fde
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.file_report.field_description
+    - field.field.media.file_report.field_language
+    - field.field.media.file_report.field_media_file
+    - media.type.file_report
+  module:
+    - file
+id: media.file_report.default
+targetEntityType: media
+bundle: file_report
+mode: default
+content:
+  field_description:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_language:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_media_file:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 4
+    region: content
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  uid: true

--- a/config/core.entity_form_display.media.file_report.media_library.yml
+++ b/config/core.entity_form_display.media.file_report.media_library.yml
@@ -1,0 +1,32 @@
+uuid: caa2f494-8ae4-4c02-9814-738ee219f8bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.file_report.field_description
+    - field.field.media.file_report.field_language
+    - field.field.media.file_report.field_media_file
+    - media.type.file_report
+id: media.file_report.media_library
+targetEntityType: media
+bundle: file_report
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_description: true
+  field_language: true
+  field_media_file: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/config/core.entity_form_display.media.image_announcement.default.yml
+++ b/config/core.entity_form_display.media.image_announcement.default.yml
@@ -1,0 +1,43 @@
+uuid: 062c44c8-345d-4e15-a444-7736617d48db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_announcement.field_media_image
+    - image.style.thumbnail
+    - media.type.image_announcement
+  module:
+    - image
+id: media.image_announcement.default
+targetEntityType: media
+bundle: image_announcement
+mode: default
+content:
+  field_media_image:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 2
+    region: content
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  uid: true

--- a/config/core.entity_form_display.media.image_announcement.media_library.yml
+++ b/config/core.entity_form_display.media.image_announcement.media_library.yml
@@ -1,0 +1,38 @@
+uuid: 769d76cf-9101-4ed0-967a-37616a79b036
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.image_announcement.field_media_image
+    - image.style.thumbnail
+    - media.type.image_announcement
+  module:
+    - image
+id: media.image_announcement.media_library
+targetEntityType: media
+bundle: image_announcement
+mode: media_library
+content:
+  field_media_image:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/config/core.entity_form_display.media.image_blog_post.default.yml
+++ b/config/core.entity_form_display.media.image_blog_post.default.yml
@@ -1,0 +1,52 @@
+uuid: 45e52e2a-67db-446e-93ec-b0f9fd422759
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_blog_post.field_copyright
+    - field.field.media.image_blog_post.field_media_image
+    - image.style.thumbnail
+    - media.type.image_blog_post
+  module:
+    - image
+id: media.image_blog_post.default
+targetEntityType: media
+bundle: image_blog_post
+mode: default
+content:
+  field_copyright:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_media_image:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    region: content
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  uid: true

--- a/config/core.entity_form_display.media.image_blog_post.media_library.yml
+++ b/config/core.entity_form_display.media.image_blog_post.media_library.yml
@@ -1,0 +1,40 @@
+uuid: 142f39f6-8731-44a9-8287-fb327964aaf4
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.image_blog_post.field_copyright
+    - field.field.media.image_blog_post.field_media_image
+    - image.style.thumbnail
+    - media.type.image_blog_post
+  module:
+    - image
+id: media.image_blog_post.media_library
+targetEntityType: media
+bundle: image_blog_post
+mode: media_library
+content:
+  field_media_image:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_copyright: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/config/core.entity_form_display.media.image_headline.default.yml
+++ b/config/core.entity_form_display.media.image_headline.default.yml
@@ -1,0 +1,52 @@
+uuid: c6cc5ae5-1397-4800-ad88-4f3055fb3c07
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_headline.field_copyright
+    - field.field.media.image_headline.field_media_image
+    - image.style.thumbnail
+    - media.type.image_headline
+  module:
+    - image
+id: media.image_headline.default
+targetEntityType: media
+bundle: image_headline
+mode: default
+content:
+  field_copyright:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_media_image:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    region: content
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  uid: true

--- a/config/core.entity_form_display.media.image_headline.media_library.yml
+++ b/config/core.entity_form_display.media.image_headline.media_library.yml
@@ -1,0 +1,40 @@
+uuid: 7c049706-3061-4774-be7f-c0a3be8115b9
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.image_headline.field_copyright
+    - field.field.media.image_headline.field_media_image
+    - image.style.thumbnail
+    - media.type.image_headline
+  module:
+    - image
+id: media.image_headline.media_library
+targetEntityType: media
+bundle: image_headline
+mode: media_library
+content:
+  field_media_image:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_copyright: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/config/core.entity_form_display.media.image_report.default.yml
+++ b/config/core.entity_form_display.media.image_report.default.yml
@@ -1,0 +1,52 @@
+uuid: 07bbdb97-88d9-45ec-8043-23ecfe68ec3e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_report.field_copyright
+    - field.field.media.image_report.field_media_image
+    - image.style.thumbnail
+    - media.type.image_report
+  module:
+    - image
+id: media.image_report.default
+targetEntityType: media
+bundle: image_report
+mode: default
+content:
+  field_copyright:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_media_image:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    region: content
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  uid: true

--- a/config/core.entity_form_display.media.image_report.media_library.yml
+++ b/config/core.entity_form_display.media.image_report.media_library.yml
@@ -1,0 +1,40 @@
+uuid: 65759fba-95e6-4981-a71e-c66ae711d95c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.image_report.field_copyright
+    - field.field.media.image_report.field_media_image
+    - image.style.thumbnail
+    - media.type.image_report
+  module:
+    - image
+id: media.image_report.media_library
+targetEntityType: media
+bundle: image_report
+mode: media_library
+content:
+  field_media_image:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_copyright: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/config/core.entity_form_display.node.announcement.default.yml
+++ b/config/core.entity_form_display.node.announcement.default.yml
@@ -3,75 +3,64 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.announcement.body
+    - field.field.node.announcement.field_image
+    - field.field.node.announcement.field_link
     - node.type.announcement
   module:
-    - path
+    - link
+    - media_library
+    - text
 id: node.announcement.default
 targetEntityType: node
 bundle: announcement
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
+  body:
+    weight: 3
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
     third_party_settings: {  }
-  langcode:
-    type: language_select
+    type: text_textarea_with_summary
+    region: content
+  field_image:
     weight: 2
-    region: content
     settings:
-      include_locked: true
+      media_types: {  }
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
+    type: media_library_widget
     region: content
-    settings: {  }
-    third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
+  field_link:
+    weight: 1
     settings:
-      display_label: true
-    weight: 15
-    region: content
+      placeholder_url: ''
+      placeholder_title: ''
     third_party_settings: {  }
+    type: link_default
+    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 16
+    weight: 4
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-      match_limit: 10
-    region: content
-    third_party_settings: {  }
-  url_redirects:
-    weight: 50
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-hidden: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  promote: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_display.node.announcement.default.yml
+++ b/config/core.entity_form_display.node.announcement.default.yml
@@ -1,0 +1,77 @@
+uuid: 80b301b0-e52c-47f7-a168-fe5d5f6f04d1
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+  module:
+    - path
+id: node.announcement.default
+targetEntityType: node
+bundle: announcement
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_form_display.node.blog_post.default.yml
+++ b/config/core.entity_form_display.node.blog_post.default.yml
@@ -3,75 +3,90 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_attached_images
+    - field.field.node.blog_post.field_author
+    - field.field.node.blog_post.field_image
+    - field.field.node.blog_post.field_publication_date
+    - field.field.node.blog_post.field_tags
     - node.type.blog_post
   module:
-    - path
+    - datetime
+    - media_library
+    - text
 id: node.blog_post.default
 targetEntityType: node
 bundle: blog_post
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
+  body:
+    weight: 4
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
     third_party_settings: {  }
-  langcode:
-    type: language_select
+    type: text_textarea_with_summary
+    region: content
+  field_attached_images:
+    weight: 6
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
+    region: content
+  field_author:
     weight: 2
-    region: content
     settings:
-      include_locked: true
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
+    type: string_textfield
     region: content
+  field_image:
+    weight: 5
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
+    region: content
+  field_publication_date:
+    weight: 3
     settings: {  }
     third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 15
+    type: datetime_default
     region: content
+  field_tags:
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 16
+    weight: 7
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-      match_limit: 10
-    region: content
-    third_party_settings: {  }
-  url_redirects:
-    weight: 50
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-hidden: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  promote: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_display.node.blog_post.default.yml
+++ b/config/core.entity_form_display.node.blog_post.default.yml
@@ -1,0 +1,77 @@
+uuid: 2bddba81-6ba3-40de-bac4-7ed1945cd6c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog_post
+  module:
+    - path
+id: node.blog_post.default
+targetEntityType: node
+bundle: blog_post
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_form_display.node.book.default.yml
+++ b/config/core.entity_form_display.node.book.default.yml
@@ -1,0 +1,91 @@
+uuid: 56621ca7-18ff-4a6e-b244-f51296e6dfbe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.book.body
+    - node.type.book
+  module:
+    - path
+    - text
+_core:
+  default_config_hash: vLiV0db8dn1tmCTZrfImOXWBXV9bX677QMct9iI5nn0
+id: node.book.default
+targetEntityType: node
+bundle: book
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 26
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_form_display.node.job.default.yml
+++ b/config/core.entity_form_display.node.job.default.yml
@@ -1,0 +1,77 @@
+uuid: af6a4803-0a4e-4ed9-a24e-cdd8eb6d6195
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.job
+  module:
+    - path
+id: node.job.default
+targetEntityType: node
+bundle: job
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_form_display.node.job.default.yml
+++ b/config/core.entity_form_display.node.job.default.yml
@@ -3,75 +3,120 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.job.body
+    - field.field.node.job.field_career_categories
+    - field.field.node.job.field_city
+    - field.field.node.job.field_country
+    - field.field.node.job.field_how_to_apply
+    - field.field.node.job.field_job_closing_date
+    - field.field.node.job.field_job_experience
+    - field.field.node.job.field_job_type
+    - field.field.node.job.field_source
+    - field.field.node.job.field_theme
     - node.type.job
   module:
-    - path
+    - allowed_formats
+    - datetime
+    - text
 id: node.job.default
 targetEntityType: node
 bundle: job
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
+  body:
+    weight: 9
+    settings:
+      rows: 20
+      placeholder: ''
+      summary_rows: 3
+      show_summary: false
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+    type: text_textarea_with_summary
     region: content
+  field_career_categories:
+    weight: 7
     settings: {  }
     third_party_settings: {  }
-  langcode:
-    type: language_select
+    type: options_buttons
+    region: content
+  field_city:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_country:
     weight: 2
-    region: content
-    settings:
-      include_locked: true
-    third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
     settings: {  }
     third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 15
+    type: options_select
     region: content
+  field_how_to_apply:
+    weight: 10
+    settings:
+      rows: 10
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+    type: text_textarea
+    region: content
+  field_job_closing_date:
+    weight: 4
+    settings: {  }
     third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_job_experience:
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_job_type:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_source:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_theme:
+    weight: 8
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 16
+    weight: 11
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
-      size: 60
+      size: 150
       placeholder: ''
     third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-      match_limit: 10
-    region: content
-    third_party_settings: {  }
-  url_redirects:
-    weight: 50
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-hidden: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  promote: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_display.node.report.default.yml
+++ b/config/core.entity_form_display.node.report.default.yml
@@ -1,0 +1,77 @@
+uuid: 9f041f7a-f1a3-413d-ba53-c714222e0611
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.report
+  module:
+    - path
+id: node.report.default
+targetEntityType: node
+bundle: report
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_form_display.node.report.default.yml
+++ b/config/core.entity_form_display.node.report.default.yml
@@ -3,75 +3,226 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.report.body
+    - field.field.node.report.field_bury
+    - field.field.node.report.field_content_format
+    - field.field.node.report.field_country
+    - field.field.node.report.field_disaster
+    - field.field.node.report.field_disaster_type
+    - field.field.node.report.field_embargo_date
+    - field.field.node.report.field_feature
+    - field.field.node.report.field_file
+    - field.field.node.report.field_headline
+    - field.field.node.report.field_headline_image
+    - field.field.node.report.field_headline_summary
+    - field.field.node.report.field_headline_title
+    - field.field.node.report.field_image
+    - field.field.node.report.field_language
+    - field.field.node.report.field_notify
+    - field.field.node.report.field_ocha_product
+    - field.field.node.report.field_origin
+    - field.field.node.report.field_origin_notes
+    - field.field.node.report.field_original_publication_date
+    - field.field.node.report.field_primary_country
+    - field.field.node.report.field_source
+    - field.field.node.report.field_theme
+    - field.field.node.report.field_vulnerable_groups
     - node.type.report
   module:
+    - datetime
+    - media_library
     - path
+    - text
 id: node.report.default
 targetEntityType: node
 bundle: report
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  langcode:
-    type: language_select
+  body:
     weight: 2
-    region: content
     settings:
-      include_locked: true
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
+    type: text_textarea_with_summary
     region: content
-    settings: {  }
-    third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
+  field_bury:
+    weight: 22
     settings:
       display_label: true
-    weight: 15
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
+  field_content_format:
+    weight: 15
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_country:
+    weight: 11
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_disaster:
+    weight: 13
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_disaster_type:
+    weight: 14
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_embargo_date:
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_feature:
+    weight: 21
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_file:
+    type: media_library_widget
+    weight: 3
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_headline:
+    weight: 17
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_headline_image:
+    type: media_library_widget
+    weight: 19
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_headline_summary:
+    weight: 20
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_headline_title:
+    weight: 18
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_image:
+    weight: 4
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
+    region: content
+  field_language:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_notify:
+    weight: 23
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_ocha_product:
+    weight: 8
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_origin:
+    weight: 9
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_origin_notes:
+    weight: 10
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_original_publication_date:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_primary_country:
+    weight: 12
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_source:
+    weight: 7
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_theme:
+    weight: 16
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  path:
+    type: path
+    weight: 25
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 16
+    weight: 24
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 1
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-      match_limit: 10
-    region: content
-    third_party_settings: {  }
-  url_redirects:
-    weight: 50
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-hidden: {  }
+hidden:
+  created: true
+  field_vulnerable_groups: true
+  langcode: true
+  promote: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_display.node.topic.default.yml
+++ b/config/core.entity_form_display.node.topic.default.yml
@@ -1,0 +1,77 @@
+uuid: 4518a1d5-599e-405b-92b8-65e3cb17753c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.topic
+  module:
+    - path
+id: node.topic.default
+targetEntityType: node
+bundle: topic
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_form_display.node.training.default.yml
+++ b/config/core.entity_form_display.node.training.default.yml
@@ -3,75 +3,168 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.training.body
+    - field.field.node.training.field_career_categories
+    - field.field.node.training.field_city
+    - field.field.node.training.field_cost
+    - field.field.node.training.field_country
+    - field.field.node.training.field_fee_information
+    - field.field.node.training.field_how_to_register
+    - field.field.node.training.field_language
+    - field.field.node.training.field_link
+    - field.field.node.training.field_registration_deadline
+    - field.field.node.training.field_source
+    - field.field.node.training.field_theme
+    - field.field.node.training.field_training_date
+    - field.field.node.training.field_training_format
+    - field.field.node.training.field_training_language
+    - field.field.node.training.field_training_type
     - node.type.training
   module:
-    - path
+    - allowed_formats
+    - datetime
+    - datetime_range
+    - link
+    - text
 id: node.training.default
 targetEntityType: node
 bundle: training
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  langcode:
-    type: language_select
-    weight: 2
-    region: content
-    settings:
-      include_locked: true
-    third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
+  body:
     weight: 15
+    settings:
+      rows: 20
+      placeholder: ''
+      summary_rows: 3
+      show_summary: false
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+    type: text_textarea_with_summary
     region: content
+  field_career_categories:
+    weight: 11
+    settings: {  }
     third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_city:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_cost:
+    weight: 7
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_country:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_fee_information:
+    weight: 8
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_how_to_register:
+    weight: 16
+    settings:
+      rows: 10
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+    type: text_textarea
+    region: content
+  field_language:
+    weight: 13
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_link:
+    weight: 6
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_registration_deadline:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_source:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_theme:
+    weight: 12
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_training_date:
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+    type: daterange_default
+    region: content
+  field_training_format:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_training_language:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_training_type:
+    weight: 9
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 16
+    weight: 17
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 14
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-      match_limit: 10
-    region: content
-    third_party_settings: {  }
-  url_redirects:
-    weight: 50
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-hidden: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  promote: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_display.node.training.default.yml
+++ b/config/core.entity_form_display.node.training.default.yml
@@ -1,0 +1,77 @@
+uuid: 87ccfd44-ffd6-487a-8679-eb4d3a638baf
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.training
+  module:
+    - path
+id: node.training.default
+targetEntityType: node
+bundle: training
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_form_display.taxonomy_term.career_category.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.career_category.default.yml
@@ -1,0 +1,37 @@
+uuid: 31d69a61-e2ac-4120-b2bf-797f883d1fc9
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.career_category
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.career_category.default
+targetEntityType: taxonomy_term
+bundle: career_category
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.content_format.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.content_format.default.yml
@@ -1,0 +1,37 @@
+uuid: ebfc1450-d16a-4ecd-88f9-48b110dcf28a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.content_format
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.content_format.default
+targetEntityType: taxonomy_term
+bundle: content_format
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.country.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.country.default.yml
@@ -1,0 +1,99 @@
+uuid: e8c6085a-3d86-47cb-9c1f-7811c3ed730a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.country.field_aliases
+    - field.field.taxonomy_term.country.field_iso3
+    - field.field.taxonomy_term.country.field_location
+    - field.field.taxonomy_term.country.field_longname
+    - field.field.taxonomy_term.country.field_profile
+    - field.field.taxonomy_term.country.field_shortname
+    - field.field.taxonomy_term.country.field_timezone
+    - taxonomy.vocabulary.country
+  module:
+    - geofield
+    - text
+id: taxonomy_term.country.default
+targetEntityType: taxonomy_term
+bundle: country
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 4
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  field_aliases:
+    weight: 3
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_iso3:
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_location:
+    weight: 6
+    settings:
+      html5_geolocation: false
+    third_party_settings: {  }
+    type: geofield_latlon
+    region: content
+  field_longname:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_profile:
+    weight: 7
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_shortname:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_timezone:
+    weight: 8
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 9
+    region: content
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true

--- a/config/core.entity_form_display.taxonomy_term.disaster.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.disaster.default.yml
@@ -1,0 +1,124 @@
+uuid: 63c8e53a-5618-4ce0-8800-ca4ec0c7eda5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.disaster.field_country
+    - field.field.taxonomy_term.disaster.field_disaster_date
+    - field.field.taxonomy_term.disaster.field_disaster_type
+    - field.field.taxonomy_term.disaster.field_glide
+    - field.field.taxonomy_term.disaster.field_glide_related
+    - field.field.taxonomy_term.disaster.field_primary_country
+    - field.field.taxonomy_term.disaster.field_primary_disaster_type
+    - field.field.taxonomy_term.disaster.field_profile
+    - field.field.taxonomy_term.disaster.field_timezone
+    - taxonomy.vocabulary.disaster
+  module:
+    - datetime
+    - text
+id: taxonomy_term.disaster.default
+targetEntityType: taxonomy_term
+bundle: disaster
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 6
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  field_country:
+    weight: 2
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_disaster_date:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_disaster_type:
+    weight: 4
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_glide:
+    weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_glide_related:
+    weight: 8
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_primary_country:
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_primary_disaster_type:
+    weight: 3
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_profile:
+    weight: 9
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_timezone:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 11
+    region: content
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true

--- a/config/core.entity_form_display.taxonomy_term.disaster_type.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.disaster_type.default.yml
@@ -1,0 +1,46 @@
+uuid: faff24e4-2a72-4d44-abcc-70a3e0e1728a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.disaster_type.field_disaster_type_code
+    - taxonomy.vocabulary.disaster_type
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.disaster_type.default
+targetEntityType: taxonomy_term
+bundle: disaster_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  field_disaster_type_code:
+    weight: 2
+    settings:
+      size: 2
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.feature.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.feature.default.yml
@@ -1,0 +1,33 @@
+uuid: ac7c73a9-2352-4a9c-ad95-a54be7696a2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.feature
+  module:
+    - text
+id: taxonomy_term.feature.default
+targetEntityType: taxonomy_term
+bundle: feature
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.job_experience.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.job_experience.default.yml
@@ -1,0 +1,37 @@
+uuid: b7fab13e-871b-42e7-a87a-019760e7d923
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.job_experience
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.job_experience.default
+targetEntityType: taxonomy_term
+bundle: job_experience
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.job_type.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.job_type.default.yml
@@ -1,0 +1,37 @@
+uuid: 6938fa0a-93fa-4d7a-aa63-08dc71e7078b
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.job_type
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.job_type.default
+targetEntityType: taxonomy_term
+bundle: job_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.language.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.language.default.yml
@@ -1,0 +1,48 @@
+uuid: 35221578-9cf8-4f01-9117-3929030323bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.language.field_language_code
+    - taxonomy.vocabulary.language
+  module:
+    - text
+id: taxonomy_term.language.default
+targetEntityType: taxonomy_term
+bundle: language
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  field_language_code:
+    weight: 2
+    settings:
+      size: 2
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    region: content
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true

--- a/config/core.entity_form_display.taxonomy_term.ocha_product.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.ocha_product.default.yml
@@ -1,0 +1,37 @@
+uuid: 717ae0b6-64cf-4932-a215-01ceaab066b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.ocha_product
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.ocha_product.default
+targetEntityType: taxonomy_term
+bundle: ocha_product
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.organization_type.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.organization_type.default.yml
@@ -1,0 +1,37 @@
+uuid: d3f300bc-ae35-4b95-b605-f072015b9986
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organization_type
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.organization_type.default
+targetEntityType: taxonomy_term
+bundle: organization_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.source.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.source.default.yml
@@ -1,0 +1,194 @@
+uuid: e20c1eec-225e-440d-b0a5-cb1bafb7dc9e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.source.field_aliases
+    - field.field.taxonomy_term.source.field_allowed_content_types
+    - field.field.taxonomy_term.source.field_attention_job
+    - field.field.taxonomy_term.source.field_attention_report
+    - field.field.taxonomy_term.source.field_attention_training
+    - field.field.taxonomy_term.source.field_country
+    - field.field.taxonomy_term.source.field_disclaimer
+    - field.field.taxonomy_term.source.field_fts_id
+    - field.field.taxonomy_term.source.field_homepage
+    - field.field.taxonomy_term.source.field_job_import_feed_url
+    - field.field.taxonomy_term.source.field_links
+    - field.field.taxonomy_term.source.field_logo
+    - field.field.taxonomy_term.source.field_longname
+    - field.field.taxonomy_term.source.field_organization_type
+    - field.field.taxonomy_term.source.field_shortname
+    - field.field.taxonomy_term.source.field_spanish_name
+    - image.style.thumbnail
+    - taxonomy.vocabulary.source
+  module:
+    - allowed_formats
+    - image
+    - link
+    - path
+    - text
+id: taxonomy_term.source.default
+targetEntityType: taxonomy_term
+bundle: source
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 5
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  field_aliases:
+    weight: 4
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_allowed_content_types:
+    weight: 11
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_attention_job:
+    weight: 14
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_attention_report:
+    weight: 13
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_attention_training:
+    weight: 15
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_country:
+    weight: 7
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_disclaimer:
+    weight: 12
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_fts_id:
+    weight: 16
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_homepage:
+    weight: 9
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_job_import_feed_url:
+    weight: 17
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_links:
+    weight: 10
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_logo:
+    weight: 8
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  field_longname:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_organization_type:
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_shortname:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_spanish_name:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 18
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 19
+    region: content
+    third_party_settings: {  }
+hidden:
+  langcode: true

--- a/config/core.entity_form_display.taxonomy_term.tag.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.tag.default.yml
@@ -1,0 +1,37 @@
+uuid: 10a6dddc-0d31-4776-921c-d34de4187780
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tag
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.tag.default
+targetEntityType: taxonomy_term
+bundle: tag
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.theme.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.theme.default.yml
@@ -1,0 +1,37 @@
+uuid: 886edc1f-8ba1-4276-b25b-3ae37a4c8739
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.theme
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.theme.default
+targetEntityType: taxonomy_term
+bundle: theme
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.training_format.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.training_format.default.yml
@@ -1,0 +1,37 @@
+uuid: d7e208e9-e7f2-46c0-97f0-81ef81c7582a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.training_format
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.training_format.default
+targetEntityType: taxonomy_term
+bundle: training_format
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.training_type.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.training_type.default.yml
@@ -1,0 +1,37 @@
+uuid: 690de04c-2484-4cda-b2c9-2f4857fdb2a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.training_type
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.training_type.default
+targetEntityType: taxonomy_term
+bundle: training_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.vulnerable_group.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.vulnerable_group.default.yml
@@ -1,0 +1,37 @@
+uuid: 3ab7ff23-5d22-428e-bff2-ec6cc0009ec2
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.vulnerable_group
+  module:
+    - allowed_formats
+    - text
+id: taxonomy_term.vulnerable_group.default
+targetEntityType: taxonomy_term
+bundle: vulnerable_group
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_form_mode.media.media_library.yml
+++ b/config/core.entity_form_mode.media.media_library.yml
@@ -1,0 +1,15 @@
+uuid: af6d132b-39d6-4579-9448-2a8291e0f74a
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - media_library
+  module:
+    - media
+_core:
+  default_config_hash: pkq0uj-IoqEQRBOP_ddUDV0ZJ-dKQ_fLcppsEDF2UO8
+id: media.media_library
+label: 'Media library'
+targetEntityType: media
+cache: true

--- a/config/core.entity_view_display.media.file_report.default.yml
+++ b/config/core.entity_view_display.media.file_report.default.yml
@@ -1,0 +1,46 @@
+uuid: bd835a98-8829-40ab-ab23-20823723c94f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.file_report.field_description
+    - field.field.media.file_report.field_language
+    - field.field.media.file_report.field_media_file
+    - media.type.file_report
+  module:
+    - file
+id: media.file_report.default
+targetEntityType: media
+bundle: file_report
+mode: default
+content:
+  field_description:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_language:
+    weight: 2
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_media_file:
+    label: visually_hidden
+    weight: 0
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    type: file_default
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.media.file_report.media_library.yml
+++ b/config/core.entity_view_display.media.file_report.media_library.yml
@@ -1,0 +1,35 @@
+uuid: 6c2ca9fc-8cf4-427f-a167-5f579b5948ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.file_report.field_description
+    - field.field.media.file_report.field_language
+    - field.field.media.file_report.field_media_file
+    - image.style.medium
+    - media.type.file_report
+  module:
+    - image
+id: media.file_report.media_library
+targetEntityType: media
+bundle: file_report
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_description: true
+  field_language: true
+  field_media_file: true
+  langcode: true
+  name: true
+  uid: true

--- a/config/core.entity_view_display.media.image_announcement.default.yml
+++ b/config/core.entity_view_display.media.image_announcement.default.yml
@@ -1,0 +1,30 @@
+uuid: 12c4d3c4-c007-41f0-bee7-a76b6a0edcdf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_announcement.field_media_image
+    - image.style.large
+    - media.type.image_announcement
+  module:
+    - image
+id: media.image_announcement.default
+targetEntityType: media
+bundle: image_announcement
+mode: default
+content:
+  field_media_image:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.media.image_announcement.media_library.yml
+++ b/config/core.entity_view_display.media.image_announcement.media_library.yml
@@ -1,0 +1,31 @@
+uuid: 96388c71-3595-4a70-865b-b45cabd8df6b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.image_announcement.field_media_image
+    - image.style.medium
+    - media.type.image_announcement
+  module:
+    - image
+id: media.image_announcement.media_library
+targetEntityType: media
+bundle: image_announcement
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_image: true
+  langcode: true
+  name: true
+  uid: true

--- a/config/core.entity_view_display.media.image_blog_post.default.yml
+++ b/config/core.entity_view_display.media.image_blog_post.default.yml
@@ -1,0 +1,39 @@
+uuid: 3ceb177b-5015-4520-8d96-c35a14cd9dc3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_blog_post.field_copyright
+    - field.field.media.image_blog_post.field_media_image
+    - image.style.large
+    - media.type.image_blog_post
+  module:
+    - image
+id: media.image_blog_post.default
+targetEntityType: media
+bundle: image_blog_post
+mode: default
+content:
+  field_copyright:
+    weight: 1
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_media_image:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.media.image_blog_post.media_library.yml
+++ b/config/core.entity_view_display.media.image_blog_post.media_library.yml
@@ -1,0 +1,33 @@
+uuid: f1ed5cca-b681-478b-a93a-0c1aca55faf5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.image_blog_post.field_copyright
+    - field.field.media.image_blog_post.field_media_image
+    - image.style.medium
+    - media.type.image_blog_post
+  module:
+    - image
+id: media.image_blog_post.media_library
+targetEntityType: media
+bundle: image_blog_post
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_copyright: true
+  field_media_image: true
+  langcode: true
+  name: true
+  uid: true

--- a/config/core.entity_view_display.media.image_headline.default.yml
+++ b/config/core.entity_view_display.media.image_headline.default.yml
@@ -1,0 +1,39 @@
+uuid: e11684a0-cd13-4cb9-ab94-58824793fbdd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_headline.field_copyright
+    - field.field.media.image_headline.field_media_image
+    - image.style.large
+    - media.type.image_headline
+  module:
+    - image
+id: media.image_headline.default
+targetEntityType: media
+bundle: image_headline
+mode: default
+content:
+  field_copyright:
+    weight: 1
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_media_image:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.media.image_headline.media_library.yml
+++ b/config/core.entity_view_display.media.image_headline.media_library.yml
@@ -1,0 +1,33 @@
+uuid: d14377d1-6f46-4c7a-8f3e-1ac5e31af7d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.image_headline.field_copyright
+    - field.field.media.image_headline.field_media_image
+    - image.style.medium
+    - media.type.image_headline
+  module:
+    - image
+id: media.image_headline.media_library
+targetEntityType: media
+bundle: image_headline
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_copyright: true
+  field_media_image: true
+  langcode: true
+  name: true
+  uid: true

--- a/config/core.entity_view_display.media.image_report.default.yml
+++ b/config/core.entity_view_display.media.image_report.default.yml
@@ -1,0 +1,39 @@
+uuid: 3ea08b59-5fea-4485-aeef-406c3870c0f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.image_report.field_copyright
+    - field.field.media.image_report.field_media_image
+    - image.style.large
+    - media.type.image_report
+  module:
+    - image
+id: media.image_report.default
+targetEntityType: media
+bundle: image_report
+mode: default
+content:
+  field_copyright:
+    weight: 1
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_media_image:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.media.image_report.media_library.yml
+++ b/config/core.entity_view_display.media.image_report.media_library.yml
@@ -1,0 +1,33 @@
+uuid: fcd232ed-44a6-4e0c-88ad-989d2371f608
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.image_report.field_copyright
+    - field.field.media.image_report.field_media_image
+    - image.style.medium
+    - media.type.image_report
+  module:
+    - image
+id: media.image_report.media_library
+targetEntityType: media
+bundle: image_report
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_copyright: true
+  field_media_image: true
+  langcode: true
+  name: true
+  uid: true

--- a/config/core.entity_view_display.node.announcement.default.yml
+++ b/config/core.entity_view_display.node.announcement.default.yml
@@ -1,0 +1,20 @@
+uuid: c723279c-00a0-403a-98ca-caf1583bbe20
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+  module:
+    - user
+id: node.announcement.default
+targetEntityType: node
+bundle: announcement
+mode: default
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.announcement.default.yml
+++ b/config/core.entity_view_display.node.announcement.default.yml
@@ -3,18 +3,47 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.announcement.body
+    - field.field.node.announcement.field_image
+    - field.field.node.announcement.field_link
     - node.type.announcement
   module:
+    - link
+    - text
     - user
 id: node.announcement.default
 targetEntityType: node
 bundle: announcement
 mode: default
 content:
-  links:
-    weight: 100
+  body:
+    weight: 2
+    label: above
     settings: {  }
     third_party_settings: {  }
+    type: text_default
+    region: content
+  field_image:
+    type: entity_reference_entity_view
+    weight: 1
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_link:
+    weight: 0
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
     region: content
 hidden:
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.announcement.teaser.yml
+++ b/config/core.entity_view_display.node.announcement.teaser.yml
@@ -4,6 +4,9 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.announcement.body
+    - field.field.node.announcement.field_image
+    - field.field.node.announcement.field_link
     - node.type.announcement
   module:
     - user
@@ -12,10 +15,17 @@ targetEntityType: node
 bundle: announcement
 mode: teaser
 content:
-  links:
-    weight: 100
-    settings: {  }
-    third_party_settings: {  }
+  field_image:
+    type: entity_reference_entity_view
+    weight: 0
     region: content
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
 hidden:
+  body: true
+  field_link: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.announcement.teaser.yml
+++ b/config/core.entity_view_display.node.announcement.teaser.yml
@@ -1,0 +1,21 @@
+uuid: 9d01b74f-8ab8-402e-92d4-b55194465bfb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.announcement
+  module:
+    - user
+id: node.announcement.teaser
+targetEntityType: node
+bundle: announcement
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.blog_post.default.yml
+++ b/config/core.entity_view_display.node.blog_post.default.yml
@@ -3,18 +3,64 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_attached_images
+    - field.field.node.blog_post.field_author
+    - field.field.node.blog_post.field_image
+    - field.field.node.blog_post.field_publication_date
+    - field.field.node.blog_post.field_tags
     - node.type.blog_post
   module:
+    - datetime
+    - text
     - user
 id: node.blog_post.default
 targetEntityType: node
 bundle: blog_post
 mode: default
 content:
-  links:
-    weight: 100
+  body:
+    weight: 4
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    type: text_default
+    region: content
+  field_author:
+    weight: 0
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_image:
+    weight: 3
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_publication_date:
+    weight: 2
+    label: inline
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_tags:
+    weight: 1
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
 hidden:
+  field_attached_images: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.blog_post.default.yml
+++ b/config/core.entity_view_display.node.blog_post.default.yml
@@ -1,0 +1,20 @@
+uuid: 89747a66-9b3e-4cf4-ade7-538e9020eca4
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog_post
+  module:
+    - user
+id: node.blog_post.default
+targetEntityType: node
+bundle: blog_post
+mode: default
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.blog_post.teaser.yml
+++ b/config/core.entity_view_display.node.blog_post.teaser.yml
@@ -1,0 +1,21 @@
+uuid: 858ca213-be60-43bc-b570-fefa42685f50
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.blog_post
+  module:
+    - user
+id: node.blog_post.teaser
+targetEntityType: node
+bundle: blog_post
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.blog_post.teaser.yml
+++ b/config/core.entity_view_display.node.blog_post.teaser.yml
@@ -4,18 +4,57 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.blog_post.body
+    - field.field.node.blog_post.field_attached_images
+    - field.field.node.blog_post.field_author
+    - field.field.node.blog_post.field_image
+    - field.field.node.blog_post.field_publication_date
+    - field.field.node.blog_post.field_tags
     - node.type.blog_post
   module:
+    - datetime
+    - text
     - user
 id: node.blog_post.teaser
 targetEntityType: node
 bundle: blog_post
 mode: teaser
 content:
-  links:
-    weight: 100
-    settings: {  }
-    third_party_settings: {  }
+  body:
+    type: text_summary_or_trimmed
+    weight: 1
     region: content
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+  field_author:
+    type: string
+    weight: 0
+    region: content
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_publication_date:
+    type: datetime_default
+    weight: 2
+    region: content
+    label: inline
+    settings:
+      timezone_override: UTC
+      format_type: date_short
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_label
+    weight: 3
+    region: content
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
 hidden:
+  field_attached_images: true
+  field_image: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.book.default.yml
+++ b/config/core.entity_view_display.node.book.default.yml
@@ -1,0 +1,29 @@
+uuid: b5b49834-7824-427b-a3e1-e8054dfbae11
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.book.body
+    - node.type.book
+  module:
+    - text
+    - user
+_core:
+  default_config_hash: UWTnZUj-u-jp8I_S1C1nUCTlM5iIV2QKdxm37ehFjoI
+id: node.book.default
+targetEntityType: node
+bundle: book
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 101
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.book.teaser.yml
+++ b/config/core.entity_view_display.node.book.teaser.yml
@@ -1,0 +1,31 @@
+uuid: c1310210-6363-42a8-b61e-12f37fc5b3c2
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.book.body
+    - node.type.book
+  module:
+    - text
+    - user
+_core:
+  default_config_hash: krIbNOdqw4vMF3Ty8qAW6AxgxmdBig5XuQRBW8-HYCU
+id: node.book.teaser
+targetEntityType: node
+bundle: book
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 100
+    region: content
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+  links:
+    weight: 101
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.job.default.yml
+++ b/config/core.entity_view_display.node.job.default.yml
@@ -3,18 +3,105 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.job.body
+    - field.field.node.job.field_career_categories
+    - field.field.node.job.field_city
+    - field.field.node.job.field_country
+    - field.field.node.job.field_how_to_apply
+    - field.field.node.job.field_job_closing_date
+    - field.field.node.job.field_job_experience
+    - field.field.node.job.field_job_type
+    - field.field.node.job.field_source
+    - field.field.node.job.field_theme
     - node.type.job
   module:
+    - datetime
+    - text
     - user
 id: node.job.default
 targetEntityType: node
 bundle: job
 mode: default
 content:
-  links:
-    weight: 100
+  body:
+    weight: 3
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    type: text_default
+    region: content
+  field_career_categories:
+    weight: 7
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_city:
+    weight: 5
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_country:
+    weight: 0
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_how_to_apply:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_job_closing_date:
+    weight: 2
+    label: inline
+    settings:
+      timezone_override: UTC
+      format_type: date_short
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_job_experience:
+    weight: 8
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_job_type:
+    weight: 6
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_source:
+    weight: 1
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_theme:
+    weight: 9
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
 hidden:
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.job.default.yml
+++ b/config/core.entity_view_display.node.job.default.yml
@@ -1,0 +1,20 @@
+uuid: 09f86b64-a62b-46c9-acab-3e6a9df88384
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.job
+  module:
+    - user
+id: node.job.default
+targetEntityType: node
+bundle: job
+mode: default
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.job.teaser.yml
+++ b/config/core.entity_view_display.node.job.teaser.yml
@@ -4,18 +4,50 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.job.body
+    - field.field.node.job.field_career_categories
+    - field.field.node.job.field_city
+    - field.field.node.job.field_country
+    - field.field.node.job.field_how_to_apply
+    - field.field.node.job.field_job_closing_date
+    - field.field.node.job.field_job_experience
+    - field.field.node.job.field_job_type
+    - field.field.node.job.field_source
+    - field.field.node.job.field_theme
     - node.type.job
   module:
+    - datetime
     - user
 id: node.job.teaser
 targetEntityType: node
 bundle: job
 mode: teaser
 content:
-  links:
-    weight: 100
-    settings: {  }
-    third_party_settings: {  }
+  field_job_closing_date:
+    type: datetime_default
+    weight: 1
     region: content
+    label: inline
+    settings:
+      timezone_override: UTC
+      format_type: date_short
+    third_party_settings: {  }
+  field_source:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
 hidden:
+  body: true
+  field_career_categories: true
+  field_city: true
+  field_country: true
+  field_how_to_apply: true
+  field_job_experience: true
+  field_job_type: true
+  field_theme: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.job.teaser.yml
+++ b/config/core.entity_view_display.node.job.teaser.yml
@@ -1,0 +1,21 @@
+uuid: 64c5c36b-83f1-4c2e-94a8-7f4c59b723f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.job
+  module:
+    - user
+id: node.job.teaser
+targetEntityType: node
+bundle: job
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.report.default.yml
+++ b/config/core.entity_view_display.node.report.default.yml
@@ -3,18 +3,157 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.report.body
+    - field.field.node.report.field_bury
+    - field.field.node.report.field_content_format
+    - field.field.node.report.field_country
+    - field.field.node.report.field_disaster
+    - field.field.node.report.field_disaster_type
+    - field.field.node.report.field_embargo_date
+    - field.field.node.report.field_feature
+    - field.field.node.report.field_file
+    - field.field.node.report.field_headline
+    - field.field.node.report.field_headline_image
+    - field.field.node.report.field_headline_summary
+    - field.field.node.report.field_headline_title
+    - field.field.node.report.field_image
+    - field.field.node.report.field_language
+    - field.field.node.report.field_notify
+    - field.field.node.report.field_ocha_product
+    - field.field.node.report.field_origin
+    - field.field.node.report.field_origin_notes
+    - field.field.node.report.field_original_publication_date
+    - field.field.node.report.field_primary_country
+    - field.field.node.report.field_source
+    - field.field.node.report.field_theme
+    - field.field.node.report.field_vulnerable_groups
     - node.type.report
   module:
+    - datetime
+    - text
     - user
 id: node.report.default
 targetEntityType: node
 bundle: report
 mode: default
 content:
-  links:
-    weight: 100
+  body:
+    weight: 7
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    type: text_default
+    region: content
+  field_content_format:
+    weight: 2
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_country:
+    weight: 1
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_disaster:
+    weight: 10
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_disaster_type:
+    weight: 11
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_file:
+    type: entity_reference_entity_view
+    weight: 8
+    label: visually_hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_image:
+    weight: 6
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_language:
+    weight: 12
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_origin_notes:
+    weight: 5
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_original_publication_date:
+    weight: 4
+    label: inline
+    settings:
+      timezone_override: UTC
+      format_type: date_short
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_primary_country:
+    weight: 0
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_source:
+    weight: 3
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_theme:
+    weight: 9
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
 hidden:
+  field_bury: true
+  field_embargo_date: true
+  field_feature: true
+  field_headline: true
+  field_headline_image: true
+  field_headline_summary: true
+  field_headline_title: true
+  field_notify: true
+  field_ocha_product: true
+  field_origin: true
+  field_vulnerable_groups: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.report.default.yml
+++ b/config/core.entity_view_display.node.report.default.yml
@@ -1,0 +1,20 @@
+uuid: 21fa0978-1640-4ca5-82d7-6bf99f5c94e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.report
+  module:
+    - user
+id: node.report.default
+targetEntityType: node
+bundle: report
+mode: default
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.report.headline.yml
+++ b/config/core.entity_view_display.node.report.headline.yml
@@ -1,0 +1,107 @@
+uuid: a79940ab-ecbb-4710-9ca4-4fd4e965ca28
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.headline
+    - field.field.node.report.body
+    - field.field.node.report.field_bury
+    - field.field.node.report.field_content_format
+    - field.field.node.report.field_country
+    - field.field.node.report.field_disaster
+    - field.field.node.report.field_disaster_type
+    - field.field.node.report.field_embargo_date
+    - field.field.node.report.field_feature
+    - field.field.node.report.field_file
+    - field.field.node.report.field_headline
+    - field.field.node.report.field_headline_image
+    - field.field.node.report.field_headline_summary
+    - field.field.node.report.field_headline_title
+    - field.field.node.report.field_image
+    - field.field.node.report.field_language
+    - field.field.node.report.field_notify
+    - field.field.node.report.field_ocha_product
+    - field.field.node.report.field_origin
+    - field.field.node.report.field_origin_notes
+    - field.field.node.report.field_original_publication_date
+    - field.field.node.report.field_primary_country
+    - field.field.node.report.field_source
+    - field.field.node.report.field_theme
+    - field.field.node.report.field_vulnerable_groups
+    - node.type.report
+  module:
+    - user
+id: node.report.headline
+targetEntityType: node
+bundle: report
+mode: headline
+content:
+  field_country:
+    weight: 2
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_headline_image:
+    type: entity_reference_entity_view
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+  field_headline_summary:
+    type: basic_string
+    weight: 4
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_headline_title:
+    type: string
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_primary_country:
+    weight: 1
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_source:
+    weight: 5
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  body: true
+  field_bury: true
+  field_content_format: true
+  field_disaster: true
+  field_disaster_type: true
+  field_embargo_date: true
+  field_feature: true
+  field_file: true
+  field_headline: true
+  field_image: true
+  field_language: true
+  field_notify: true
+  field_ocha_product: true
+  field_origin: true
+  field_origin_notes: true
+  field_original_publication_date: true
+  field_theme: true
+  field_vulnerable_groups: true
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.node.report.teaser.yml
+++ b/config/core.entity_view_display.node.report.teaser.yml
@@ -1,0 +1,21 @@
+uuid: 25faa30b-99b9-4871-897a-4e1b237842d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.report
+  module:
+    - user
+id: node.report.teaser
+targetEntityType: node
+bundle: report
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.report.teaser.yml
+++ b/config/core.entity_view_display.node.report.teaser.yml
@@ -4,18 +4,114 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.report.body
+    - field.field.node.report.field_bury
+    - field.field.node.report.field_content_format
+    - field.field.node.report.field_country
+    - field.field.node.report.field_disaster
+    - field.field.node.report.field_disaster_type
+    - field.field.node.report.field_embargo_date
+    - field.field.node.report.field_feature
+    - field.field.node.report.field_file
+    - field.field.node.report.field_headline
+    - field.field.node.report.field_headline_image
+    - field.field.node.report.field_headline_summary
+    - field.field.node.report.field_headline_title
+    - field.field.node.report.field_image
+    - field.field.node.report.field_language
+    - field.field.node.report.field_notify
+    - field.field.node.report.field_ocha_product
+    - field.field.node.report.field_origin
+    - field.field.node.report.field_origin_notes
+    - field.field.node.report.field_original_publication_date
+    - field.field.node.report.field_primary_country
+    - field.field.node.report.field_source
+    - field.field.node.report.field_theme
+    - field.field.node.report.field_vulnerable_groups
     - node.type.report
   module:
+    - datetime
+    - text
     - user
 id: node.report.teaser
 targetEntityType: node
 bundle: report
 mode: teaser
 content:
-  links:
-    weight: 100
-    settings: {  }
-    third_party_settings: {  }
+  body:
+    type: text_summary_or_trimmed
+    weight: 3
     region: content
+    label: hidden
+    settings:
+      trim_length: 300
+    third_party_settings: {  }
+  field_content_format:
+    type: entity_reference_label
+    weight: 4
+    region: content
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_country:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_file:
+    type: entity_reference_label
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_original_publication_date:
+    type: datetime_default
+    weight: 6
+    region: content
+    label: inline
+    settings:
+      timezone_override: UTC
+      format_type: date_short
+    third_party_settings: {  }
+  field_primary_country:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_source:
+    type: entity_reference_label
+    weight: 5
+    region: content
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
 hidden:
+  field_bury: true
+  field_disaster: true
+  field_disaster_type: true
+  field_embargo_date: true
+  field_feature: true
+  field_headline: true
+  field_headline_image: true
+  field_headline_summary: true
+  field_headline_title: true
+  field_image: true
+  field_language: true
+  field_notify: true
+  field_ocha_product: true
+  field_origin: true
+  field_origin_notes: true
+  field_theme: true
+  field_vulnerable_groups: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.topic.default.yml
+++ b/config/core.entity_view_display.node.topic.default.yml
@@ -1,0 +1,20 @@
+uuid: 46656ea9-6803-4cb8-b3d7-e846ba95ea69
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.topic
+  module:
+    - user
+id: node.topic.default
+targetEntityType: node
+bundle: topic
+mode: default
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.topic.teaser.yml
+++ b/config/core.entity_view_display.node.topic.teaser.yml
@@ -1,0 +1,21 @@
+uuid: 7a44c5f9-dcfd-4276-b7b9-e53d789b8604
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.topic
+  module:
+    - user
+id: node.topic.teaser
+targetEntityType: node
+bundle: topic
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.training.default.yml
+++ b/config/core.entity_view_display.node.training.default.yml
@@ -3,18 +3,159 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.training.body
+    - field.field.node.training.field_career_categories
+    - field.field.node.training.field_city
+    - field.field.node.training.field_cost
+    - field.field.node.training.field_country
+    - field.field.node.training.field_fee_information
+    - field.field.node.training.field_how_to_register
+    - field.field.node.training.field_language
+    - field.field.node.training.field_link
+    - field.field.node.training.field_registration_deadline
+    - field.field.node.training.field_source
+    - field.field.node.training.field_theme
+    - field.field.node.training.field_training_date
+    - field.field.node.training.field_training_format
+    - field.field.node.training.field_training_language
+    - field.field.node.training.field_training_type
     - node.type.training
   module:
+    - datetime
+    - datetime_range
+    - link
+    - options
+    - text
     - user
 id: node.training.default
 targetEntityType: node
 bundle: training
 mode: default
 content:
-  links:
-    weight: 100
+  body:
+    weight: 5
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    type: text_default
+    region: content
+  field_career_categories:
+    weight: 10
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_city:
+    weight: 13
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_cost:
+    weight: 14
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_country:
+    weight: 0
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_fee_information:
+    weight: 7
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_how_to_register:
+    weight: 6
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_link:
+    weight: 4
+    label: inline
+    settings:
+      trim_length: null
+      url_only: true
+      target: _blank
+      url_plain: false
+      rel: '0'
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_registration_deadline:
+    weight: 3
+    label: inline
+    settings:
+      timezone_override: UTC
+      format_type: date_short
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_source:
+    weight: 1
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_theme:
+    weight: 11
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_training_date:
+    weight: 2
+    label: inline
+    settings:
+      timezone_override: UTC
+      format_type: date_short
+      separator: '-'
+    third_party_settings: {  }
+    type: daterange_default
+    region: content
+  field_training_format:
+    weight: 8
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_training_language:
+    weight: 12
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_training_type:
+    weight: 9
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
 hidden:
+  field_language: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.node.training.default.yml
+++ b/config/core.entity_view_display.node.training.default.yml
@@ -1,0 +1,20 @@
+uuid: ca11599a-8db6-47ba-bed7-3b5b8cec5ebf
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.training
+  module:
+    - user
+id: node.training.default
+targetEntityType: node
+bundle: training
+mode: default
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.training.teaser.yml
+++ b/config/core.entity_view_display.node.training.teaser.yml
@@ -1,0 +1,21 @@
+uuid: 7db5666e-0390-467d-a10a-b2769bc4aae1
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.training
+  module:
+    - user
+id: node.training.teaser
+targetEntityType: node
+bundle: training
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.node.training.teaser.yml
+++ b/config/core.entity_view_display.node.training.teaser.yml
@@ -4,18 +4,79 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.training.body
+    - field.field.node.training.field_career_categories
+    - field.field.node.training.field_city
+    - field.field.node.training.field_cost
+    - field.field.node.training.field_country
+    - field.field.node.training.field_fee_information
+    - field.field.node.training.field_how_to_register
+    - field.field.node.training.field_language
+    - field.field.node.training.field_link
+    - field.field.node.training.field_registration_deadline
+    - field.field.node.training.field_source
+    - field.field.node.training.field_theme
+    - field.field.node.training.field_training_date
+    - field.field.node.training.field_training_format
+    - field.field.node.training.field_training_language
+    - field.field.node.training.field_training_type
     - node.type.training
   module:
+    - datetime
+    - datetime_range
     - user
 id: node.training.teaser
 targetEntityType: node
 bundle: training
 mode: teaser
 content:
-  links:
-    weight: 100
-    settings: {  }
-    third_party_settings: {  }
+  field_country:
+    type: entity_reference_label
+    weight: 0
     region: content
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_registration_deadline:
+    type: datetime_default
+    weight: 3
+    region: content
+    label: inline
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+  field_source:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_training_date:
+    type: daterange_default
+    weight: 2
+    region: content
+    label: inline
+    settings:
+      separator: '-'
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
 hidden:
+  body: true
+  field_career_categories: true
+  field_city: true
+  field_cost: true
+  field_fee_information: true
+  field_how_to_register: true
+  field_language: true
+  field_link: true
+  field_theme: true
+  field_training_format: true
+  field_training_language: true
+  field_training_type: true
   langcode: true
+  links: true

--- a/config/core.entity_view_display.taxonomy_term.country.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.country.default.yml
@@ -1,0 +1,28 @@
+uuid: 1abc3fa6-1452-4cd6-a19d-ce0150dcce74
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.country.field_aliases
+    - field.field.taxonomy_term.country.field_iso3
+    - field.field.taxonomy_term.country.field_location
+    - field.field.taxonomy_term.country.field_longname
+    - field.field.taxonomy_term.country.field_profile
+    - field.field.taxonomy_term.country.field_shortname
+    - field.field.taxonomy_term.country.field_timezone
+    - taxonomy.vocabulary.country
+id: taxonomy_term.country.default
+targetEntityType: taxonomy_term
+bundle: country
+mode: default
+content: {  }
+hidden:
+  description: true
+  field_aliases: true
+  field_iso3: true
+  field_location: true
+  field_longname: true
+  field_profile: true
+  field_shortname: true
+  field_timezone: true
+  langcode: true

--- a/config/core.entity_view_display.taxonomy_term.disaster.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.disaster.default.yml
@@ -1,0 +1,53 @@
+uuid: e36c5174-de83-4ce8-beef-49861c180cea
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.disaster.field_country
+    - field.field.taxonomy_term.disaster.field_disaster_date
+    - field.field.taxonomy_term.disaster.field_disaster_type
+    - field.field.taxonomy_term.disaster.field_glide
+    - field.field.taxonomy_term.disaster.field_glide_related
+    - field.field.taxonomy_term.disaster.field_primary_country
+    - field.field.taxonomy_term.disaster.field_primary_disaster_type
+    - field.field.taxonomy_term.disaster.field_profile
+    - field.field.taxonomy_term.disaster.field_timezone
+    - taxonomy.vocabulary.disaster
+id: taxonomy_term.disaster.default
+targetEntityType: taxonomy_term
+bundle: disaster
+mode: default
+content:
+  field_country:
+    weight: 2
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_disaster_type:
+    weight: 1
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_glide:
+    weight: 0
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  description: true
+  field_disaster_date: true
+  field_glide_related: true
+  field_primary_country: true
+  field_primary_disaster_type: true
+  field_profile: true
+  field_timezone: true
+  langcode: true

--- a/config/core.entity_view_display.taxonomy_term.disaster_type.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.disaster_type.default.yml
@@ -1,0 +1,31 @@
+uuid: f0aa3264-de38-4d79-a2a3-2e7160656628
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.disaster_type.field_disaster_type_code
+    - taxonomy.vocabulary.disaster_type
+  module:
+    - text
+id: taxonomy_term.disaster_type.default
+targetEntityType: taxonomy_term
+bundle: disaster_type
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_disaster_type_code:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.taxonomy_term.language.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.language.default.yml
@@ -1,0 +1,31 @@
+uuid: 0316d687-aa4b-4a3c-a077-ab97f5110a9f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.language.field_language_code
+    - taxonomy.vocabulary.language
+  module:
+    - text
+id: taxonomy_term.language.default
+targetEntityType: taxonomy_term
+bundle: language
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_language_code:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  langcode: true

--- a/config/core.entity_view_display.taxonomy_term.source.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.source.default.yml
@@ -1,0 +1,91 @@
+uuid: 53e2fe3a-d125-4005-8566-3c2cabbcb92c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.source.field_aliases
+    - field.field.taxonomy_term.source.field_allowed_content_types
+    - field.field.taxonomy_term.source.field_attention_job
+    - field.field.taxonomy_term.source.field_attention_report
+    - field.field.taxonomy_term.source.field_attention_training
+    - field.field.taxonomy_term.source.field_country
+    - field.field.taxonomy_term.source.field_disclaimer
+    - field.field.taxonomy_term.source.field_fts_id
+    - field.field.taxonomy_term.source.field_homepage
+    - field.field.taxonomy_term.source.field_job_import_feed_url
+    - field.field.taxonomy_term.source.field_links
+    - field.field.taxonomy_term.source.field_logo
+    - field.field.taxonomy_term.source.field_longname
+    - field.field.taxonomy_term.source.field_organization_type
+    - field.field.taxonomy_term.source.field_shortname
+    - field.field.taxonomy_term.source.field_spanish_name
+    - taxonomy.vocabulary.source
+  module:
+    - link
+    - text
+id: taxonomy_term.source.default
+targetEntityType: taxonomy_term
+bundle: source
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_country:
+    weight: 2
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_homepage:
+    weight: 3
+    label: inline
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_links:
+    weight: 4
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_organization_type:
+    weight: 1
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  field_aliases: true
+  field_allowed_content_types: true
+  field_attention_job: true
+  field_attention_report: true
+  field_attention_training: true
+  field_disclaimer: true
+  field_fts_id: true
+  field_job_import_feed_url: true
+  field_logo: true
+  field_longname: true
+  field_shortname: true
+  field_spanish_name: true
+  langcode: true

--- a/config/core.entity_view_mode.media.media_library.yml
+++ b/config/core.entity_view_mode.media.media_library.yml
@@ -1,0 +1,15 @@
+uuid: 5ec635bf-528e-4ea4-b49c-5afcc1206a4e
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - media_library
+  module:
+    - media
+_core:
+  default_config_hash: pkq0uj-IoqEQRBOP_ddUDV0ZJ-dKQ_fLcppsEDF2UO8
+id: media.media_library
+label: 'Media library'
+targetEntityType: media
+cache: true

--- a/config/core.entity_view_mode.node.headline.yml
+++ b/config/core.entity_view_mode.node.headline.yml
@@ -1,0 +1,10 @@
+uuid: 90dd489e-189a-4c81-b705-766aebc91c47
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.headline
+label: Headline
+targetEntityType: node
+cache: true

--- a/config/core.entity_view_mode.node.print.yml
+++ b/config/core.entity_view_mode.node.print.yml
@@ -1,0 +1,15 @@
+uuid: 945122fc-739d-4e11-8c59-7ea6a853a702
+langcode: en
+status: false
+dependencies:
+  enforced:
+    module:
+      - book
+  module:
+    - node
+_core:
+  default_config_hash: ERjobPGdPFAM9p5cmQIcJzk-0cY-1mE1OV_pKmMlJaE
+id: node.print
+label: Print
+targetEntityType: node
+cache: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -24,6 +24,7 @@ module:
   locale: 0
   maintenance200: 0
   media: 0
+  media_library: 0
   menu_link_content: 0
   menu_ui: 0
   metatag: 0

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -2,6 +2,7 @@ module:
   admin_denied: 0
   allowed_formats: 0
   block: 0
+  book: 0
   breakpoint: 0
   components: 0
   config: 0
@@ -17,13 +18,18 @@ module:
   image: 0
   imageapi_optimize: 0
   imageapi_optimize_binaries: 0
+  inline_form_errors: 0
   language: 0
   link: 0
+  locale: 0
   maintenance200: 0
   media: 0
   menu_link_content: 0
   menu_ui: 0
   metatag: 0
+  migrate: 0
+  migrate_plus: 0
+  migrate_tools: 0
   node: 0
   options: 0
   page_cache: 0
@@ -31,6 +37,7 @@ module:
   path_alias: 0
   redirect: 0
   redis: 0
+  reliefweb_migrate: 0
   responsive_image: 0
   social_api: 0
   social_auth: 0

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -14,6 +14,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  geofield: 0
   google_tag: 0
   image: 0
   imageapi_optimize: 0

--- a/config/field.field.media.file_report.field_description.yml
+++ b/config/field.field.media.file_report.field_description.yml
@@ -1,0 +1,19 @@
+uuid: 210a6437-37cd-41be-b6a8-4b8fa6922796
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_description
+    - media.type.file_report
+id: media.file_report.field_description
+field_name: field_description
+entity_type: media
+bundle: file_report
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.media.file_report.field_language.yml
+++ b/config/field.field.media.file_report.field_language.yml
@@ -1,0 +1,29 @@
+uuid: fec5a85b-14a0-4b8b-8b88-aa33b3d824dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_language
+    - media.type.file_report
+    - taxonomy.vocabulary.language
+id: media.file_report.field_language
+field_name: field_language
+entity_type: media
+bundle: file_report
+label: Language
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      language: language
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.media.file_report.field_media_file.yml
+++ b/config/field.field.media.file_report.field_media_file.yml
@@ -1,0 +1,27 @@
+uuid: 731e4c0f-193e-4e4e-8434-682ed0089675
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_file
+    - media.type.file_report
+  module:
+    - file
+id: media.file_report.field_media_file
+field_name: field_media_file
+entity_type: media
+bundle: file_report
+label: File
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'txt doc docx pdf'
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/field.field.media.image_announcement.field_media_image.yml
+++ b/config/field.field.media.image_announcement.field_media_image.yml
@@ -1,0 +1,38 @@
+uuid: acdae1c8-7968-4e7f-b13c-25f6d3984962
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.image_announcement
+  module:
+    - image
+id: media.image_announcement.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: image_announcement
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/field.field.media.image_blog_post.field_copyright.yml
+++ b/config/field.field.media.image_blog_post.field_copyright.yml
@@ -1,0 +1,19 @@
+uuid: 46cac358-5e7e-4575-999e-ed4bbd13b888
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_copyright
+    - media.type.image_blog_post
+id: media.image_blog_post.field_copyright
+field_name: field_copyright
+entity_type: media
+bundle: image_blog_post
+label: Copyright
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.media.image_blog_post.field_media_image.yml
+++ b/config/field.field.media.image_blog_post.field_media_image.yml
@@ -1,0 +1,38 @@
+uuid: d20a7a7e-9e25-4735-a8fa-77d4d4ba80b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.image_blog_post
+  module:
+    - image
+id: media.image_blog_post.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: image_blog_post
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/field.field.media.image_headline.field_copyright.yml
+++ b/config/field.field.media.image_headline.field_copyright.yml
@@ -1,0 +1,19 @@
+uuid: 8a5cd581-ddb6-41ed-a51a-8eb3b9ae2417
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_copyright
+    - media.type.image_headline
+id: media.image_headline.field_copyright
+field_name: field_copyright
+entity_type: media
+bundle: image_headline
+label: Copyright
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.media.image_headline.field_media_image.yml
+++ b/config/field.field.media.image_headline.field_media_image.yml
@@ -1,0 +1,38 @@
+uuid: e0e0f6a5-e9d7-47be-870a-75a7f808a46d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.image_headline
+  module:
+    - image
+id: media.image_headline.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: image_headline
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/field.field.media.image_report.field_copyright.yml
+++ b/config/field.field.media.image_report.field_copyright.yml
@@ -1,0 +1,19 @@
+uuid: 49041cd0-ad64-4ec6-8164-24a57d47eda3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_copyright
+    - media.type.image_report
+id: media.image_report.field_copyright
+field_name: field_copyright
+entity_type: media
+bundle: image_report
+label: Copyright
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.media.image_report.field_media_image.yml
+++ b/config/field.field.media.image_report.field_media_image.yml
@@ -1,0 +1,38 @@
+uuid: 922b81e9-09a1-4381-a298-2c5f36cdfaaa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.image_report
+  module:
+    - image
+id: media.image_report.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: image_report
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/field.field.node.announcement.body.yml
+++ b/config/field.field.node.announcement.body.yml
@@ -1,0 +1,27 @@
+uuid: 9edb6233-d706-446f-bc10-fb5bf7a5b4a1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.announcement
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    plain_text: plain_text
+id: node.announcement.body
+field_name: body
+entity_type: node
+bundle: announcement
+label: Description
+description: 'Description of the banner for when it cannot be shown or for those who cannot see it (ex: screenreaders). Do not use special characters.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.announcement.field_image.yml
+++ b/config/field.field.node.announcement.field_image.yml
@@ -1,0 +1,29 @@
+uuid: 6a4091b3-1ef5-49fd-b990-1e93027ae005
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - media.type.image_announcement
+    - node.type.announcement
+id: node.announcement.field_image
+field_name: field_image
+entity_type: node
+bundle: announcement
+label: Banner
+description: 'Announcement''s banner image. It should be exactly 1200x400 pixels.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image_announcement: image_announcement
+    sort:
+      field: mid
+      direction: DESC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.announcement.field_link.yml
+++ b/config/field.field.node.announcement.field_link.yml
@@ -1,0 +1,23 @@
+uuid: e658589f-3fc1-4ba7-aec6-76bc57d33985
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_link
+    - node.type.announcement
+  module:
+    - link
+id: node.announcement.field_link
+field_name: field_link
+entity_type: node
+bundle: announcement
+label: URL
+description: 'Link to the page the announcement is about.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/field.field.node.blog_post.body.yml
+++ b/config/field.field.node.blog_post.body.yml
@@ -1,0 +1,29 @@
+uuid: 3156b91a-8571-4c31-a5e5-d0ebd325d1b1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.blog_post
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    markdown: markdown
+    html: '0'
+    plain_text: '0'
+id: node.blog_post.body
+field_name: body
+entity_type: node
+bundle: blog_post
+label: Body
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.blog_post.field_attached_images.yml
+++ b/config/field.field.node.blog_post.field_attached_images.yml
@@ -1,0 +1,29 @@
+uuid: c983edd3-d269-4bd1-ac90-394435f6f3b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_attached_images
+    - media.type.image_blog_post
+    - node.type.blog_post
+id: node.blog_post.field_attached_images
+field_name: field_attached_images
+entity_type: node
+bundle: blog_post
+label: 'Attached images'
+description: 'Screenshots and illustrations to be embedded within the blog post. No copyrighted images to be used here. Once uploaded, embed them with: <code>![title](path-to-image-uploaded-here)</code>. Recommended width is 750px.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image_blog_post: image_blog_post
+    sort:
+      field: mid
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.blog_post.field_author.yml
+++ b/config/field.field.node.blog_post.field_author.yml
@@ -1,0 +1,19 @@
+uuid: 9d74ee77-c7a0-4b8b-a43c-3ade7db6dc4f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_author
+    - node.type.blog_post
+id: node.blog_post.field_author
+field_name: field_author
+entity_type: node
+bundle: blog_post
+label: Author
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.blog_post.field_image.yml
+++ b/config/field.field.node.blog_post.field_image.yml
@@ -1,0 +1,29 @@
+uuid: 5c62cae0-0eda-4074-abd2-f1684bd6e104
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - media.type.image_blog_post
+    - node.type.blog_post
+id: node.blog_post.field_image
+field_name: field_image
+entity_type: node
+bundle: blog_post
+label: Image
+description: 'Main illustration for the blog post. Recommended width is 750px.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image_blog_post: image_blog_post
+    sort:
+      field: mid
+      direction: DESC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.blog_post.field_publication_date.yml
+++ b/config/field.field.node.blog_post.field_publication_date.yml
@@ -1,0 +1,21 @@
+uuid: 662c3ece-6a7e-4fa0-b387-ce55c1f36f95
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publication_date
+    - node.type.blog_post
+  module:
+    - datetime
+id: node.blog_post.field_publication_date
+field_name: field_publication_date
+entity_type: node
+bundle: blog_post
+label: 'Publication date'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/field.field.node.blog_post.field_tags.yml
+++ b/config/field.field.node.blog_post.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: 39ecedf0-ff2f-4e52-9fc3-bda9113897f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.blog_post
+    - taxonomy.vocabulary.tag
+id: node.blog_post.field_tags
+field_name: field_tags
+entity_type: node
+bundle: blog_post
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tag: tag
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.book.body.yml
+++ b/config/field.field.node.book.body.yml
@@ -1,0 +1,25 @@
+uuid: b3891c9f-26fe-43fe-a6d6-ce29ab29f079
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.book
+  module:
+    - text
+_core:
+  default_config_hash: 718sPNbCWIXxNeDj1kRMyvll4TdMM9sxlzPrShb1dKU
+id: node.book.body
+field_name: body
+entity_type: node
+bundle: book
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.job.body.yml
+++ b/config/field.field.node.job.body.yml
@@ -1,0 +1,29 @@
+uuid: 94943cc6-b2d8-4da4-9b31-5742d5684611
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.job
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    markdown: markdown
+    html: '0'
+    plain_text: '0'
+id: node.job.body
+field_name: body
+entity_type: node
+bundle: job
+label: 'Job description'
+description: 'The description should be long enough and sufficient in order to attract qualified candidates.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.job.field_career_categories.yml
+++ b/config/field.field.node.job.field_career_categories.yml
@@ -1,0 +1,29 @@
+uuid: 75755e2d-2a32-49a5-bf08-4889fa2ad6e0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_career_categories
+    - node.type.job
+    - taxonomy.vocabulary.career_category
+id: node.job.field_career_categories
+field_name: field_career_categories
+entity_type: node
+bundle: job
+label: 'Career categories'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      career_category: career_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.job.field_city.yml
+++ b/config/field.field.node.job.field_city.yml
@@ -1,0 +1,19 @@
+uuid: 2fc18f33-3de7-48b7-983d-964ad7c38305
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_city
+    - node.type.job
+id: node.job.field_city
+field_name: field_city
+entity_type: node
+bundle: job
+label: City
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.job.field_country.yml
+++ b/config/field.field.node.job.field_country.yml
@@ -1,0 +1,29 @@
+uuid: c2a084a1-c78b-4be2-8ff0-ec04b48a3a24
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_country
+    - node.type.job
+    - taxonomy.vocabulary.country
+id: node.job.field_country
+field_name: field_country
+entity_type: node
+bundle: job
+label: Country
+description: 'Where the actual job is based, regardless of the travel destinations it may require.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.job.field_how_to_apply.yml
+++ b/config/field.field.node.job.field_how_to_apply.yml
@@ -1,0 +1,27 @@
+uuid: 4fa9a999-ac8f-43af-be22-7e4b65bfb10c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_how_to_apply
+    - node.type.job
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    markdown: markdown
+    html: '0'
+    plain_text: '0'
+id: node.job.field_how_to_apply
+field_name: field_how_to_apply
+entity_type: node
+bundle: job
+label: 'How to apply'
+description: 'Brief and clear instructions how to apply only. Not to be used to duplicate the job description.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/field.field.node.job.field_job_closing_date.yml
+++ b/config/field.field.node.job.field_job_closing_date.yml
@@ -1,0 +1,21 @@
+uuid: 16ade5f0-1781-48e7-9b05-5f80f2519c3a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_job_closing_date
+    - node.type.job
+  module:
+    - datetime
+id: node.job.field_job_closing_date
+field_name: field_job_closing_date
+entity_type: node
+bundle: job
+label: 'Closing date'
+description: 'Please make sure it matches the closing date on your ad and/or job application portal, if applicable.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/field.field.node.job.field_job_experience.yml
+++ b/config/field.field.node.job.field_job_experience.yml
@@ -1,0 +1,29 @@
+uuid: ff3e125a-4e6e-48d4-9fe5-e91d11f0786e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_job_experience
+    - node.type.job
+    - taxonomy.vocabulary.job_experience
+id: node.job.field_job_experience
+field_name: field_job_experience
+entity_type: node
+bundle: job
+label: 'Job years of experience'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      job_experience: job_experience
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.job.field_job_type.yml
+++ b/config/field.field.node.job.field_job_type.yml
@@ -1,0 +1,29 @@
+uuid: ab055837-aed9-4246-805e-81d7d9b37844
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_job_type
+    - node.type.job
+    - taxonomy.vocabulary.job_type
+id: node.job.field_job_type
+field_name: field_job_type
+entity_type: node
+bundle: job
+label: 'Job type'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      job_type: job_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.job.field_source.yml
+++ b/config/field.field.node.job.field_source.yml
@@ -1,0 +1,29 @@
+uuid: 792e8002-df17-4393-8a0b-8b8905529560
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_source
+    - node.type.job
+    - taxonomy.vocabulary.source
+id: node.job.field_source
+field_name: field_source
+entity_type: node
+bundle: job
+label: Organization
+description: 'The name of the organization issuing the hiring contract. Please check if your organization is already on our list. New organizations will undergo a brief verification by our team.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      source: source
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.job.field_theme.yml
+++ b/config/field.field.node.job.field_theme.yml
@@ -1,0 +1,29 @@
+uuid: 91bb6c37-f55c-4304-89d6-ebb42d1604b7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_theme
+    - node.type.job
+    - taxonomy.vocabulary.theme
+id: node.job.field_theme
+field_name: field_theme
+entity_type: node
+bundle: job
+label: Theme
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      theme: theme
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.body.yml
+++ b/config/field.field.node.report.body.yml
@@ -1,0 +1,29 @@
+uuid: 574f5529-1670-4d50-9f1a-7cefec8b5aee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.report
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    markdown: markdown
+    html: '0'
+    plain_text: '0'
+id: node.report.body
+field_name: body
+entity_type: node
+bundle: report
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.report.field_bury.yml
+++ b/config/field.field.node.report.field_bury.yml
@@ -1,0 +1,23 @@
+uuid: 958566d7-d9ed-4207-9761-c440a3194862
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_bury
+    - node.type.report
+id: node.report.field_bury
+field_name: field_bury
+entity_type: node
+bundle: report
+label: Bury
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/field.field.node.report.field_content_format.yml
+++ b/config/field.field.node.report.field_content_format.yml
@@ -1,0 +1,29 @@
+uuid: 6fec9477-ec47-40d2-9f61-5d405f12f6a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_format
+    - node.type.report
+    - taxonomy.vocabulary.content_format
+id: node.report.field_content_format
+field_name: field_content_format
+entity_type: node
+bundle: report
+label: 'Content format'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      content_format: content_format
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_country.yml
+++ b/config/field.field.node.report.field_country.yml
@@ -1,0 +1,29 @@
+uuid: ff27f54c-b886-4c62-9811-7bed0121e54d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_country
+    - node.type.report
+    - taxonomy.vocabulary.country
+id: node.report.field_country
+field_name: field_country
+entity_type: node
+bundle: report
+label: Country
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_disaster.yml
+++ b/config/field.field.node.report.field_disaster.yml
@@ -1,0 +1,29 @@
+uuid: fd5bef58-731c-4b94-9362-5d6111c23545
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_disaster
+    - node.type.report
+    - taxonomy.vocabulary.disaster
+id: node.report.field_disaster
+field_name: field_disaster
+entity_type: node
+bundle: report
+label: Disaster
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      disaster: disaster
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_disaster_type.yml
+++ b/config/field.field.node.report.field_disaster_type.yml
@@ -1,0 +1,29 @@
+uuid: 313bffa6-2291-42dc-a467-8bfc45263e11
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_disaster_type
+    - node.type.report
+    - taxonomy.vocabulary.disaster_type
+id: node.report.field_disaster_type
+field_name: field_disaster_type
+entity_type: node
+bundle: report
+label: 'Disaster type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      disaster_type: disaster_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_embargo_date.yml
+++ b/config/field.field.node.report.field_embargo_date.yml
@@ -1,0 +1,21 @@
+uuid: ede14584-4466-4f02-8c3b-d753c25a00fc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_embargo_date
+    - node.type.report
+  module:
+    - datetime
+id: node.report.field_embargo_date
+field_name: field_embargo_date
+entity_type: node
+bundle: report
+label: 'Embargo date'
+description: 'Date until when the document is embargoed. It will be automatically published on that date. It must be a UTC/GMT date.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/field.field.node.report.field_feature.yml
+++ b/config/field.field.node.report.field_feature.yml
@@ -1,0 +1,29 @@
+uuid: 49489e95-6250-4ee2-b310-2895456878af
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_feature
+    - node.type.report
+    - taxonomy.vocabulary.feature
+id: node.report.field_feature
+field_name: field_feature
+entity_type: node
+bundle: report
+label: Feature
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      feature: feature
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_file.yml
+++ b/config/field.field.node.report.field_file.yml
@@ -1,0 +1,29 @@
+uuid: 958a5dcb-a157-4810-8879-b2631a0f175f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_file
+    - media.type.file_report
+    - node.type.report
+id: node.report.field_file
+field_name: field_file
+entity_type: node
+bundle: report
+label: Attachments
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      file_report: file_report
+    sort:
+      field: mid
+      direction: DESC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_headline.yml
+++ b/config/field.field.node.report.field_headline.yml
@@ -1,0 +1,23 @@
+uuid: e7b24d29-5bd4-43bc-9548-f1fec8527809
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_headline
+    - node.type.report
+id: node.report.field_headline
+field_name: field_headline
+entity_type: node
+bundle: report
+label: Headline
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/field.field.node.report.field_headline_image.yml
+++ b/config/field.field.node.report.field_headline_image.yml
@@ -1,0 +1,29 @@
+uuid: 6a1dd4e9-a35b-4169-9fa2-5e19bfe3a25c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_headline_image
+    - media.type.image_headline
+    - node.type.report
+id: node.report.field_headline_image
+field_name: field_headline_image
+entity_type: node
+bundle: report
+label: 'Headline image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image_headline: image_headline
+    sort:
+      field: mid
+      direction: DESC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_headline_summary.yml
+++ b/config/field.field.node.report.field_headline_summary.yml
@@ -1,0 +1,19 @@
+uuid: e6f5af29-0ee4-4ea0-ac9f-9f311dad8a93
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_headline_summary
+    - node.type.report
+id: node.report.field_headline_summary
+field_name: field_headline_summary
+entity_type: node
+bundle: report
+label: 'Headline summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.node.report.field_headline_title.yml
+++ b/config/field.field.node.report.field_headline_title.yml
@@ -1,0 +1,19 @@
+uuid: f4caff7b-b289-4235-9d9e-989148d3ccd1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_headline_title
+    - node.type.report
+id: node.report.field_headline_title
+field_name: field_headline_title
+entity_type: node
+bundle: report
+label: 'Headline title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.report.field_image.yml
+++ b/config/field.field.node.report.field_image.yml
@@ -1,0 +1,29 @@
+uuid: a7d5d6f7-397d-4075-aa07-b9219f51fcae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - media.type.image_report
+    - node.type.report
+id: node.report.field_image
+field_name: field_image
+entity_type: node
+bundle: report
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image_report: image_report
+    sort:
+      field: mid
+      direction: DESC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_language.yml
+++ b/config/field.field.node.report.field_language.yml
@@ -1,0 +1,29 @@
+uuid: a92587f8-7ec5-45c7-8e72-734a877fbcf9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language
+    - node.type.report
+    - taxonomy.vocabulary.language
+id: node.report.field_language
+field_name: field_language
+entity_type: node
+bundle: report
+label: Language
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      language: language
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_notify.yml
+++ b/config/field.field.node.report.field_notify.yml
@@ -1,0 +1,19 @@
+uuid: a061e1d3-a711-4224-9331-4ae012b613d5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_notify
+    - node.type.report
+id: node.report.field_notify
+field_name: field_notify
+entity_type: node
+bundle: report
+label: Notify
+description: 'Enter one email address per line.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.node.report.field_ocha_product.yml
+++ b/config/field.field.node.report.field_ocha_product.yml
@@ -1,0 +1,29 @@
+uuid: d8c34ae4-4dbd-4f51-8e9e-e8dcf7e525fd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ocha_product
+    - node.type.report
+    - taxonomy.vocabulary.ocha_product
+id: node.report.field_ocha_product
+field_name: field_ocha_product
+entity_type: node
+bundle: report
+label: 'OCHA product'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      ocha_product: ocha_product
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_origin.yml
+++ b/config/field.field.node.report.field_origin.yml
@@ -1,0 +1,21 @@
+uuid: 2e14cbe1-5a85-4274-9405-7b2c5434e240
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_origin
+    - node.type.report
+  module:
+    - options
+id: node.report.field_origin
+field_name: field_origin
+entity_type: node
+bundle: report
+label: Origin
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/field.field.node.report.field_origin_notes.yml
+++ b/config/field.field.node.report.field_origin_notes.yml
@@ -1,0 +1,19 @@
+uuid: 83c0c878-28be-4cc8-9107-aec8f6fc3e9e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_origin_notes
+    - node.type.report
+id: node.report.field_origin_notes
+field_name: field_origin_notes
+entity_type: node
+bundle: report
+label: 'Origin notes'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.report.field_original_publication_date.yml
+++ b/config/field.field.node.report.field_original_publication_date.yml
@@ -1,0 +1,21 @@
+uuid: a9ff7747-8be6-41c5-844a-f46ef410e87b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_original_publication_date
+    - node.type.report
+  module:
+    - datetime
+id: node.report.field_original_publication_date
+field_name: field_original_publication_date
+entity_type: node
+bundle: report
+label: 'Original publication date'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/field.field.node.report.field_primary_country.yml
+++ b/config/field.field.node.report.field_primary_country.yml
@@ -1,0 +1,29 @@
+uuid: 5396d158-9222-4aec-b9ff-be590239e319
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_primary_country
+    - node.type.report
+    - taxonomy.vocabulary.country
+id: node.report.field_primary_country
+field_name: field_primary_country
+entity_type: node
+bundle: report
+label: 'Primary country'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_source.yml
+++ b/config/field.field.node.report.field_source.yml
@@ -1,0 +1,29 @@
+uuid: b2b110d1-2426-4296-a022-2133f40ec045
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_source
+    - node.type.report
+    - taxonomy.vocabulary.source
+id: node.report.field_source
+field_name: field_source
+entity_type: node
+bundle: report
+label: Organization
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      source: source
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_theme.yml
+++ b/config/field.field.node.report.field_theme.yml
@@ -1,0 +1,29 @@
+uuid: 5de9a18b-6a50-4cd3-b7a3-ef9270f119c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_theme
+    - node.type.report
+    - taxonomy.vocabulary.theme
+id: node.report.field_theme
+field_name: field_theme
+entity_type: node
+bundle: report
+label: Theme
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      theme: theme
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.report.field_vulnerable_groups.yml
+++ b/config/field.field.node.report.field_vulnerable_groups.yml
@@ -1,0 +1,29 @@
+uuid: 62b3344e-720c-49fe-9ec5-a61815362b66
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_vulnerable_groups
+    - node.type.report
+    - taxonomy.vocabulary.vulnerable_group
+id: node.report.field_vulnerable_groups
+field_name: field_vulnerable_groups
+entity_type: node
+bundle: report
+label: 'Vulnerable groups'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      vulnerable_group: vulnerable_group
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.body.yml
+++ b/config/field.field.node.training.body.yml
@@ -1,0 +1,29 @@
+uuid: 71a3a378-d434-4990-9538-48561b0c12ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.training
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    markdown: markdown
+    html: '0'
+    plain_text: '0'
+id: node.training.body
+field_name: body
+entity_type: node
+bundle: training
+label: Body
+description: 'The Body field must contain the complete description of the training opportunity (ex: introduction, methodology, objectives, target audience). This core information cannot be substituted by providing a link for "further details".'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/field.field.node.training.field_career_categories.yml
+++ b/config/field.field.node.training.field_career_categories.yml
@@ -1,0 +1,29 @@
+uuid: 2f634013-8583-49e1-9ea9-035379401db0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_career_categories
+    - node.type.training
+    - taxonomy.vocabulary.career_category
+id: node.training.field_career_categories
+field_name: field_career_categories
+entity_type: node
+bundle: training
+label: 'Professional function'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      career_category: career_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.field_city.yml
+++ b/config/field.field.node.training.field_city.yml
@@ -1,0 +1,19 @@
+uuid: 22aae2e6-48e4-4dc5-a2d0-07787f0bd713
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_city
+    - node.type.training
+id: node.training.field_city
+field_name: field_city
+entity_type: node
+bundle: training
+label: City
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.training.field_cost.yml
+++ b/config/field.field.node.training.field_cost.yml
@@ -1,0 +1,21 @@
+uuid: 42dc608a-1f44-4633-b7db-24c46dbde281
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_cost
+    - node.type.training
+  module:
+    - options
+id: node.training.field_cost
+field_name: field_cost
+entity_type: node
+bundle: training
+label: Cost
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/field.field.node.training.field_country.yml
+++ b/config/field.field.node.training.field_country.yml
@@ -1,0 +1,29 @@
+uuid: 74177a4f-fe6e-4e86-b912-5f8495f62dcd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_country
+    - node.type.training
+    - taxonomy.vocabulary.country
+id: node.training.field_country
+field_name: field_country
+entity_type: node
+bundle: training
+label: Country
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.field_fee_information.yml
+++ b/config/field.field.node.training.field_fee_information.yml
@@ -1,0 +1,19 @@
+uuid: 449cf5b9-56cc-4e65-bd0a-797da0b79cd5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_fee_information
+    - node.type.training
+id: node.training.field_fee_information
+field_name: field_fee_information
+entity_type: node
+bundle: training
+label: 'Fee information'
+description: 'The Fee Information field must contain the exact course fee (including what it does and does not cover) and cannot be substituted by providing a link for "further details". In case a training/event is offered for a fee but is also available in another format (e.g. online at no cost), the "fee-based" option should be selected.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.node.training.field_how_to_register.yml
+++ b/config/field.field.node.training.field_how_to_register.yml
@@ -1,0 +1,27 @@
+uuid: e816ea7e-66d0-4e51-b9b5-ed896ca8cc67
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_how_to_register
+    - node.type.training
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    markdown: markdown
+    html: '0'
+    plain_text: '0'
+id: node.training.field_how_to_register
+field_name: field_how_to_register
+entity_type: node
+bundle: training
+label: 'How to register'
+description: 'The requirements for this field are: the application procedure/condition(s) and contact details. This core information cannot be substituted by providing a link for "further details". If no registration is required, provide contact details, a link to the advertisement (on the Organization’s website) or include the text: "No registration required."'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/field.field.node.training.field_language.yml
+++ b/config/field.field.node.training.field_language.yml
@@ -1,0 +1,29 @@
+uuid: 83c3d9d5-b67c-40d2-bc84-6fb9e61c84b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language
+    - node.type.training
+    - taxonomy.vocabulary.language
+id: node.training.field_language
+field_name: field_language
+entity_type: node
+bundle: training
+label: 'Advertisement language'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      language: language
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.field_link.yml
+++ b/config/field.field.node.training.field_link.yml
@@ -1,0 +1,23 @@
+uuid: 5b17fa3d-99cf-4e89-8df8-8622150cd869
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_link
+    - node.type.training
+  module:
+    - link
+id: node.training.field_link
+field_name: field_link
+entity_type: node
+bundle: training
+label: 'Event URL'
+description: 'The Event URL field is now mandatory. Add a link where more information can be found about the training opportunity. No social media URL should be used in this field, although it can be mentioned in the Body field.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/field.field.node.training.field_registration_deadline.yml
+++ b/config/field.field.node.training.field_registration_deadline.yml
@@ -1,0 +1,21 @@
+uuid: 6a92e2b3-86d0-4ada-b153-b8d0fbf97d7e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_registration_deadline
+    - node.type.training
+  module:
+    - datetime
+id: node.training.field_registration_deadline
+field_name: field_registration_deadline
+entity_type: node
+bundle: training
+label: 'Registration deadline'
+description: 'All advertisements should include a registration deadline unless it is an "ongoing course". Advertisements immediately expire after the registration deadline has passed. Advertisements tagged with "Call for Papers" usually include a submission deadline in the body text, so they should not be ongoing ads. For Universities, any ads advertising degrees should not be ongoing ads and should have a deadline.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/field.field.node.training.field_source.yml
+++ b/config/field.field.node.training.field_source.yml
@@ -1,0 +1,29 @@
+uuid: b9b5accb-b018-4fb5-ad9e-ea3f4f0eae13
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_source
+    - node.type.training
+    - taxonomy.vocabulary.source
+id: node.training.field_source
+field_name: field_source
+entity_type: node
+bundle: training
+label: Organization
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      source: source
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.field_theme.yml
+++ b/config/field.field.node.training.field_theme.yml
@@ -1,0 +1,29 @@
+uuid: e202cebc-28d7-4a0e-bd54-716fbe09adce
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_theme
+    - node.type.training
+    - taxonomy.vocabulary.theme
+id: node.training.field_theme
+field_name: field_theme
+entity_type: node
+bundle: training
+label: Theme
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      theme: theme
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.field_training_date.yml
+++ b/config/field.field.node.training.field_training_date.yml
@@ -1,0 +1,26 @@
+uuid: 0c7817e5-6c51-4913-b0a4-6e5bebfba27f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_training_date
+    - node.type.training
+  module:
+    - datetime_range
+id: node.training.field_training_date
+field_name: field_training_date
+entity_type: node
+bundle: training
+label: 'Training date'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+    default_end_date_type: now
+    default_end_date: now
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/config/field.field.node.training.field_training_format.yml
+++ b/config/field.field.node.training.field_training_format.yml
@@ -1,0 +1,29 @@
+uuid: 5046fffb-e960-4063-a84c-965eb7c5b80e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_training_format
+    - node.type.training
+    - taxonomy.vocabulary.training_format
+id: node.training.field_training_format
+field_name: field_training_format
+entity_type: node
+bundle: training
+label: 'Training format'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      training_format: training_format
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.field_training_language.yml
+++ b/config/field.field.node.training.field_training_language.yml
@@ -1,0 +1,29 @@
+uuid: 722d8198-d944-4ac5-bf9a-9554758ba73b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_training_language
+    - node.type.training
+    - taxonomy.vocabulary.language
+id: node.training.field_training_language
+field_name: field_training_language
+entity_type: node
+bundle: training
+label: 'Course/Event language'
+description: 'Select the language(s) in which the training will be held.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      language: language
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.training.field_training_type.yml
+++ b/config/field.field.node.training.field_training_type.yml
@@ -1,0 +1,29 @@
+uuid: 18c25b2f-a278-4a38-b56b-1a708da5a904
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_training_type
+    - node.type.training
+    - taxonomy.vocabulary.training_type
+id: node.training.field_training_type
+field_name: field_training_type
+entity_type: node
+bundle: training
+label: Category
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      training_type: training_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.country.field_aliases.yml
+++ b/config/field.field.taxonomy_term.country.field_aliases.yml
@@ -1,0 +1,19 @@
+uuid: c07ed08e-ce49-4826-9fc7-339b11b75431
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_aliases
+    - taxonomy.vocabulary.country
+id: taxonomy_term.country.field_aliases
+field_name: field_aliases
+entity_type: taxonomy_term
+bundle: country
+label: 'Alternative names'
+description: 'List of alternative or past names of the country. Enter one name per line.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.taxonomy_term.country.field_iso3.yml
+++ b/config/field.field.taxonomy_term.country.field_iso3.yml
@@ -1,0 +1,19 @@
+uuid: e70a2e50-673d-45fe-9817-d73cc834f262
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_iso3
+    - taxonomy.vocabulary.country
+id: taxonomy_term.country.field_iso3
+field_name: field_iso3
+entity_type: taxonomy_term
+bundle: country
+label: 'ISO 3 code'
+description: '3 letters ISO 3166-1 alpha-3 country code.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.country.field_location.yml
+++ b/config/field.field.taxonomy_term.country.field_location.yml
@@ -1,0 +1,22 @@
+uuid: 6a535b8f-6ec2-40b6-88ea-9d51188e6530
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_location
+    - taxonomy.vocabulary.country
+  module:
+    - geofield
+id: taxonomy_term.country.field_location
+field_name: field_location
+entity_type: taxonomy_term
+bundle: country
+label: Location
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  backend: geofield_backend_default
+field_type: geofield

--- a/config/field.field.taxonomy_term.country.field_longname.yml
+++ b/config/field.field.taxonomy_term.country.field_longname.yml
@@ -1,0 +1,19 @@
+uuid: 82cfeb2f-baa4-4468-adb3-08d712bb5d05
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_longname
+    - taxonomy.vocabulary.country
+id: taxonomy_term.country.field_longname
+field_name: field_longname
+entity_type: taxonomy_term
+bundle: country
+label: Longname
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.country.field_profile.yml
+++ b/config/field.field.taxonomy_term.country.field_profile.yml
@@ -1,0 +1,23 @@
+uuid: 9af45ea3-3c2a-431d-9c9d-037f2beed960
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_profile
+    - taxonomy.vocabulary.country
+id: taxonomy_term.country.field_profile
+field_name: field_profile
+entity_type: taxonomy_term
+bundle: country
+label: 'Show profile'
+description: 'When selected, the country''s profile (description, key content etc.) will be visible to visitors.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/field.field.taxonomy_term.country.field_shortname.yml
+++ b/config/field.field.taxonomy_term.country.field_shortname.yml
@@ -1,0 +1,19 @@
+uuid: 778ccedb-cf31-4fe2-ae2b-ef873e1dce35
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_shortname
+    - taxonomy.vocabulary.country
+id: taxonomy_term.country.field_shortname
+field_name: field_shortname
+entity_type: taxonomy_term
+bundle: country
+label: Shortname
+description: 'Country short name (ex: USA). If none is available, simply copy the name of the country.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.country.field_timezone.yml
+++ b/config/field.field.taxonomy_term.country.field_timezone.yml
@@ -1,0 +1,21 @@
+uuid: 5858a019-e3ec-46dd-91a7-4d19ce8b2d1f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_timezone
+    - taxonomy.vocabulary.country
+  module:
+    - options
+id: taxonomy_term.country.field_timezone
+field_name: field_timezone
+entity_type: taxonomy_term
+bundle: country
+label: 'Time zone'
+description: 'Choose the main time zone for this country. This information will be used for instance to determine at what time to send out notifications for related content.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/field.field.taxonomy_term.disaster.field_country.yml
+++ b/config/field.field.taxonomy_term.disaster.field_country.yml
@@ -1,0 +1,29 @@
+uuid: 6c957263-6ed7-41f9-98f5-458a758e5960
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_country
+    - taxonomy.vocabulary.country
+    - taxonomy.vocabulary.disaster
+id: taxonomy_term.disaster.field_country
+field_name: field_country
+entity_type: taxonomy_term
+bundle: disaster
+label: Country
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.disaster.field_disaster_date.yml
+++ b/config/field.field.taxonomy_term.disaster.field_disaster_date.yml
@@ -1,0 +1,21 @@
+uuid: 71469558-58b8-4412-8a87-518f8965da4f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_disaster_date
+    - taxonomy.vocabulary.disaster
+  module:
+    - datetime
+id: taxonomy_term.disaster.field_disaster_date
+field_name: field_disaster_date
+entity_type: taxonomy_term
+bundle: disaster
+label: 'Event date'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/field.field.taxonomy_term.disaster.field_disaster_type.yml
+++ b/config/field.field.taxonomy_term.disaster.field_disaster_type.yml
@@ -1,0 +1,29 @@
+uuid: e0ec45fa-6b53-4822-9149-a6796bd164c9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_disaster_type
+    - taxonomy.vocabulary.disaster
+    - taxonomy.vocabulary.disaster_type
+id: taxonomy_term.disaster.field_disaster_type
+field_name: field_disaster_type
+entity_type: taxonomy_term
+bundle: disaster
+label: 'Disaster type'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      disaster_type: disaster_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.disaster.field_glide.yml
+++ b/config/field.field.taxonomy_term.disaster.field_glide.yml
@@ -1,0 +1,19 @@
+uuid: 4a1b28f8-47b0-4bbc-80eb-b184ff415535
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_glide
+    - taxonomy.vocabulary.disaster
+id: taxonomy_term.disaster.field_glide
+field_name: field_glide
+entity_type: taxonomy_term
+bundle: disaster
+label: 'GLIDE number'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.disaster.field_glide_related.yml
+++ b/config/field.field.taxonomy_term.disaster.field_glide_related.yml
@@ -1,0 +1,19 @@
+uuid: 3b19331e-6fd7-4ef1-8cfb-67c665b8a74b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_glide_related
+    - taxonomy.vocabulary.disaster
+id: taxonomy_term.disaster.field_glide_related
+field_name: field_glide_related
+entity_type: taxonomy_term
+bundle: disaster
+label: 'Related GLIDE numbers'
+description: 'One related GLIDE number per line.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.taxonomy_term.disaster.field_primary_country.yml
+++ b/config/field.field.taxonomy_term.disaster.field_primary_country.yml
@@ -1,0 +1,29 @@
+uuid: 3091a465-1084-47f9-b01b-f5c0a360d7fe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_primary_country
+    - taxonomy.vocabulary.country
+    - taxonomy.vocabulary.disaster
+id: taxonomy_term.disaster.field_primary_country
+field_name: field_primary_country
+entity_type: taxonomy_term
+bundle: disaster
+label: 'Primary country'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.disaster.field_primary_disaster_type.yml
+++ b/config/field.field.taxonomy_term.disaster.field_primary_disaster_type.yml
@@ -1,0 +1,29 @@
+uuid: 86ae3d82-7da8-45cb-89f6-69df57ac091d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_primary_disaster_type
+    - taxonomy.vocabulary.disaster
+    - taxonomy.vocabulary.disaster_type
+id: taxonomy_term.disaster.field_primary_disaster_type
+field_name: field_primary_disaster_type
+entity_type: taxonomy_term
+bundle: disaster
+label: 'Primary disaster type'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      disaster_type: disaster_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.disaster.field_profile.yml
+++ b/config/field.field.taxonomy_term.disaster.field_profile.yml
@@ -1,0 +1,23 @@
+uuid: 007650ec-b284-4e01-b651-024a7443eead
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_profile
+    - taxonomy.vocabulary.disaster
+id: taxonomy_term.disaster.field_profile
+field_name: field_profile
+entity_type: taxonomy_term
+bundle: disaster
+label: 'Show profile'
+description: 'When selected, the disaster''s profile (description, key content etc.) will be visible to visitors.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/field.field.taxonomy_term.disaster.field_timezone.yml
+++ b/config/field.field.taxonomy_term.disaster.field_timezone.yml
@@ -1,0 +1,21 @@
+uuid: d8297309-413d-48b4-8426-0bef5672c5c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_timezone
+    - taxonomy.vocabulary.disaster
+  module:
+    - options
+id: taxonomy_term.disaster.field_timezone
+field_name: field_timezone
+entity_type: taxonomy_term
+bundle: disaster
+label: 'Notifications time zone'
+description: 'Choose the main time zone for this disaster entry. This information will be used for instance to determine at what time to send out notifications for related content.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/field.field.taxonomy_term.disaster_type.field_disaster_type_code.yml
+++ b/config/field.field.taxonomy_term.disaster_type.field_disaster_type_code.yml
@@ -1,0 +1,19 @@
+uuid: 11350577-66bb-4ce1-a714-34c3e47a2ac5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_disaster_type_code
+    - taxonomy.vocabulary.disaster_type
+id: taxonomy_term.disaster_type.field_disaster_type_code
+field_name: field_disaster_type_code
+entity_type: taxonomy_term
+bundle: disaster_type
+label: Code
+description: '2 letters disaster type code (ex: FL for Floods).'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.language.field_language_code.yml
+++ b/config/field.field.taxonomy_term.language.field_language_code.yml
@@ -1,0 +1,19 @@
+uuid: dd97e451-942a-47a6-80f7-d75a46ee8097
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_language_code
+    - taxonomy.vocabulary.language
+id: taxonomy_term.language.field_language_code
+field_name: field_language_code
+entity_type: taxonomy_term
+bundle: language
+label: 'Language code'
+description: '2 letters ISO 639-1 language code.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.source.field_aliases.yml
+++ b/config/field.field.taxonomy_term.source.field_aliases.yml
@@ -1,0 +1,19 @@
+uuid: 401885bb-a0e7-47d7-b18d-7d9a35d41b82
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_aliases
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_aliases
+field_name: field_aliases
+entity_type: taxonomy_term
+bundle: source
+label: 'Alternative names'
+description: 'Previous names, other names etc. One per line.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.taxonomy_term.source.field_allowed_content_types.yml
+++ b/config/field.field.taxonomy_term.source.field_allowed_content_types.yml
@@ -1,0 +1,21 @@
+uuid: 6d9be077-3a88-4b33-a54f-1a517c9cf579
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_allowed_content_types
+    - taxonomy.vocabulary.source
+  module:
+    - options
+id: taxonomy_term.source.field_allowed_content_types
+field_name: field_allowed_content_types
+entity_type: taxonomy_term
+bundle: source
+label: 'Allowed content types'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_integer

--- a/config/field.field.taxonomy_term.source.field_attention_job.yml
+++ b/config/field.field.taxonomy_term.source.field_attention_job.yml
@@ -1,0 +1,19 @@
+uuid: 33eeaa97-f39c-49fe-834d-29d082edb599
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_attention_job
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_attention_job
+field_name: field_attention_job
+entity_type: taxonomy_term
+bundle: source
+label: 'Attention job'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.taxonomy_term.source.field_attention_report.yml
+++ b/config/field.field.taxonomy_term.source.field_attention_report.yml
@@ -1,0 +1,19 @@
+uuid: 807a47a3-3fc3-4aac-9006-055a67ca95af
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_attention_report
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_attention_report
+field_name: field_attention_report
+entity_type: taxonomy_term
+bundle: source
+label: 'Attention report'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.taxonomy_term.source.field_attention_training.yml
+++ b/config/field.field.taxonomy_term.source.field_attention_training.yml
@@ -1,0 +1,19 @@
+uuid: d5611d77-6e6e-447f-a05c-e33eeac06490
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_attention_training
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_attention_training
+field_name: field_attention_training
+entity_type: taxonomy_term
+bundle: source
+label: 'Attention training'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.taxonomy_term.source.field_country.yml
+++ b/config/field.field.taxonomy_term.source.field_country.yml
@@ -1,0 +1,29 @@
+uuid: 123b19b9-dc6e-48fe-9bba-03ff57525516
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_country
+    - taxonomy.vocabulary.country
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_country
+field_name: field_country
+entity_type: taxonomy_term
+bundle: source
+label: Country
+description: 'Organization headquarter(s).'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      country: country
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.source.field_disclaimer.yml
+++ b/config/field.field.taxonomy_term.source.field_disclaimer.yml
@@ -1,0 +1,19 @@
+uuid: cecd4734-7f3a-494c-906b-fea42c27bec8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_disclaimer
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_disclaimer
+field_name: field_disclaimer
+entity_type: taxonomy_term
+bundle: source
+label: Disclaimer
+description: 'Source disclaimer in plain text.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.taxonomy_term.source.field_fts_id.yml
+++ b/config/field.field.taxonomy_term.source.field_fts_id.yml
@@ -1,0 +1,19 @@
+uuid: 1874fc12-21e6-43ce-b056-fc37cffff3b4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_fts_id
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_fts_id
+field_name: field_fts_id
+entity_type: taxonomy_term
+bundle: source
+label: 'FTS id'
+description: 'Id number used by FTS.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.source.field_homepage.yml
+++ b/config/field.field.taxonomy_term.source.field_homepage.yml
@@ -1,0 +1,23 @@
+uuid: 229218d1-c4d0-4aa4-8b8a-792a4f941361
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_homepage
+    - taxonomy.vocabulary.source
+  module:
+    - link
+id: taxonomy_term.source.field_homepage
+field_name: field_homepage
+entity_type: taxonomy_term
+bundle: source
+label: 'Home page'
+description: 'URL of the homepage of the organization starting with https:// or http://'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/field.field.taxonomy_term.source.field_job_import_feed_url.yml
+++ b/config/field.field.taxonomy_term.source.field_job_import_feed_url.yml
@@ -1,0 +1,23 @@
+uuid: e036796c-7dc2-42db-8645-8d8db1f5d8c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_job_import_feed_url
+    - taxonomy.vocabulary.source
+  module:
+    - link
+id: taxonomy_term.source.field_job_import_feed_url
+field_name: field_job_import_feed_url
+entity_type: taxonomy_term
+bundle: source
+label: 'Job import feed URL'
+description: 'For automatic job imports. Link URL is a feed url of an updated list of the organizations job offers.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 2
+field_type: link

--- a/config/field.field.taxonomy_term.source.field_links.yml
+++ b/config/field.field.taxonomy_term.source.field_links.yml
@@ -1,0 +1,23 @@
+uuid: d4759e00-2194-4c8d-ba41-5188c83bd477
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_links
+    - taxonomy.vocabulary.source
+  module:
+    - link
+id: taxonomy_term.source.field_links
+field_name: field_links
+entity_type: taxonomy_term
+bundle: source
+label: 'Social media links'
+description: 'Links to social media platforms like twitter.com, youtube.com or facebook.com.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/field.field.taxonomy_term.source.field_logo.yml
+++ b/config/field.field.taxonomy_term.source.field_logo.yml
@@ -1,0 +1,38 @@
+uuid: 259797d2-54e1-480d-953c-bff5c6f2a9f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_logo
+    - taxonomy.vocabulary.source
+  module:
+    - image
+id: taxonomy_term.source.field_logo
+field_name: field_logo
+entity_type: taxonomy_term
+bundle: source
+label: Logo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: organization-logos
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/field.field.taxonomy_term.source.field_longname.yml
+++ b/config/field.field.taxonomy_term.source.field_longname.yml
@@ -1,0 +1,19 @@
+uuid: fc5f9589-d4e0-4375-bb3c-bdd1dd72d242
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_longname
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_longname
+field_name: field_longname
+entity_type: taxonomy_term
+bundle: source
+label: Longname
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.source.field_organization_type.yml
+++ b/config/field.field.taxonomy_term.source.field_organization_type.yml
@@ -1,0 +1,29 @@
+uuid: 03295425-177a-4ecd-ab27-feb89c19073d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_organization_type
+    - taxonomy.vocabulary.organization_type
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_organization_type
+field_name: field_organization_type
+entity_type: taxonomy_term
+bundle: source
+label: 'Organization type'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      organization_type: organization_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.source.field_shortname.yml
+++ b/config/field.field.taxonomy_term.source.field_shortname.yml
@@ -1,0 +1,19 @@
+uuid: 1ca6088f-7d29-4d7e-83f6-0ae9ecc7729b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_shortname
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_shortname
+field_name: field_shortname
+entity_type: taxonomy_term
+bundle: source
+label: Shortname
+description: 'Acronym or short name. If none is available, simply copy the name of the source.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.source.field_spanish_name.yml
+++ b/config/field.field.taxonomy_term.source.field_spanish_name.yml
@@ -1,0 +1,19 @@
+uuid: c1a088a9-7bf0-4314-b3de-5bde23fe3bcd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_spanish_name
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source.field_spanish_name
+field_name: field_spanish_name
+entity_type: taxonomy_term
+bundle: source
+label: 'Spanish name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.media.field_copyright.yml
+++ b/config/field.storage.media.field_copyright.yml
@@ -1,0 +1,21 @@
+uuid: 398528df-600d-49b7-a604-6afa077561a0
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_copyright
+field_name: field_copyright
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_description.yml
+++ b/config/field.storage.media.field_description.yml
@@ -1,0 +1,21 @@
+uuid: c2b3b801-3720-4fed-a5af-7ed7bb10f5ba
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_description
+field_name: field_description
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_language.yml
+++ b/config/field.storage.media.field_language.yml
@@ -1,0 +1,20 @@
+uuid: 730ebf70-237d-4817-8a0f-52c01d32b890
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.field_language
+field_name: field_language
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_media_file.yml
+++ b/config/field.storage.media.field_media_file.yml
@@ -1,0 +1,23 @@
+uuid: 8686462a-ee0c-4a8e-bc38-8c091b4a3a9a
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - media
+id: media.field_media_file
+field_name: field_media_file
+entity_type: media
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.media.field_media_image.yml
+++ b/config/field.storage.media.field_media_image.yml
@@ -1,0 +1,30 @@
+uuid: 0779a599-8347-4d48-a366-df3e5d596c42
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - media
+id: media.field_media_image
+field_name: field_media_image
+entity_type: media
+type: image
+settings:
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_attached_images.yml
+++ b/config/field.storage.node.field_attached_images.yml
@@ -1,0 +1,20 @@
+uuid: 3b92e7bd-6dc5-4620-b96b-5b2b7f1c3635
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_attached_images
+field_name: field_attached_images
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_author.yml
+++ b/config/field.storage.node.field_author.yml
@@ -1,0 +1,21 @@
+uuid: b836e71b-ccf5-4020-bd09-a64f2bba3986
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_author
+field_name: field_author
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_bury.yml
+++ b/config/field.storage.node.field_bury.yml
@@ -1,0 +1,18 @@
+uuid: 2ddb4322-a606-4852-b775-847fb967a863
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_bury
+field_name: field_bury
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_career_categories.yml
+++ b/config/field.storage.node.field_career_categories.yml
@@ -1,0 +1,20 @@
+uuid: f9abb3c2-de9c-47b0-aeb3-26ca1731b96c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_career_categories
+field_name: field_career_categories
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_city.yml
+++ b/config/field.storage.node.field_city.yml
@@ -1,0 +1,21 @@
+uuid: f8a82c55-d289-44f3-8b26-6e8603cca71b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_city
+field_name: field_city
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_content_format.yml
+++ b/config/field.storage.node.field_content_format.yml
@@ -1,0 +1,20 @@
+uuid: d5cbaf17-1be1-4865-a2cb-0af26a403b45
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_content_format
+field_name: field_content_format
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_cost.yml
+++ b/config/field.storage.node.field_cost.yml
@@ -1,0 +1,27 @@
+uuid: d84a6345-dfe9-4ce5-a540-8834b9a78c9c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_cost
+field_name: field_cost
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: free
+      label: free
+    -
+      value: fee-based
+      label: fee-based
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_country.yml
+++ b/config/field.storage.node.field_country.yml
@@ -1,0 +1,20 @@
+uuid: 6a80599a-171e-44fc-979e-5a3d8fbec139
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_country
+field_name: field_country
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_disaster.yml
+++ b/config/field.storage.node.field_disaster.yml
@@ -1,0 +1,20 @@
+uuid: f6b164dd-8aad-45b6-97b9-a56e9c6ab0ca
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_disaster
+field_name: field_disaster
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_disaster_type.yml
+++ b/config/field.storage.node.field_disaster_type.yml
@@ -1,0 +1,20 @@
+uuid: 810f2568-f26c-4769-82cf-10a7a6ef2b21
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_disaster_type
+field_name: field_disaster_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_embargo_date.yml
+++ b/config/field.storage.node.field_embargo_date.yml
@@ -1,0 +1,20 @@
+uuid: 9d63ee50-be0d-4db0-917e-44e5864927c3
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_embargo_date
+field_name: field_embargo_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_feature.yml
+++ b/config/field.storage.node.field_feature.yml
@@ -1,0 +1,20 @@
+uuid: 8d92bd27-6677-42f9-b376-b699cdb4219e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_feature
+field_name: field_feature
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_fee_information.yml
+++ b/config/field.storage.node.field_fee_information.yml
@@ -1,0 +1,19 @@
+uuid: 298c02ce-a26a-46a7-b487-0e04e3439eda
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_fee_information
+field_name: field_fee_information
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_file.yml
+++ b/config/field.storage.node.field_file.yml
@@ -1,0 +1,20 @@
+uuid: fd39bfa9-22e4-47d1-9401-fd7595fe0428
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_file
+field_name: field_file
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_headline.yml
+++ b/config/field.storage.node.field_headline.yml
@@ -1,0 +1,18 @@
+uuid: 5fc4fa31-4422-4f8e-93ca-0f03d3aa1e25
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_headline
+field_name: field_headline
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_headline_image.yml
+++ b/config/field.storage.node.field_headline_image.yml
@@ -1,0 +1,20 @@
+uuid: bd36f40a-8ace-4894-a267-9f332258cea4
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_headline_image
+field_name: field_headline_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_headline_summary.yml
+++ b/config/field.storage.node.field_headline_summary.yml
@@ -1,0 +1,19 @@
+uuid: 777b7f5d-2986-44ca-9f57-b4c1fd0946ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_headline_summary
+field_name: field_headline_summary
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_headline_title.yml
+++ b/config/field.storage.node.field_headline_title.yml
@@ -1,0 +1,21 @@
+uuid: 661c4c85-0fb9-42cf-a5c2-bd477e665405
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_headline_title
+field_name: field_headline_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_how_to_apply.yml
+++ b/config/field.storage.node.field_how_to_apply.yml
@@ -1,0 +1,19 @@
+uuid: 944fb3a6-18be-4a31-a276-d367d2b7673f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_how_to_apply
+field_name: field_how_to_apply
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_how_to_register.yml
+++ b/config/field.storage.node.field_how_to_register.yml
@@ -1,0 +1,19 @@
+uuid: 18826c6e-77c0-4a1e-8b99-d2013c7f7e80
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_how_to_register
+field_name: field_how_to_register
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_image.yml
+++ b/config/field.storage.node.field_image.yml
@@ -1,0 +1,20 @@
+uuid: abe8075e-b9e1-4ce7-9c7f-ae88b53f9152
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_image
+field_name: field_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_job_closing_date.yml
+++ b/config/field.storage.node.field_job_closing_date.yml
@@ -1,0 +1,20 @@
+uuid: 920b5c36-9b13-43fe-b26e-52df76907a3d
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_job_closing_date
+field_name: field_job_closing_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_job_experience.yml
+++ b/config/field.storage.node.field_job_experience.yml
@@ -1,0 +1,20 @@
+uuid: 117ff346-6a23-43e4-8237-29d317c45987
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_job_experience
+field_name: field_job_experience
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_job_type.yml
+++ b/config/field.storage.node.field_job_type.yml
@@ -1,0 +1,20 @@
+uuid: 7c252dbd-943e-460b-ab29-044c3fde1a9d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_job_type
+field_name: field_job_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_language.yml
+++ b/config/field.storage.node.field_language.yml
@@ -1,0 +1,20 @@
+uuid: 4e8128a6-7a2d-4c73-bd43-46e809d5dfd3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_language
+field_name: field_language
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_link.yml
+++ b/config/field.storage.node.field_link.yml
@@ -1,0 +1,19 @@
+uuid: 7966db9b-0d47-4946-be55-63c35240926f
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_link
+field_name: field_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_notify.yml
+++ b/config/field.storage.node.field_notify.yml
@@ -1,0 +1,19 @@
+uuid: bac227aa-3380-4a2d-97b5-e7d873b1c7b9
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_notify
+field_name: field_notify
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_ocha_product.yml
+++ b/config/field.storage.node.field_ocha_product.yml
@@ -1,0 +1,20 @@
+uuid: 38fd3006-a0ed-4031-8a18-e68b134ea8db
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_ocha_product
+field_name: field_ocha_product
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_origin.yml
+++ b/config/field.storage.node.field_origin.yml
@@ -1,0 +1,30 @@
+uuid: 689ecb45-ba0e-4c6d-b167-215de04dddec
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_origin
+field_name: field_origin
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '0'
+      label: URL
+    -
+      value: '1'
+      label: 'Submit mailbox'
+    -
+      value: '2'
+      label: 'Reliefweb product'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_origin_notes.yml
+++ b/config/field.storage.node.field_origin_notes.yml
@@ -1,0 +1,21 @@
+uuid: 8dd45619-ae07-4cf8-8505-5f8b0ef3170d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_origin_notes
+field_name: field_origin_notes
+entity_type: node
+type: string
+settings:
+  max_length: 1024
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_original_publication_date.yml
+++ b/config/field.storage.node.field_original_publication_date.yml
@@ -1,0 +1,20 @@
+uuid: eab4fe03-7fb2-48c2-9554-9d08739b356e
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_original_publication_date
+field_name: field_original_publication_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_primary_country.yml
+++ b/config/field.storage.node.field_primary_country.yml
@@ -1,0 +1,20 @@
+uuid: ec4191e4-9288-4f59-b1ec-6ab3957d7bfe
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_primary_country
+field_name: field_primary_country
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_publication_date.yml
+++ b/config/field.storage.node.field_publication_date.yml
@@ -1,0 +1,20 @@
+uuid: 8cd7bb70-d89c-49eb-afd9-7b8d858c741d
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_publication_date
+field_name: field_publication_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_registration_deadline.yml
+++ b/config/field.storage.node.field_registration_deadline.yml
@@ -1,0 +1,20 @@
+uuid: 7ba8f700-12f0-4d52-a43e-b4e6a7acf5ea
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_registration_deadline
+field_name: field_registration_deadline
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_source.yml
+++ b/config/field.storage.node.field_source.yml
@@ -1,0 +1,20 @@
+uuid: ac587b7a-ee09-42ba-9ad2-9469a0b6bef2
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_source
+field_name: field_source
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_tags.yml
+++ b/config/field.storage.node.field_tags.yml
@@ -1,0 +1,20 @@
+uuid: c4e2c43b-2ed3-4e8b-8adc-747bd63e266e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_tags
+field_name: field_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_theme.yml
+++ b/config/field.storage.node.field_theme.yml
@@ -1,0 +1,20 @@
+uuid: 26988156-3a77-4524-ac0a-7db63f08c463
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_theme
+field_name: field_theme
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_training_date.yml
+++ b/config/field.storage.node.field_training_date.yml
@@ -1,0 +1,20 @@
+uuid: 96a31221-1f67-42cb-887e-6add5ef014f4
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_training_date
+field_name: field_training_date
+entity_type: node
+type: daterange
+settings:
+  datetime_type: date
+module: datetime_range
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_training_format.yml
+++ b/config/field.storage.node.field_training_format.yml
@@ -1,0 +1,20 @@
+uuid: e0cfc8a9-ac60-4780-9086-5b2256b9222f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_training_format
+field_name: field_training_format
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 2
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_training_language.yml
+++ b/config/field.storage.node.field_training_language.yml
@@ -1,0 +1,20 @@
+uuid: 43ad778f-ec72-4639-bf89-8c2ab917d394
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_training_language
+field_name: field_training_language
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_training_type.yml
+++ b/config/field.storage.node.field_training_type.yml
@@ -1,0 +1,20 @@
+uuid: 20eca8c7-b8b4-461b-94cc-fb77e9534647
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_training_type
+field_name: field_training_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_vulnerable_groups.yml
+++ b/config/field.storage.node.field_vulnerable_groups.yml
@@ -1,0 +1,20 @@
+uuid: 3aa0ca60-9bbb-4632-bbaa-e1ff46ac39be
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_vulnerable_groups
+field_name: field_vulnerable_groups
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_aliases.yml
+++ b/config/field.storage.taxonomy_term.field_aliases.yml
@@ -1,0 +1,19 @@
+uuid: 7eb33f4c-5897-4871-93a7-4c073bd816c2
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_aliases
+field_name: field_aliases
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_allowed_content_types.yml
+++ b/config/field.storage.taxonomy_term.field_allowed_content_types.yml
@@ -1,0 +1,30 @@
+uuid: a2749e87-2ae4-40ba-b97e-4d2200d8271c
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - taxonomy
+id: taxonomy_term.field_allowed_content_types
+field_name: field_allowed_content_types
+entity_type: taxonomy_term
+type: list_integer
+settings:
+  allowed_values:
+    -
+      value: 0
+      label: Job
+    -
+      value: 1
+      label: Report
+    -
+      value: 2
+      label: Training
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_attention_job.yml
+++ b/config/field.storage.taxonomy_term.field_attention_job.yml
@@ -1,0 +1,19 @@
+uuid: cbe76f4c-37f1-42b5-b6e3-e519995a5cb5
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_attention_job
+field_name: field_attention_job
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_attention_report.yml
+++ b/config/field.storage.taxonomy_term.field_attention_report.yml
@@ -1,0 +1,19 @@
+uuid: 12b204ff-42f6-4ed6-931a-9238f188d0bd
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_attention_report
+field_name: field_attention_report
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_attention_training.yml
+++ b/config/field.storage.taxonomy_term.field_attention_training.yml
@@ -1,0 +1,19 @@
+uuid: d3cb4c59-b620-4ff5-8a8b-98e241b02a92
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_attention_training
+field_name: field_attention_training
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_country.yml
+++ b/config/field.storage.taxonomy_term.field_country.yml
@@ -1,0 +1,19 @@
+uuid: 1147c5f3-7a6e-4902-9008-c96be926dd99
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_country
+field_name: field_country
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_disaster_date.yml
+++ b/config/field.storage.taxonomy_term.field_disaster_date.yml
@@ -1,0 +1,20 @@
+uuid: 022e20a2-926d-4a6d-89ba-a742adeccb0f
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - taxonomy
+id: taxonomy_term.field_disaster_date
+field_name: field_disaster_date
+entity_type: taxonomy_term
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_disaster_type.yml
+++ b/config/field.storage.taxonomy_term.field_disaster_type.yml
@@ -1,0 +1,19 @@
+uuid: db26784d-8c86-4c69-ba1f-e8c0a33ffd73
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_disaster_type
+field_name: field_disaster_type
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_disaster_type_code.yml
+++ b/config/field.storage.taxonomy_term.field_disaster_type_code.yml
@@ -1,0 +1,21 @@
+uuid: 833862d8-9661-439a-a093-82bcf5c6e945
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_disaster_type_code
+field_name: field_disaster_type_code
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 2
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_disclaimer.yml
+++ b/config/field.storage.taxonomy_term.field_disclaimer.yml
@@ -1,0 +1,19 @@
+uuid: 21a0e97c-6b87-403f-a297-87a0ca1c14e1
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_disclaimer
+field_name: field_disclaimer
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_fts_id.yml
+++ b/config/field.storage.taxonomy_term.field_fts_id.yml
@@ -1,0 +1,21 @@
+uuid: b565c8a4-84a4-4309-914f-ead4a093cd93
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_fts_id
+field_name: field_fts_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_glide.yml
+++ b/config/field.storage.taxonomy_term.field_glide.yml
@@ -1,0 +1,21 @@
+uuid: a07f641c-c488-4345-b9e1-831813e9ea9a
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_glide
+field_name: field_glide
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 20
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_glide_related.yml
+++ b/config/field.storage.taxonomy_term.field_glide_related.yml
@@ -1,0 +1,19 @@
+uuid: fe603e23-966d-4c52-acad-0acf0f38ac9d
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_glide_related
+field_name: field_glide_related
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_homepage.yml
+++ b/config/field.storage.taxonomy_term.field_homepage.yml
@@ -1,0 +1,19 @@
+uuid: cf332262-cb00-4172-a0bd-4de2f5374540
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - taxonomy
+id: taxonomy_term.field_homepage
+field_name: field_homepage
+entity_type: taxonomy_term
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_iso3.yml
+++ b/config/field.storage.taxonomy_term.field_iso3.yml
@@ -1,0 +1,21 @@
+uuid: 236be4e3-7cb1-4c6d-8dc4-ab6f849a6533
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_iso3
+field_name: field_iso3
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 3
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_job_import_feed_url.yml
+++ b/config/field.storage.taxonomy_term.field_job_import_feed_url.yml
@@ -1,0 +1,19 @@
+uuid: 18cd59c6-9f83-427a-8a77-b779c33a75b6
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - taxonomy
+id: taxonomy_term.field_job_import_feed_url
+field_name: field_job_import_feed_url
+entity_type: taxonomy_term
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_language_code.yml
+++ b/config/field.storage.taxonomy_term.field_language_code.yml
@@ -1,0 +1,21 @@
+uuid: 6724006a-2512-4564-8e3c-597fa20d8d34
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_language_code
+field_name: field_language_code
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 2
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_links.yml
+++ b/config/field.storage.taxonomy_term.field_links.yml
@@ -1,0 +1,19 @@
+uuid: efe5ccfb-0c42-4bb9-824f-374f3abf0798
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - taxonomy
+id: taxonomy_term.field_links
+field_name: field_links
+entity_type: taxonomy_term
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_location.yml
+++ b/config/field.storage.taxonomy_term.field_location.yml
@@ -1,0 +1,20 @@
+uuid: 81ffe249-b84d-450f-a7a2-2389a10cf39c
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - taxonomy
+id: taxonomy_term.field_location
+field_name: field_location
+entity_type: taxonomy_term
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_logo.yml
+++ b/config/field.storage.taxonomy_term.field_logo.yml
@@ -1,0 +1,30 @@
+uuid: fc5ba416-3d06-46a4-8d64-fedeb600bb42
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - taxonomy
+id: taxonomy_term.field_logo
+field_name: field_logo
+entity_type: taxonomy_term
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_longname.yml
+++ b/config/field.storage.taxonomy_term.field_longname.yml
@@ -1,0 +1,21 @@
+uuid: 91e2dd15-6346-40ec-a4b3-b3b487e8af93
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_longname
+field_name: field_longname
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_organization_type.yml
+++ b/config/field.storage.taxonomy_term.field_organization_type.yml
@@ -1,0 +1,19 @@
+uuid: a74943cd-5258-4399-a7cb-3f2088ed61d6
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_organization_type
+field_name: field_organization_type
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_primary_country.yml
+++ b/config/field.storage.taxonomy_term.field_primary_country.yml
@@ -1,0 +1,19 @@
+uuid: ede941fe-d650-44c8-bb19-94368f40a866
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_primary_country
+field_name: field_primary_country
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_primary_disaster_type.yml
+++ b/config/field.storage.taxonomy_term.field_primary_disaster_type.yml
@@ -1,0 +1,19 @@
+uuid: fd64ea4d-2f27-479a-833d-91b791d50ce6
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_primary_disaster_type
+field_name: field_primary_disaster_type
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_profile.yml
+++ b/config/field.storage.taxonomy_term.field_profile.yml
@@ -1,0 +1,18 @@
+uuid: 0aad3638-ffcd-40d8-86ab-92aeb4844e5e
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_profile
+field_name: field_profile
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_shortname.yml
+++ b/config/field.storage.taxonomy_term.field_shortname.yml
@@ -1,0 +1,21 @@
+uuid: e38fbbea-a864-4dac-b6ad-efbc69d7112e
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_shortname
+field_name: field_shortname
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_spanish_name.yml
+++ b/config/field.storage.taxonomy_term.field_spanish_name.yml
@@ -1,0 +1,21 @@
+uuid: 319b6d70-7d13-4492-a915-50a479516a7a
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_spanish_name
+field_name: field_spanish_name
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_timezone.yml
+++ b/config/field.storage.taxonomy_term.field_timezone.yml
@@ -1,0 +1,93 @@
+uuid: 030c9d0c-bcd9-4462-93c3-649d0f8d194d
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - taxonomy
+id: taxonomy_term.field_timezone
+field_name: field_timezone
+entity_type: taxonomy_term
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '-11'
+      label: '-1100'
+    -
+      value: '-10'
+      label: '-1000'
+    -
+      value: '-9'
+      label: '-0900'
+    -
+      value: '-8'
+      label: '-0800'
+    -
+      value: '-7'
+      label: '-0700'
+    -
+      value: '-6'
+      label: '-0600'
+    -
+      value: '-5'
+      label: '-0500'
+    -
+      value: '-4'
+      label: '-0400'
+    -
+      value: '-3'
+      label: '-0300'
+    -
+      value: '-2'
+      label: '-0200'
+    -
+      value: '-1'
+      label: '-0100'
+    -
+      value: '0'
+      label: '0000'
+    -
+      value: '1'
+      label: '0100'
+    -
+      value: '2'
+      label: '0200'
+    -
+      value: '3'
+      label: '0300'
+    -
+      value: '4'
+      label: '0400'
+    -
+      value: '5'
+      label: '0500'
+    -
+      value: '6'
+      label: '0600'
+    -
+      value: '7'
+      label: '0700'
+    -
+      value: '8'
+      label: '0800'
+    -
+      value: '9'
+      label: '0900'
+    -
+      value: '10'
+      label: '1000'
+    -
+      value: '11'
+      label: '1100'
+    -
+      value: '12'
+      label: '1200'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/filter.format.html.yml
+++ b/config/filter.format.html.yml
@@ -1,0 +1,34 @@
+uuid: 50fcce6b-6bbe-4a8e-85c9-dce9317d4efd
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+name: HTML
+format: html
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <th> <td> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
+      filter_html_help: false
+      filter_html_nofollow: false
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
+  media_embed:
+    id: media_embed
+    provider: media
+    status: false
+    weight: 100
+    settings:
+      default_view_mode: default
+      allowed_media_types: {  }
+      allowed_view_modes: {  }

--- a/config/filter.format.markdown.yml
+++ b/config/filter.format.markdown.yml
@@ -1,0 +1,34 @@
+uuid: f5a49762-f4b8-49a8-a29c-194878aafc84
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+name: Markdown
+format: markdown
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <th> <td> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
+      filter_html_help: false
+      filter_html_nofollow: false
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
+  media_embed:
+    id: media_embed
+    provider: media
+    status: false
+    weight: 100
+    settings:
+      default_view_mode: default
+      allowed_media_types: {  }
+      allowed_view_modes: {  }

--- a/config/image.style.media_library.yml
+++ b/config/image.style.media_library.yml
@@ -1,0 +1,21 @@
+uuid: bb70fc64-1120-4008-bbb4-461cb49ecbbb
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - media_library
+_core:
+  default_config_hash: 7qJqToD1OQLAyeswpmg7M0LRxQlw1URQkJDWUJCnmR8
+name: media_library
+label: 'Media Library thumbnail (220×220)'
+effects:
+  75b076a8-1234-4b42-85db-bf377c4d8d5f:
+    uuid: 75b076a8-1234-4b42-85db-bf377c4d8d5f
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false
+pipeline: __default__

--- a/config/imageapi_optimize.pipeline.local_binaries.yml
+++ b/config/imageapi_optimize.pipeline.local_binaries.yml
@@ -46,7 +46,7 @@ processors:
     weight: 5
     data:
       manual_executable_path: ''
-      progressive: 0
+      progressive: false
   fb380dd6-14f0-4b5f-8615-1ed40147ae17:
     uuid: fb380dd6-14f0-4b5f-8615-1ed40147ae17
     id: optipng

--- a/config/imageapi_optimize.settings.yml
+++ b/config/imageapi_optimize.settings.yml
@@ -1,3 +1,3 @@
-default_pipeline: null
+default_pipeline: local_binaries
 _core:
   default_config_hash: MTm0uqe2B71zGYpOt10vRcS7pf9m92Yy2P4cnTXbSR0

--- a/config/language.content_settings.media.file_report.yml
+++ b/config/language.content_settings.media.file_report.yml
@@ -1,0 +1,11 @@
+uuid: ba3318f0-9193-489d-a52c-ef0a1fb0016f
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file_report
+id: media.file_report
+target_entity_type_id: media
+target_bundle: file_report
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.media.image_announcement.yml
+++ b/config/language.content_settings.media.image_announcement.yml
@@ -1,0 +1,11 @@
+uuid: 6b8c876a-601e-475c-8efe-ed67c0bb592c
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image_announcement
+id: media.image_announcement
+target_entity_type_id: media
+target_bundle: image_announcement
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.media.image_blog_post.yml
+++ b/config/language.content_settings.media.image_blog_post.yml
@@ -1,0 +1,11 @@
+uuid: bb441489-f7a9-4fe7-a123-cb2cb099968f
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image_blog_post
+id: media.image_blog_post
+target_entity_type_id: media
+target_bundle: image_blog_post
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.media.image_headline.yml
+++ b/config/language.content_settings.media.image_headline.yml
@@ -1,0 +1,11 @@
+uuid: 7d14e3e6-5216-4074-b4d4-764cc3062604
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image_headline
+id: media.image_headline
+target_entity_type_id: media
+target_bundle: image_headline
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.media.image_report.yml
+++ b/config/language.content_settings.media.image_report.yml
@@ -1,0 +1,11 @@
+uuid: 14c94746-3b7f-4406-ab8d-3c7a5eb9b151
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image_report
+id: media.image_report
+target_entity_type_id: media
+target_bundle: image_report
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.node.announcement.yml
+++ b/config/language.content_settings.node.announcement.yml
@@ -1,0 +1,11 @@
+uuid: b1ae3ed8-60eb-4d50-93d9-9aa672bca000
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+id: node.announcement
+target_entity_type_id: node
+target_bundle: announcement
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.node.blog_post.yml
+++ b/config/language.content_settings.node.blog_post.yml
@@ -1,0 +1,11 @@
+uuid: f7650400-a7c2-4416-91a0-3edd8bf14ce6
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog_post
+id: node.blog_post
+target_entity_type_id: node
+target_bundle: blog_post
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.node.book.yml
+++ b/config/language.content_settings.node.book.yml
@@ -1,0 +1,11 @@
+uuid: ab338a89-0fb2-4304-bf0b-360b59009f48
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.book
+id: node.book
+target_entity_type_id: node
+target_bundle: book
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.node.job.yml
+++ b/config/language.content_settings.node.job.yml
@@ -1,0 +1,11 @@
+uuid: fc3f202b-1a10-4bf0-b6b2-d1dd70b7ca87
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.job
+id: node.job
+target_entity_type_id: node
+target_bundle: job
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.node.report.yml
+++ b/config/language.content_settings.node.report.yml
@@ -1,0 +1,11 @@
+uuid: b1c60b35-8bee-4876-aa94-c66d7bcd2639
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.report
+id: node.report
+target_entity_type_id: node
+target_bundle: report
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.node.topic.yml
+++ b/config/language.content_settings.node.topic.yml
@@ -1,0 +1,11 @@
+uuid: 48ee6dce-872b-4fc3-b29a-dcb636613185
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.topic
+id: node.topic
+target_entity_type_id: node
+target_bundle: topic
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.node.training.yml
+++ b/config/language.content_settings.node.training.yml
@@ -1,0 +1,11 @@
+uuid: 114fcb4d-c1b7-44b2-85a2-b3687ba065e8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.training
+id: node.training
+target_entity_type_id: node
+target_bundle: training
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.career_category.yml
+++ b/config/language.content_settings.taxonomy_term.career_category.yml
@@ -1,0 +1,11 @@
+uuid: c07f2417-54f7-4a2d-ba94-417a40c71e82
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.career_category
+id: taxonomy_term.career_category
+target_entity_type_id: taxonomy_term
+target_bundle: career_category
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.content_format.yml
+++ b/config/language.content_settings.taxonomy_term.content_format.yml
@@ -1,0 +1,11 @@
+uuid: 5e1c00b4-a8d8-4d16-8e4a-8077a7bd73f0
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.content_format
+id: taxonomy_term.content_format
+target_entity_type_id: taxonomy_term
+target_bundle: content_format
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.country.yml
+++ b/config/language.content_settings.taxonomy_term.country.yml
@@ -1,0 +1,11 @@
+uuid: a9fd745f-af9c-4f59-9ad3-41cc7d069c48
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.country
+id: taxonomy_term.country
+target_entity_type_id: taxonomy_term
+target_bundle: country
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.disaster.yml
+++ b/config/language.content_settings.taxonomy_term.disaster.yml
@@ -1,0 +1,11 @@
+uuid: 60d21872-7883-4e9e-9816-7f35a153e039
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.disaster
+id: taxonomy_term.disaster
+target_entity_type_id: taxonomy_term
+target_bundle: disaster
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.disaster_type.yml
+++ b/config/language.content_settings.taxonomy_term.disaster_type.yml
@@ -1,0 +1,11 @@
+uuid: 67cd782f-eeb5-41f0-a4f7-1b1324ef2409
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.disaster_type
+id: taxonomy_term.disaster_type
+target_entity_type_id: taxonomy_term
+target_bundle: disaster_type
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.feature.yml
+++ b/config/language.content_settings.taxonomy_term.feature.yml
@@ -1,0 +1,11 @@
+uuid: d38b6803-c974-4a9c-8fb8-b8c2ec8adb8a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.feature
+id: taxonomy_term.feature
+target_entity_type_id: taxonomy_term
+target_bundle: feature
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.job_experience.yml
+++ b/config/language.content_settings.taxonomy_term.job_experience.yml
@@ -1,0 +1,11 @@
+uuid: 3863848a-61f2-4243-9363-6438a15447d6
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.job_experience
+id: taxonomy_term.job_experience
+target_entity_type_id: taxonomy_term
+target_bundle: job_experience
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.job_type.yml
+++ b/config/language.content_settings.taxonomy_term.job_type.yml
@@ -1,0 +1,11 @@
+uuid: 827d5482-7910-4ee7-a048-681066ebf998
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.job_type
+id: taxonomy_term.job_type
+target_entity_type_id: taxonomy_term
+target_bundle: job_type
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.language.yml
+++ b/config/language.content_settings.taxonomy_term.language.yml
@@ -1,0 +1,11 @@
+uuid: 6387021e-8af0-43ea-9d21-892b976e6ccb
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.language
+id: taxonomy_term.language
+target_entity_type_id: taxonomy_term
+target_bundle: language
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.ocha_product.yml
+++ b/config/language.content_settings.taxonomy_term.ocha_product.yml
@@ -1,0 +1,11 @@
+uuid: cae1051f-09ef-4b3c-b76a-0bbf6ddb7794
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.ocha_product
+id: taxonomy_term.ocha_product
+target_entity_type_id: taxonomy_term
+target_bundle: ocha_product
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.organization_type.yml
+++ b/config/language.content_settings.taxonomy_term.organization_type.yml
@@ -1,0 +1,11 @@
+uuid: 7dc1f0eb-0b27-48c2-bb9d-4b7bf773e757
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organization_type
+id: taxonomy_term.organization_type
+target_entity_type_id: taxonomy_term
+target_bundle: organization_type
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.source.yml
+++ b/config/language.content_settings.taxonomy_term.source.yml
@@ -1,0 +1,11 @@
+uuid: fcc9a88a-81f3-4c42-af42-6658989ff9a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.source
+id: taxonomy_term.source
+target_entity_type_id: taxonomy_term
+target_bundle: source
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.tag.yml
+++ b/config/language.content_settings.taxonomy_term.tag.yml
@@ -1,0 +1,11 @@
+uuid: 02150b3a-444f-420c-b323-efe174d6e2e5
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tag
+id: taxonomy_term.tag
+target_entity_type_id: taxonomy_term
+target_bundle: tag
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.theme.yml
+++ b/config/language.content_settings.taxonomy_term.theme.yml
@@ -1,0 +1,11 @@
+uuid: df14a3fe-09e4-46ba-99bb-6f2342ccb1b4
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.theme
+id: taxonomy_term.theme
+target_entity_type_id: taxonomy_term
+target_bundle: theme
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.training_format.yml
+++ b/config/language.content_settings.taxonomy_term.training_format.yml
@@ -1,0 +1,11 @@
+uuid: 56ef803a-e4af-47b5-95f3-4f4cee637bef
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.training_format
+id: taxonomy_term.training_format
+target_entity_type_id: taxonomy_term
+target_bundle: training_format
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.training_type.yml
+++ b/config/language.content_settings.taxonomy_term.training_type.yml
@@ -1,0 +1,11 @@
+uuid: 4dfe6ac3-80a3-4a04-b432-d0a2e0d60578
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.training_type
+id: taxonomy_term.training_type
+target_entity_type_id: taxonomy_term
+target_bundle: training_type
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.vulnerable_group.yml
+++ b/config/language.content_settings.taxonomy_term.vulnerable_group.yml
@@ -1,0 +1,11 @@
+uuid: 57da1060-ff7c-4ab7-ae59-8cbf68794685
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.vulnerable_group
+id: taxonomy_term.vulnerable_group
+target_entity_type_id: taxonomy_term
+target_bundle: vulnerable_group
+default_langcode: site_default
+language_alterable: false

--- a/config/locale.settings.yml
+++ b/config/locale.settings.yml
@@ -1,0 +1,15 @@
+cache_strings: true
+translate_english: false
+javascript:
+  directory: languages
+translation:
+  use_source: remote_and_local
+  default_filename: '%project-%version.%language.po'
+  default_server_pattern: 'https://ftp.drupal.org/files/translations/%core/%project/%project-%version.%language.po'
+  overwrite_customized: false
+  overwrite_not_customized: true
+  update_interval_days: 0
+  path: sites/default/files/translations
+  import_enabled: true
+_core:
+  default_config_hash: cSdYeE-_AQETCNZnl8BMFS9-sVn5--VzAYILkpPBUbM

--- a/config/media.type.file_report.yml
+++ b/config/media.type.file_report.yml
@@ -1,0 +1,13 @@
+uuid: 2bd44cd5-9a62-4d4a-aac8-f621d86cb79a
+langcode: en
+status: true
+dependencies: {  }
+id: file_report
+label: 'File - Report'
+description: 'Files attached to reports.'
+source: file
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_file
+field_map: {  }

--- a/config/media.type.image_announcement.yml
+++ b/config/media.type.image_announcement.yml
@@ -1,0 +1,13 @@
+uuid: 3c0018ec-48bc-489a-b497-94f8ca04891c
+langcode: en
+status: true
+dependencies: {  }
+id: image_announcement
+label: 'Image - Announcement'
+description: 'Images for the announcement banners on the homepage.'
+source: image
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_image
+field_map: {  }

--- a/config/media.type.image_blog_post.yml
+++ b/config/media.type.image_blog_post.yml
@@ -1,0 +1,13 @@
+uuid: e13728a4-310a-49ff-b49f-079042403926
+langcode: en
+status: true
+dependencies: {  }
+id: image_blog_post
+label: 'Image - Blog post'
+description: 'Images for the blog posts.'
+source: image
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_image
+field_map: {  }

--- a/config/media.type.image_headline.yml
+++ b/config/media.type.image_headline.yml
@@ -1,0 +1,13 @@
+uuid: 52b56f89-651a-4975-abd0-9ca1313fbe82
+langcode: en
+status: true
+dependencies: {  }
+id: image_headline
+label: 'Image - Headline'
+description: 'Images for the headlines.'
+source: image
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_image
+field_map: {  }

--- a/config/media.type.image_report.yml
+++ b/config/media.type.image_report.yml
@@ -1,0 +1,13 @@
+uuid: e1383454-0781-4e6b-9b7b-129c4125b332
+langcode: en
+status: true
+dependencies: {  }
+id: image_report
+label: 'Image - Report'
+description: 'Images for the report articles.'
+source: image
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_image
+field_map: {  }

--- a/config/media_library.settings.yml
+++ b/config/media_library.settings.yml
@@ -1,0 +1,3 @@
+advanced_ui: false
+_core:
+  default_config_hash: _3gQsCnZELUjUUqHk8SSh8bXnx7TZwN95vctAeVJG60

--- a/config/migrate_plus.migration.rw_menu_link__footer.yml
+++ b/config/migrate_plus.migration.rw_menu_link__footer.yml
@@ -1,0 +1,83 @@
+uuid: 877e62e9-a17d-4454-8c6f-99cce3f9a29e
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - reliefweb_migrate
+_core:
+  default_config_hash: iw-rEb_NDT8suqncAnLJP5vMRvNxLPHsEMKbYuEC09w
+id: rw_menu_link__footer
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: reliefweb
+label: 'Migrate ReliefWeb footer menu links.'
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      id: 8
+      title: Blog
+      description: Blog
+      link_uri: 'internal:/blog'
+      external: 0
+      weight: 0
+    -
+      id: 9
+      title: Labs
+      description: Labs
+      link_uri: 'https://labs.reliefweb.int/'
+      external: 1
+      weight: 1
+    -
+      id: 10
+      title: About
+      description: About
+      link_uri: 'internal:/about'
+      external: 0
+      weight: 2
+    -
+      id: 11
+      title: Terms
+      description: Terms
+      link_uri: 'internal:/terms-conditions'
+      external: 0
+      weight: 3
+    -
+      id: 12
+      title: Contact
+      description: Contact
+      link_uri: 'internal:/contact'
+      external: 0
+      weight: 4
+  ids:
+    id:
+      type: integer
+  constants:
+    bundle: menu_link_content
+    menu_name: footer
+    enabled: 1
+    expanded: 0
+    parent: null
+process:
+  id: id
+  bundle: constants/bundle
+  title: title
+  description: description
+  menu_name: constants/menu_name
+  link/uri: link_uri
+  external: external
+  weight: weight
+  expanded: constants/expanded
+  enabled: constants/enabled
+  parent: constants/parent
+destination:
+  plugin: 'entity:menu_link_content'
+  no_stub: true
+migration_dependencies:
+  required:
+    - rw_menu_link__main

--- a/config/migrate_plus.migration.rw_menu_link__main.yml
+++ b/config/migrate_plus.migration.rw_menu_link__main.yml
@@ -1,0 +1,97 @@
+uuid: 72e0dd61-4cfb-4384-bfe5-330640d946fa
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - reliefweb_migrate
+_core:
+  default_config_hash: RH9Q9AbYNAVmOjwDSK0HzPrXsVNyKxiOmDh3nCMewTw
+id: rw_menu_link__main
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7'
+  - Content
+migration_group: reliefweb
+label: 'Migrate ReliefWeb main menu links.'
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      id: 1
+      title: Updates
+      description: Updates
+      link_uri: 'internal:/updates'
+      external: 0
+      weight: 0
+    -
+      id: 2
+      title: Countries
+      description: Countries
+      link_uri: 'internal:/countries'
+      external: 0
+      weight: 1
+    -
+      id: 3
+      title: Disasters
+      description: Disasters
+      link_uri: 'internal:/disasters'
+      external: 0
+      weight: 2
+    -
+      id: 4
+      title: Organizations
+      description: Organizations
+      link_uri: 'internal:/organizations'
+      external: 0
+      weight: 3
+    -
+      id: 5
+      title: Topics
+      description: Topics
+      link_uri: 'internal:/topics'
+      external: 0
+      weight: 4
+    -
+      id: 6
+      title: Jobs
+      description: Jobs
+      link_uri: 'internal:/jobs'
+      external: 0
+      weight: 5
+    -
+      id: 7
+      title: Training
+      description: Training
+      link_uri: 'internal:/training'
+      external: 0
+      weight: 6
+  ids:
+    id:
+      type: integer
+  constants:
+    bundle: menu_link_content
+    menu_name: main
+    enabled: 1
+    expanded: 0
+    parent: null
+process:
+  id: id
+  bundle: constants/bundle
+  title: title
+  description: description
+  menu_name: constants/menu_name
+  link/uri: link_uri
+  external: external
+  weight: weight
+  expanded: constants/expanded
+  enabled: constants/enabled
+  parent: constants/parent
+destination:
+  plugin: 'entity:menu_link_content'
+  no_stub: true
+migration_dependencies:
+  required:
+    - null

--- a/config/migrate_plus.migration_group.default.yml
+++ b/config/migrate_plus.migration_group.default.yml
@@ -1,0 +1,10 @@
+uuid: 8c00356f-30c9-4c75-80bf-6a396a5080ab
+langcode: en
+status: true
+dependencies: {  }
+id: default
+label: Default
+description: 'A container for any migrations not explicitly assigned to a group.'
+source_type: null
+module: null
+shared_configuration: null

--- a/config/migrate_plus.migration_group.reliefweb.yml
+++ b/config/migrate_plus.migration_group.reliefweb.yml
@@ -1,0 +1,10 @@
+uuid: f85bf0c7-02ab-49ce-b489-fd6538700f4e
+langcode: en
+status: true
+dependencies: {  }
+id: reliefweb
+label: reliefweb
+description: ''
+source_type: null
+module: null
+shared_configuration: null

--- a/config/node.type.announcement.yml
+++ b/config/node.type.announcement.yml
@@ -1,0 +1,17 @@
+uuid: 25180469-ab00-4123-bdf0-faf3870db35b
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Announcement
+type: announcement
+description: 'Announcement from partners etc.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/node.type.blog_post.yml
+++ b/config/node.type.blog_post.yml
@@ -1,0 +1,17 @@
+uuid: 29a0eb05-c48d-4a25-b0d5-c8e4d8be768c
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: 'Blog post'
+type: blog_post
+description: 'Blog entry'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/node.type.book.yml
+++ b/config/node.type.book.yml
@@ -1,0 +1,22 @@
+uuid: c0b66caf-3c4f-4490-8232-f232debe314a
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - book
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+_core:
+  default_config_hash: 2gWGA-X4ERc4McStS7cMEG3ZBpDEqfNRDPTjB1v674Y
+name: 'Book page'
+type: book
+description: '<em>Books</em> have a built-in hierarchical navigation. Use for handbooks or tutorials.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/node.type.job.yml
+++ b/config/node.type.job.yml
@@ -1,0 +1,17 @@
+uuid: c75023ab-0dfb-422f-9de3-e7cbb89327aa
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Job
+type: job
+description: 'Open job opportunities in the humanitarian field.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/node.type.report.yml
+++ b/config/node.type.report.yml
@@ -1,0 +1,17 @@
+uuid: 898f96c0-ffcc-4233-85fc-980587f908d6
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Report
+type: report
+description: 'Latest humanitarian reports, maps and infographics and full document archive.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/node.type.topic.yml
+++ b/config/node.type.topic.yml
@@ -1,0 +1,17 @@
+uuid: ea63ca1b-0f54-4824-a4ae-7c802cfa6638
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Topic
+type: topic
+description: 'Curated pages dedicated to humanitarian themes and specific humanitarian crises.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/node.type.training.yml
+++ b/config/node.type.training.yml
@@ -1,0 +1,17 @@
+uuid: 2d63a63d-4578-4459-a25c-69666bd32fe0
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Training
+type: training
+description: 'Open training opportunities in the humanitarian field.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/taxonomy.vocabulary.career_category.yml
+++ b/config/taxonomy.vocabulary.career_category.yml
@@ -1,0 +1,8 @@
+uuid: 2aff787d-45e0-4b8b-9310-3cfe506c7e7d
+langcode: en
+status: true
+dependencies: {  }
+name: 'Career category'
+vid: career_category
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.content_format.yml
+++ b/config/taxonomy.vocabulary.content_format.yml
@@ -1,0 +1,8 @@
+uuid: 8379c8d6-e3d8-48ae-a411-660950e95707
+langcode: en
+status: true
+dependencies: {  }
+name: 'Content format'
+vid: content_format
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.country.yml
+++ b/config/taxonomy.vocabulary.country.yml
@@ -1,0 +1,8 @@
+uuid: 29d1ac0b-dc4e-4f09-8c02-a66522bc1151
+langcode: en
+status: true
+dependencies: {  }
+name: Country
+vid: country
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.disaster.yml
+++ b/config/taxonomy.vocabulary.disaster.yml
@@ -1,0 +1,8 @@
+uuid: 8754b6a9-5769-4123-b4f3-c58efa14b419
+langcode: en
+status: true
+dependencies: {  }
+name: Disaster
+vid: disaster
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.disaster_type.yml
+++ b/config/taxonomy.vocabulary.disaster_type.yml
@@ -1,0 +1,8 @@
+uuid: 38705e0e-6fde-4c93-870d-4f6327f2f27f
+langcode: en
+status: true
+dependencies: {  }
+name: 'Disaster type'
+vid: disaster_type
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.feature.yml
+++ b/config/taxonomy.vocabulary.feature.yml
@@ -1,0 +1,8 @@
+uuid: 26b6a49c-72f1-4a1f-830b-570d64666552
+langcode: en
+status: true
+dependencies: {  }
+name: Feature
+vid: feature
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.job_experience.yml
+++ b/config/taxonomy.vocabulary.job_experience.yml
@@ -1,0 +1,8 @@
+uuid: 89420aca-6f59-453e-89a9-81366eed33d7
+langcode: en
+status: true
+dependencies: {  }
+name: 'Years of experience'
+vid: job_experience
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.job_type.yml
+++ b/config/taxonomy.vocabulary.job_type.yml
@@ -1,0 +1,8 @@
+uuid: f21e2362-44b2-412c-8d24-752c963049e4
+langcode: en
+status: true
+dependencies: {  }
+name: 'Job type'
+vid: job_type
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.language.yml
+++ b/config/taxonomy.vocabulary.language.yml
@@ -1,0 +1,8 @@
+uuid: f1df90a0-2446-4cc8-8743-f6c4198ae94f
+langcode: en
+status: true
+dependencies: {  }
+name: Language
+vid: language
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.ocha_product.yml
+++ b/config/taxonomy.vocabulary.ocha_product.yml
@@ -1,0 +1,8 @@
+uuid: 26a76463-6251-41ec-b133-4843afa6ec3d
+langcode: en
+status: true
+dependencies: {  }
+name: 'OCHA product'
+vid: ocha_product
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.organization_type.yml
+++ b/config/taxonomy.vocabulary.organization_type.yml
@@ -1,0 +1,8 @@
+uuid: de368695-46ac-47c1-a32d-d32080e3ea4a
+langcode: en
+status: true
+dependencies: {  }
+name: 'Organization type'
+vid: organization_type
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.source.yml
+++ b/config/taxonomy.vocabulary.source.yml
@@ -1,0 +1,8 @@
+uuid: c0c7ae86-2334-49d0-a783-38aaf7c18a64
+langcode: en
+status: true
+dependencies: {  }
+name: Source
+vid: source
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.tag.yml
+++ b/config/taxonomy.vocabulary.tag.yml
@@ -1,0 +1,8 @@
+uuid: 82b3a271-a8bb-4762-b56f-d89f4c8ac73e
+langcode: en
+status: true
+dependencies: {  }
+name: Tag
+vid: tag
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.theme.yml
+++ b/config/taxonomy.vocabulary.theme.yml
@@ -1,0 +1,8 @@
+uuid: 1756e2af-e6e1-4032-b043-808b1c94b1af
+langcode: en
+status: true
+dependencies: {  }
+name: Theme
+vid: theme
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.training_format.yml
+++ b/config/taxonomy.vocabulary.training_format.yml
@@ -1,0 +1,8 @@
+uuid: c5389dd8-49ea-44d5-a375-733a7621703a
+langcode: en
+status: true
+dependencies: {  }
+name: 'Training format'
+vid: training_format
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.training_type.yml
+++ b/config/taxonomy.vocabulary.training_type.yml
@@ -1,0 +1,8 @@
+uuid: ccec743d-d377-45c7-9fdd-fc8a47d0a288
+langcode: en
+status: true
+dependencies: {  }
+name: 'Training type'
+vid: training_type
+description: ''
+weight: 0

--- a/config/taxonomy.vocabulary.vulnerable_group.yml
+++ b/config/taxonomy.vocabulary.vulnerable_group.yml
@@ -1,0 +1,8 @@
+uuid: 65a96b4d-ecc4-45e5-9539-f0e9077ff9d3
+langcode: en
+status: true
+dependencies: {  }
+name: 'Vulnerable group'
+vid: vulnerable_group
+description: ''
+weight: 0

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -10,4 +10,5 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
+  - 'use text format markdown'
   - 'view media'

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -6,4 +6,5 @@ id: editor
 label: Editor
 weight: 2
 is_admin: null
-permissions: {  }
+permissions:
+  - 'use text format markdown'

--- a/config/views.view.media_library.yml
+++ b/config/views.view.media_library.yml
@@ -1,0 +1,1389 @@
+uuid: d63c9123-8676-467d-b124-6197e326565a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - image.style.media_library
+  enforced:
+    module:
+      - media_library
+  module:
+    - image
+    - media
+    - media_library
+    - user
+_core:
+  default_config_hash: dHOSWSHbMJNke0ZBGh1O5KrnwynSOCOpQycITW-pwfs
+id: media_library
+label: 'Media library'
+module: views
+description: 'Find and manage media.'
+tag: ''
+base_table: media_field_data
+base_field: mid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access media overview'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: 'Apply filters'
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: false
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 24
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '6, 12, 24, 48'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        media_bulk_form:
+          id: media_bulk_form
+          table: media
+          field: media_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: media
+          plugin_id: bulk_form
+        rendered_entity:
+          id: rendered_entity
+          table: media
+          field: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: media_library
+          entity_type: media
+          plugin_id: rendered_entity
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Publishing status'
+            description: null
+            use_operator: false
+            operator: status_op
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: true
+          group_info:
+            label: Published
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
+          plugin_id: boolean
+          entity_type: media
+          entity_field: status
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: bundle_op
+            label: 'Media type'
+            description: ''
+            use_operator: false
+            operator: bundle_op
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: 'Media type'
+            description: null
+            identifier: bundle
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
+        status_extra:
+          id: status_extra
+          table: media_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          plugin_id: media_status
+        langcode:
+          id: langcode
+          table: media_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: langcode
+          plugin_id: language
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: true
+          expose:
+            label: 'Newest first'
+          granularity: second
+          entity_type: media
+          entity_field: created
+          plugin_id: date
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: true
+          expose:
+            label: 'Name (A-Z)'
+          entity_type: media
+          entity_field: name
+          plugin_id: standard
+        name_1:
+          id: name_1
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: true
+          expose:
+            label: 'Name (Z-A)'
+          entity_type: media
+          entity_field: name
+          plugin_id: standard
+      title: Media
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No media available.'
+          plugin_id: text_custom
+      relationships: {  }
+      display_extenders: {  }
+      use_ajax: true
+      css_class: ''
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - user
+        - user.permissions
+      tags: {  }
+  page:
+    display_plugin: page
+    id: page
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media-grid
+      fields:
+        media_bulk_form:
+          id: media_bulk_form
+          table: media
+          field: media_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: media
+          plugin_id: bulk_form
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: name
+          plugin_id: field
+        edit_media:
+          id: edit_media
+          table: media
+          field: edit_media
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'Edit {{ name }}'
+            make_link: true
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: 'Edit {{ name }}'
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: Edit
+          output_url_as_text: false
+          absolute: false
+          entity_type: media
+          plugin_id: entity_link_edit
+        delete_media:
+          id: delete_media
+          table: media
+          field: delete_media
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'Delete {{ name }}'
+            make_link: true
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: 'Delete {{ name }}'
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: Delete
+          output_url_as_text: false
+          absolute: false
+          entity_type: media
+          plugin_id: entity_link_delete
+        rendered_entity:
+          id: rendered_entity
+          table: media
+          field: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: media_library
+          entity_type: media
+          plugin_id: rendered_entity
+      defaults:
+        fields: false
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - user
+        - user.permissions
+      tags: {  }
+  widget:
+    display_plugin: page
+    id: widget
+    display_title: Widget
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media-widget
+      fields:
+        media_library_select_form:
+          id: media_library_select_form
+          table: media
+          field: media_library_select_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: media
+          plugin_id: media_library_select_form
+        rendered_entity:
+          id: rendered_entity
+          table: media
+          field: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: media_library
+          entity_type: media
+          plugin_id: rendered_entity
+      defaults:
+        fields: false
+        access: false
+        filters: false
+        filter_groups: false
+        arguments: false
+        header: false
+        css_class: false
+      display_description: ''
+      access:
+        type: perm
+        options:
+          perm: 'view media'
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+        default_langcode:
+          id: default_langcode
+          table: media_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: default_langcode
+          plugin_id: boolean
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 24
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
+      header:
+        display_link_grid:
+          id: display_link_grid
+          table: views
+          field: display_link
+          display_id: widget
+          label: Grid
+          plugin_id: display_link
+          empty: true
+        display_link_table:
+          id: display_link_table
+          table: views
+          field: display_link
+          display_id: widget_table
+          label: Table
+          plugin_id: display_link
+          empty: true
+      css_class: ''
+      rendering_language: '***LANGUAGE_language_interface***'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - user.permissions
+      tags: {  }
+  widget_table:
+    display_plugin: page
+    id: widget_table
+    display_title: 'Widget (table)'
+    position: 3
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media-widget-table
+      style:
+        type: table
+        options:
+          row_class: 'media-library-item media-library-item--table js-media-library-item js-click-to-select'
+          default_row_class: true
+      defaults:
+        style: false
+        row: false
+        fields: false
+        access: false
+        filters: false
+        filter_groups: false
+        arguments: false
+        header: false
+        css_class: false
+      row:
+        type: fields
+      fields:
+        media_library_select_form:
+          id: media_library_select_form
+          label: ''
+          table: media
+          field: media_library_select_form
+          relationship: none
+          entity_type: media
+          plugin_id: media_library_select_form
+          element_wrapper_class: ''
+          element_class: ''
+        thumbnail__target_id:
+          id: thumbnail__target_id
+          label: Thumbnail
+          table: media_field_data
+          field: thumbnail__target_id
+          relationship: none
+          type: image
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
+          settings:
+            image_style: media_library
+            image_link: ''
+        name:
+          id: name
+          label: Name
+          table: media_field_data
+          field: name
+          relationship: none
+          type: string
+          entity_type: media
+          entity_field: name
+          plugin_id: field
+          settings:
+            link_to_entity: false
+        uid:
+          id: uid
+          label: Author
+          table: media_field_revision
+          field: uid
+          relationship: none
+          type: entity_reference_label
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
+          settings:
+            link: true
+        changed:
+          id: changed
+          label: Updated
+          table: media_field_data
+          field: changed
+          relationship: none
+          type: timestamp
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+      access:
+        type: perm
+        options:
+          perm: 'view media'
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+        default_langcode:
+          id: default_langcode
+          table: media_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: default_langcode
+          plugin_id: boolean
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 24
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
+      header:
+        display_link_grid:
+          id: display_link_grid
+          table: views
+          field: display_link
+          display_id: widget
+          label: Grid
+          plugin_id: display_link
+          empty: true
+        display_link_table:
+          id: display_link_table
+          table: views
+          field: display_link
+          display_id: widget_table
+          label: Table
+          plugin_id: display_link
+          empty: true
+      css_class: ''
+      rendering_language: '***LANGUAGE_language_interface***'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - user.permissions
+      tags: {  }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN rm -rf ./vendor && \
     # Update composer to avoid issues with missing drupal files.
     # @see https://github.com/drupal-composer/drupal-project/issues/282
     composer selfupdate && \
-    COMPOSER_MEMORY_LIMIT=-1 COMPOSER_PROCESS_TIMEOUT=600 composer install --no-interaction --no-dev --prefer-dist
+    composer install --no-interaction
 
 # Clean up previous npm installation and run new one. Those commands correspond
 # to running `composer sass` but without hitting the PHP timeout from composer.
@@ -60,6 +60,7 @@ COPY --from=builder /srv/www/vendor /srv/www/vendor/
 COPY --from=builder /srv/www/composer.json /srv/www/composer.json
 COPY --from=builder /srv/www/composer.patches.json /srv/www/composer.patches.json
 COPY --from=builder /srv/www/composer.lock /srv/www/composer.lock
+COPY --from=builder /srv/www/symfony.lock /srv/www/symfony.lock
 COPY --from=builder /srv/www/patches /srv/www/patches
 COPY --from=builder /srv/www/scripts /srv/www/scripts
 COPY --from=builder /srv/www/docker/fastcgi_drupal.conf /etc/nginx/apps/drupal/fastcgi_drupal.conf

--- a/html/modules/custom/reliefweb_migrate/README.md
+++ b/html/modules/custom/reliefweb_migrate/README.md
@@ -1,0 +1,11 @@
+ReliefWeb - Migrate module
+==========================
+
+This module handles the migration from Drupal 7 to Drupal 9.
+
+Migrated content
+----------------
+
+In migration order:
+
+1. Menu links

--- a/html/modules/custom/reliefweb_migrate/composer.json
+++ b/html/modules/custom/reliefweb_migrate/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "unocha/reliefweb_migrate",
+    "description": "ReliefWeb Migration to Drupal 9.",
+    "type": "drupal-module",
+    "authors": [
+        {
+          "name": "UNOCHA"
+        }
+    ],
+    "require": {
+        "drupal/migrate_plus": "^5"
+    },
+    "require-dev": {
+        "drush/drush": "^10"
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^10"
+            }
+        }
+    }
+}

--- a/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.rw_menu_link__footer.yml
+++ b/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.rw_menu_link__footer.yml
@@ -1,0 +1,76 @@
+id: rw_menu_link__footer
+label: Migrate ReliefWeb footer menu links.
+migration_group: reliefweb
+dependencies:
+  enforced:
+    module:
+      - reliefweb_migrate
+audit: true
+migration_tags:
+  - Drupal 7
+  - Content
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      id: 8
+      title: Blog
+      description: Blog
+      link_uri: internal:/blog
+      external: 0
+      weight: 0
+    -
+      id: 9
+      title: Labs
+      description: Labs
+      link_uri: https://labs.reliefweb.int/
+      external: 1
+      weight: 1
+    -
+      id: 10
+      title: About
+      description: About
+      link_uri: internal:/about
+      external: 0
+      weight: 2
+    -
+      id: 11
+      title: Terms
+      description: Terms
+      link_uri: internal:/terms-conditions
+      external: 0
+      weight: 3
+    -
+      id: 12
+      title: Contact
+      description: Contact
+      link_uri: internal:/contact
+      external: 0
+      weight: 4
+  ids:
+    id:
+      type: integer
+  constants:
+    bundle: menu_link_content
+    menu_name: footer
+    enabled: 1
+    expanded: 0
+    parent: null
+destination:
+  plugin: entity:menu_link_content
+  no_stub: true
+process:
+  id: id
+  bundle: constants/bundle
+  title: title
+  description: description
+  menu_name: constants/menu_name
+  link/uri: link_uri
+  external: external
+  weight: weight
+  expanded: constants/expanded
+  enabled: constants/enabled
+  parent: constants/parent
+migration_dependencies:
+  required:
+    - rw_menu_link__main

--- a/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.rw_menu_link__main.yml
+++ b/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.rw_menu_link__main.yml
@@ -1,0 +1,90 @@
+id: rw_menu_link__main
+label: Migrate ReliefWeb main menu links.
+migration_group: reliefweb
+dependencies:
+  enforced:
+    module:
+      - reliefweb_migrate
+audit: true
+migration_tags:
+  - Drupal 7
+  - Content
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      id: 1
+      title: Updates
+      description: Updates
+      link_uri: internal:/updates
+      external: 0
+      weight: 0
+    -
+      id: 2
+      title: Countries
+      description: Countries
+      link_uri: internal:/countries
+      external: 0
+      weight: 1
+    -
+      id: 3
+      title: Disasters
+      description: Disasters
+      link_uri: internal:/disasters
+      external: 0
+      weight: 2
+    -
+      id: 4
+      title: Organizations
+      description: Organizations
+      link_uri: internal:/organizations
+      external: 0
+      weight: 3
+    -
+      id: 5
+      title: Topics
+      description: Topics
+      link_uri: internal:/topics
+      external: 0
+      weight: 4
+    -
+      id: 6
+      title: Jobs
+      description: Jobs
+      link_uri: internal:/jobs
+      external: 0
+      weight: 5
+    -
+      id: 7
+      title: Training
+      description: Training
+      link_uri: internal:/training
+      external: 0
+      weight: 6
+  ids:
+    id:
+      type: integer
+  constants:
+    bundle: menu_link_content
+    menu_name: main
+    enabled: 1
+    expanded: 0
+    parent: null
+destination:
+  plugin: entity:menu_link_content
+  no_stub: true
+process:
+  id: id
+  bundle: constants/bundle
+  title: title
+  description: description
+  menu_name: constants/menu_name
+  link/uri: link_uri
+  external: external
+  weight: weight
+  expanded: constants/expanded
+  enabled: constants/enabled
+  parent: constants/parent
+migration_dependencies:
+  required:
+    -

--- a/html/modules/custom/reliefweb_migrate/drush.services.yml
+++ b/html/modules/custom/reliefweb_migrate/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  reliefweb_migrate.commands:
+    class: \Drupal\reliefweb_migrate\Commands\RWMigrateCommands
+    arguments: ['@config.installer', '@config.manager']
+    tags:
+      - { name: drush.command }

--- a/html/modules/custom/reliefweb_migrate/reliefweb_migrate.info.yml
+++ b/html/modules/custom/reliefweb_migrate/reliefweb_migrate.info.yml
@@ -1,0 +1,9 @@
+type: module
+name: ReliefWeb Migration to Drupal 9
+description: 'Migrate ReliefWeb content from Drupal 7 to Drupal 9.'
+package: reliefweb
+core_version_requirement: ^9
+dependencies:
+  - drupal:migrate
+  - migrate_plus:migrate_plus
+  - migrate_tools:migrate_tools

--- a/html/modules/custom/reliefweb_migrate/reliefweb_migrate.install
+++ b/html/modules/custom/reliefweb_migrate/reliefweb_migrate.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Uninstall ReliefWeb migration files.
+ */
+
+/**
+ * Implements hook_uninstall().
+ *
+ * Uninstall the migration configuration.
+ */
+function reliefweb_migrate_uninstall() {
+  \Drupal::service('config.manager')->uninstall('module', 'reliefweb_migrate');
+
+  drupal_flush_all_caches();
+}

--- a/html/modules/custom/reliefweb_migrate/src/Commands/RWMigrateCommands.php
+++ b/html/modules/custom/reliefweb_migrate/src/Commands/RWMigrateCommands.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\reliefweb_migrate\Commands;
+
+use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
+use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
+use Drupal\Core\Config\ConfigInstallerInterface;
+use Drupal\Core\Config\ConfigManager;
+use Drush\Commands\DrushCommands;
+
+/**
+ * RW migration Drush commandfile.
+ */
+class RWMigrateCommands extends DrushCommands implements SiteAliasManagerAwareInterface {
+
+  use SiteAliasManagerAwareTrait;
+
+  /**
+   * Config Installer.
+   *
+   * @var Drupal\Core\Config\ConfigInstallerInterface
+   */
+  protected $configInstaller;
+
+  /**
+   * Config Manager.
+   *
+   * @var Drupal\Core\Config\ConfigManager
+   */
+  protected $configManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigInstallerInterface $config_installer, ConfigManager $config_manager) {
+    $this->configInstaller = $config_installer;
+    $this->configManager = $config_manager;
+  }
+
+  /**
+   * Reload ReliefWeb migration configurations.
+   *
+   * @command rw-migrate:reload-configuration
+   * @aliases rw-mrc,rw-migrate-reload-configuration
+   * @usage rw-migrate:reload-configuration
+   *   Reload all ReliefWeb migration configurations.
+   * @validate-module-enabled reliefweb_migrate
+   */
+  public function reloadConfiguration() {
+    // Uninstall and reinstall all configuration.
+    $this->configManager->uninstall('module', 'reliefweb_migrate');
+    $this->configInstaller->installDefaultConfig('module', 'reliefweb_migrate');
+
+    // Rebuild cache.
+    $process = $this->processManager()->drush($this->siteAliasManager()->getSelf(), 'cache-rebuild');
+    $process->mustrun();
+
+    $this->logger()->success(dt('Config reload complete.'));
+    return TRUE;
+  }
+
+}

--- a/patches/core--drupal--2570593-bundle-entity-class.patch
+++ b/patches/core--drupal--2570593-bundle-entity-class.patch
@@ -1,7 +1,7 @@
-diff --git a/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php b/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
+diff --git a/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php b/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
 index b944eea9f9..eea316acb2 100644
---- a/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
-+++ b/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
+--- a/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
++++ b/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
 @@ -225,7 +225,8 @@ protected function doLoadMultiple(array $ids = NULL) {
    protected function doCreate(array $values) {
      // Set default language to current language if not provided.
@@ -9,14 +9,14 @@ index b944eea9f9..eea316acb2 100644
 -    $entity = new $this->entityClass($values, $this->entityTypeId);
 +    $entity_class = $this->getEntityClass();
 +    $entity = new $entity_class($values, $this->entityTypeId);
- 
+
      return $entity;
    }
-diff --git a/core/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php b/core/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php
+diff --git a/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php b/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php
 new file mode 100644
 index 0000000000..9ba915fabd
 --- /dev/null
-+++ b/core/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php
++++ b/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php
 @@ -0,0 +1,33 @@
 +<?php
 +
@@ -51,14 +51,14 @@ index 0000000000..9ba915fabd
 +  public function getBundleKey();
 +
 +}
-diff --git a/core/lib/Drupal/Core/Entity/ContentEntityBase.php b/core/lib/Drupal/Core/Entity/ContentEntityBase.php
+diff --git a/lib/Drupal/Core/Entity/ContentEntityBase.php b/lib/Drupal/Core/Entity/ContentEntityBase.php
 index 35dca9a9c6..e416ced315 100644
---- a/core/lib/Drupal/Core/Entity/ContentEntityBase.php
-+++ b/core/lib/Drupal/Core/Entity/ContentEntityBase.php
+--- a/lib/Drupal/Core/Entity/ContentEntityBase.php
++++ b/lib/Drupal/Core/Entity/ContentEntityBase.php
 @@ -1125,6 +1125,23 @@ public function __unset($name) {
      }
    }
- 
+
 +  /**
 +   * {@inheritdoc}
 +   */
@@ -79,10 +79,10 @@ index 35dca9a9c6..e416ced315 100644
    /**
     * {@inheritdoc}
     */
-diff --git a/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php b/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
+diff --git a/lib/Drupal/Core/Entity/ContentEntityStorageBase.php b/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
 index b69958d8e8..e003838e0b 100644
---- a/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
-+++ b/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
+--- a/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
++++ b/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
 @@ -5,6 +5,8 @@
  use Drupal\Core\Cache\Cache;
  use Drupal\Core\Cache\CacheBackendInterface;
@@ -98,13 +98,13 @@ index b69958d8e8..e003838e0b 100644
   */
 -abstract class ContentEntityStorageBase extends EntityStorageBase implements ContentEntityStorageInterface, DynamicallyFieldableEntityStorageInterface {
 +abstract class ContentEntityStorageBase extends EntityStorageBase implements ContentEntityStorageInterface, DynamicallyFieldableEntityStorageInterface, BundleEntityStorageInterface {
- 
+
    /**
     * The entity bundle key.
 @@ -73,6 +75,34 @@ public function __construct(EntityTypeInterface $entity_type, EntityFieldManager
      $this->entityTypeBundleInfo = $entity_type_bundle_info;
    }
- 
+
 +  /**
 +   * {@inheritdoc}
 +   */
@@ -173,7 +173,7 @@ index b69958d8e8..e003838e0b 100644
 +    }
 +    return $bundle_for_class;
 +  }
- 
+
 +  /**
 +   * Retrieves the bundle from an array of values.
 +   *
@@ -228,16 +228,16 @@ index b69958d8e8..e003838e0b 100644
 +
 +    return $entity_class;
    }
- 
+
    /**
-diff --git a/core/lib/Drupal/Core/Entity/EntityStorageBase.php b/core/lib/Drupal/Core/Entity/EntityStorageBase.php
+diff --git a/lib/Drupal/Core/Entity/EntityStorageBase.php b/lib/Drupal/Core/Entity/EntityStorageBase.php
 index 8b78be167a..db9bf6efaa 100644
---- a/core/lib/Drupal/Core/Entity/EntityStorageBase.php
-+++ b/core/lib/Drupal/Core/Entity/EntityStorageBase.php
+--- a/lib/Drupal/Core/Entity/EntityStorageBase.php
++++ b/lib/Drupal/Core/Entity/EntityStorageBase.php
 @@ -99,6 +99,13 @@ public function __construct(EntityTypeInterface $entity_type, MemoryCacheInterfa
      $this->memoryCacheTag = 'entity.memory_cache:' . $this->entityTypeId;
    }
- 
+
 +  /**
 +   * {@inheritdoc}
 +   */
@@ -255,7 +255,7 @@ index 8b78be167a..db9bf6efaa 100644
 -    $entity_class = $this->entityClass;
 +    $entity_class = $this->getEntityClass();
      $entity_class::preCreate($this, $values);
- 
+
      // Assign a new UUID if there is none yet.
 @@ -234,7 +241,8 @@ public function create(array $values = []) {
     * @return \Drupal\Core\Entity\EntityInterface
@@ -265,7 +265,7 @@ index 8b78be167a..db9bf6efaa 100644
 +    $entity_class = $this->getEntityClass();
 +    return new $entity_class($values, $this->entityTypeId);
    }
- 
+
    /**
 @@ -353,17 +361,22 @@ protected function preLoad(array &$ids = NULL) {
     *   Associative array of query results, keyed on the entity ID.
@@ -300,7 +300,7 @@ index 8b78be167a..db9bf6efaa 100644
 +      }
      }
    }
- 
+
 @@ -379,7 +392,9 @@ protected function postLoad(array &$entities) {
    protected function mapFromStorageRecords(array $records) {
      $entities = [];
@@ -319,18 +319,18 @@ index 8b78be167a..db9bf6efaa 100644
 +   *   TRUE if this entity exists in storage, FALSE otherwise.
     */
    abstract protected function has($id, EntityInterface $entity);
- 
+
 @@ -406,27 +422,24 @@ public function delete(array $entities) {
        return;
      }
- 
+
 -    // Ensure that the entities are keyed by ID.
 -    $keyed_entities = [];
 -    foreach ($entities as $entity) {
 -      $keyed_entities[$entity->id()] = $entity;
 -    }
 +    $entities_by_class = $this->getEntitiesByClass($entities);
- 
+
      // Allow code to run before deleting.
 -    $entity_class = $this->entityClass;
 -    $entity_class::preDelete($this, $keyed_entities);
@@ -342,14 +342,14 @@ index 8b78be167a..db9bf6efaa 100644
 +      foreach ($items as $entity) {
 +        $this->invokeHook('predelete', $entity);
 +      }
- 
+
 -    // Perform the delete and reset the static cache for the deleted entities.
 -    $this->doDelete($keyed_entities);
 -    $this->resetCache(array_keys($keyed_entities));
 +      // Perform the delete and reset the static cache for the deleted entities.
 +      $this->doDelete($items);
 +      $this->resetCache(array_keys($items));
- 
+
 -    // Allow code to run after deleting.
 -    $entity_class::postDelete($this, $keyed_entities);
 -    foreach ($keyed_entities as $entity) {
@@ -361,11 +361,11 @@ index 8b78be167a..db9bf6efaa 100644
 +      }
      }
    }
- 
+
 @@ -605,4 +618,27 @@ public function getAggregateQuery($conjunction = 'AND') {
     */
    abstract protected function getQueryServiceName();
- 
+
 +  /**
 +   * Group the given array of entities by their class name and ID.
 +   *
@@ -390,14 +390,14 @@ index 8b78be167a..db9bf6efaa 100644
 +  }
 +
  }
-diff --git a/core/lib/Drupal/Core/Entity/EntityStorageInterface.php b/core/lib/Drupal/Core/Entity/EntityStorageInterface.php
+diff --git a/lib/Drupal/Core/Entity/EntityStorageInterface.php b/lib/Drupal/Core/Entity/EntityStorageInterface.php
 index 71898e0026..6d4762be33 100644
---- a/core/lib/Drupal/Core/Entity/EntityStorageInterface.php
-+++ b/core/lib/Drupal/Core/Entity/EntityStorageInterface.php
+--- a/lib/Drupal/Core/Entity/EntityStorageInterface.php
++++ b/lib/Drupal/Core/Entity/EntityStorageInterface.php
 @@ -230,4 +230,16 @@ public function getEntityTypeId();
     */
    public function getEntityType();
- 
+
 +  /**
 +   * Retrieves the class name used to create the entity.
 +   *
@@ -411,20 +411,20 @@ index 71898e0026..6d4762be33 100644
 +  public function getEntityClass($bundle = NULL);
 +
  }
-diff --git a/core/lib/Drupal/Core/Entity/EntityTypeRepository.php b/core/lib/Drupal/Core/Entity/EntityTypeRepository.php
+diff --git a/lib/Drupal/Core/Entity/EntityTypeRepository.php b/lib/Drupal/Core/Entity/EntityTypeRepository.php
 index 0bc900dbbc..e1c1cd5d16 100644
---- a/core/lib/Drupal/Core/Entity/EntityTypeRepository.php
-+++ b/core/lib/Drupal/Core/Entity/EntityTypeRepository.php
+--- a/lib/Drupal/Core/Entity/EntityTypeRepository.php
++++ b/lib/Drupal/Core/Entity/EntityTypeRepository.php
 @@ -2,6 +2,7 @@
- 
+
  namespace Drupal\Core\Entity;
- 
+
 +use Drupal\Core\Entity\Exception\AmbiguousBundleClassException;
  use Drupal\Core\Entity\Exception\AmbiguousEntityClassException;
  use Drupal\Core\Entity\Exception\NoCorrespondingEntityClassException;
  use Drupal\Core\StringTranslation\StringTranslationTrait;
 @@ -80,7 +81,8 @@ public function getEntityTypeFromClass($class_name) {
- 
+
      $same_class = 0;
      $entity_type_id = NULL;
 -    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
@@ -436,7 +436,7 @@ index 0bc900dbbc..e1c1cd5d16 100644
 @@ -89,6 +91,20 @@ public function getEntityTypeFromClass($class_name) {
        }
      }
- 
+
 +    // If no match was found check if it is a bundle class. This needs to be in
 +    // a separate loop to avoid false positives, since an entity class can
 +    // subclass another entity class.
@@ -454,10 +454,10 @@ index 0bc900dbbc..e1c1cd5d16 100644
      // Return the matching entity type ID if there is one.
      if ($entity_type_id) {
        $this->classNameEntityTypeMap[$class_name] = $entity_type_id;
-diff --git a/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php b/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
+diff --git a/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php b/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
 index 53af033e4d..0d05bc9673 100644
---- a/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
-+++ b/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
+--- a/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
++++ b/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
 @@ -34,6 +34,8 @@ public function getEntityTypeLabels($group = FALSE);
     *
     * @throws \Drupal\Core\Entity\Exception\AmbiguousEntityClassException
@@ -467,11 +467,11 @@ index 53af033e4d..0d05bc9673 100644
     * @throws \Drupal\Core\Entity\Exception\NoCorrespondingEntityClassException
     *   Thrown when no entity class corresponds to the called class.
     *
-diff --git a/core/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php b/core/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php
+diff --git a/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php b/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php
 new file mode 100644
 index 0000000000..f556fabbc9
 --- /dev/null
-+++ b/core/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php
++++ b/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php
 @@ -0,0 +1,23 @@
 +<?php
 +
@@ -496,11 +496,11 @@ index 0000000000..f556fabbc9
 +  }
 +
 +}
-diff --git a/core/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php b/core/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php
+diff --git a/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php b/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php
 new file mode 100644
 index 0000000000..4f0d1fd2ba
 --- /dev/null
-+++ b/core/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php
++++ b/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php
 @@ -0,0 +1,25 @@
 +<?php
 +
@@ -527,10 +527,10 @@ index 0000000000..4f0d1fd2ba
 +  }
 +
 +}
-diff --git a/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php b/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
+diff --git a/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php b/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
 index 98c5a41a32..4fe53ca1b6 100644
---- a/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
-+++ b/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
+--- a/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
++++ b/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
 @@ -93,7 +93,8 @@ public static function createInstance(ContainerInterface $container, EntityTypeI
    public function doCreate(array $values = []) {
      // Set default language to site default if not provided.
@@ -538,13 +538,13 @@ index 98c5a41a32..4fe53ca1b6 100644
 -    $entity = new $this->entityClass($values, $this->entityTypeId);
 +    $entity_class = $this->getEntityClass();
 +    $entity = new $entity_class($values, $this->entityTypeId);
- 
+
      // @todo This is handled by ContentEntityStorageBase, which assumes
      //   FieldableEntityInterface. The current approach in
-diff --git a/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php b/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
+diff --git a/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php b/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
 index 696203a6c5..bfc879df40 100644
---- a/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
-+++ b/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
+--- a/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
++++ b/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
 @@ -505,7 +505,8 @@ protected function mapFromStorageRecords(array $records, $load_from_revision = F
      foreach ($values as $id => $entity_values) {
        $bundle = $this->bundleKey ? $entity_values[$this->bundleKey][LanguageInterface::LANGCODE_DEFAULT] : FALSE;
@@ -553,12 +553,12 @@ index 696203a6c5..bfc879df40 100644
 +      $entity_class = $this->getEntityClass($bundle);
 +      $entities[$id] = new $entity_class($entity_values, $this->entityTypeId, $bundle, array_keys($translations[$id]));
      }
- 
+
      return $entities;
-diff --git a/core/lib/Drupal/Core/Entity/entity.api.php b/core/lib/Drupal/Core/Entity/entity.api.php
+diff --git a/lib/Drupal/Core/Entity/entity.api.php b/lib/Drupal/Core/Entity/entity.api.php
 index f941695da4..0547183656 100644
---- a/core/lib/Drupal/Core/Entity/entity.api.php
-+++ b/core/lib/Drupal/Core/Entity/entity.api.php
+--- a/lib/Drupal/Core/Entity/entity.api.php
++++ b/lib/Drupal/Core/Entity/entity.api.php
 @@ -846,6 +846,8 @@ function hook_entity_view_mode_info_alter(&$view_modes) {
   *     the entity type and the bundle, the one for the bundle is used.
   *   - translatable: (optional) A boolean value specifying whether this bundle
@@ -575,13 +575,13 @@ index f941695da4..0547183656 100644
 +  // Override the bundle class for the "article" node type in a custom module.
 +  $bundles['node']['article']['class'] = 'Drupal\mymodule\Entity\Article';
  }
- 
+
  /**
-diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml
+diff --git a/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml b/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml
 new file mode 100644
 index 0000000000..2bc73bd55d
 --- /dev/null
-+++ b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml
++++ b/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml
 @@ -0,0 +1,7 @@
 +name: 'Entity Bundle Class Test'
 +type: module
@@ -590,11 +590,11 @@ index 0000000000..2bc73bd55d
 +version: VERSION
 +dependencies:
 +  - drupal:entity_test
-diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module
+diff --git a/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module b/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module
 new file mode 100644
 index 0000000000..576143a4c1
 --- /dev/null
-+++ b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module
++++ b/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module
 @@ -0,0 +1,26 @@
 +<?php
 +
@@ -622,11 +622,11 @@ index 0000000000..576143a4c1
 +    $bundles['entity_test']['bundle_class']['class'] = NonInheritingBundleClass::class;
 +  }
 +}
-diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php
+diff --git a/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php b/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php
 new file mode 100644
 index 0000000000..56291da832
 --- /dev/null
-+++ b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php
++++ b/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php
 @@ -0,0 +1,11 @@
 +<?php
 +
@@ -639,11 +639,11 @@ index 0000000000..56291da832
 + */
 +class EntityTestBundleClass extends EntityTest {
 +}
-diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php
+diff --git a/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php b/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php
 new file mode 100644
 index 0000000000..1ad9b67fd5
 --- /dev/null
-+++ b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php
++++ b/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php
 @@ -0,0 +1,9 @@
 +<?php
 +
@@ -654,11 +654,11 @@ index 0000000000..1ad9b67fd5
 + */
 +class NonInheritingBundleClass {
 +}
-diff --git a/core/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php b/core/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php
+diff --git a/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php b/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php
 new file mode 100644
 index 0000000000..21a4958ff6
 --- /dev/null
-+++ b/core/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php
++++ b/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php
 @@ -0,0 +1,104 @@
 +<?php
 +

--- a/patches/core--drupal--2570593-bundle-entity-class.patch
+++ b/patches/core--drupal--2570593-bundle-entity-class.patch
@@ -1,0 +1,766 @@
+diff --git a/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php b/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
+index b944eea9f9..eea316acb2 100644
+--- a/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
++++ b/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php
+@@ -225,7 +225,8 @@ protected function doLoadMultiple(array $ids = NULL) {
+   protected function doCreate(array $values) {
+     // Set default language to current language if not provided.
+     $values += [$this->langcodeKey => $this->languageManager->getCurrentLanguage()->getId()];
+-    $entity = new $this->entityClass($values, $this->entityTypeId);
++    $entity_class = $this->getEntityClass();
++    $entity = new $entity_class($values, $this->entityTypeId);
+ 
+     return $entity;
+   }
+diff --git a/core/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php b/core/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php
+new file mode 100644
+index 0000000000..9ba915fabd
+--- /dev/null
++++ b/core/lib/Drupal/Core/Entity/BundleEntityStorageInterface.php
+@@ -0,0 +1,33 @@
++<?php
++
++namespace Drupal\Core\Entity;
++
++/**
++ * A storage that supports entities with bundle specific classes.
++ */
++interface BundleEntityStorageInterface {
++
++  /**
++   * Retrieves the bundle name for a provided class name.
++   *
++   * @param string $class_name
++   *   The class name to check.
++   *
++   * @return string|null
++   *   The bundle name of the class provided or NULL if unable to determine the
++   *   bundle from the provided class.
++   *
++   * @throws \Drupal\Core\Entity\Exception\AmbiguousBundleClassException
++   *   Thrown when multiple bundles are using the provided class.
++   */
++  public function getBundleFromClass($class_name);
++
++  /**
++   * Retrieves the entity bundle key.
++   *
++   * @return bool|string
++   *   The entity bundle key.
++   */
++  public function getBundleKey();
++
++}
+diff --git a/core/lib/Drupal/Core/Entity/ContentEntityBase.php b/core/lib/Drupal/Core/Entity/ContentEntityBase.php
+index 35dca9a9c6..e416ced315 100644
+--- a/core/lib/Drupal/Core/Entity/ContentEntityBase.php
++++ b/core/lib/Drupal/Core/Entity/ContentEntityBase.php
+@@ -1125,6 +1125,23 @@ public function __unset($name) {
+     }
+   }
+ 
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(array $values = []) {
++    $entity_type_repository = \Drupal::service('entity_type.repository');
++    $entity_type_manager = \Drupal::entityTypeManager();
++    $class_name = get_called_class();
++    $storage = $entity_type_manager->getStorage($entity_type_repository->getEntityTypeFromClass($class_name));
++
++    // Always explicitly specify the bundle if the entity has a bundle class.
++    if ($storage instanceof BundleEntityStorageInterface && ($bundle = $storage->getBundleFromClass($class_name))) {
++      $values[$storage->getBundleKey()] = $bundle;
++    }
++
++    return $storage->create($values);
++  }
++
+   /**
+    * {@inheritdoc}
+    */
+diff --git a/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php b/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
+index b69958d8e8..e003838e0b 100644
+--- a/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
++++ b/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php
+@@ -5,6 +5,8 @@
+ use Drupal\Core\Cache\Cache;
+ use Drupal\Core\Cache\CacheBackendInterface;
+ use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
++use Drupal\Core\Entity\Exception\AmbiguousBundleClassException;
++use Drupal\Core\Entity\Exception\BundleClassInheritanceException;
+ use Drupal\Core\Field\FieldDefinitionInterface;
+ use Drupal\Core\Field\FieldStorageDefinitionInterface;
+ use Drupal\Core\Language\LanguageInterface;
+@@ -14,7 +16,7 @@
+ /**
+  * Base class for content entity storage handlers.
+  */
+-abstract class ContentEntityStorageBase extends EntityStorageBase implements ContentEntityStorageInterface, DynamicallyFieldableEntityStorageInterface {
++abstract class ContentEntityStorageBase extends EntityStorageBase implements ContentEntityStorageInterface, DynamicallyFieldableEntityStorageInterface, BundleEntityStorageInterface {
+ 
+   /**
+    * The entity bundle key.
+@@ -73,6 +75,34 @@ public function __construct(EntityTypeInterface $entity_type, EntityFieldManager
+     $this->entityTypeBundleInfo = $entity_type_bundle_info;
+   }
+ 
++  /**
++   * {@inheritdoc}
++   */
++  public function create(array $values = []) {
++    // In some cases the entity bundle may be provided by the ::preCreate()
++    // method in the entity class. If a bundle is truly required an exception
++    // will be thrown in ::doCreate() so there's no need to throw one here.
++    $bundle = $this->getBundleFromValues($values);
++    $entity_class = $this->getEntityClass($bundle);
++    $entity_class::preCreate($this, $values);
++
++    // Assign a new UUID if there is none yet.
++    if ($this->uuidKey && $this->uuidService && !isset($values[$this->uuidKey])) {
++      $values[$this->uuidKey] = $this->uuidService->generate();
++    }
++
++    $entity = $this->doCreate($values);
++    $entity->enforceIsNew();
++
++    $entity->postCreate($this);
++
++    // Modules might need to add or change the data initially held by the new
++    // entity object, for instance to fill-in default values.
++    $this->invokeHook('create', $entity);
++
++    return $entity;
++  }
++
+   /**
+    * {@inheritdoc}
+    */
+@@ -90,13 +120,47 @@ public static function createInstance(ContainerInterface $container, EntityTypeI
+    * {@inheritdoc}
+    */
+   protected function doCreate(array $values) {
+-    // We have to determine the bundle first.
+-    $bundle = FALSE;
+-    if ($this->bundleKey) {
+-      if (!isset($values[$this->bundleKey])) {
+-        throw new EntityStorageException('Missing bundle for entity type ' . $this->entityTypeId);
++    $bundle = $this->getBundleFromValues($values);
++    if (!empty($this->bundleKey) && empty($bundle)) {
++      throw new EntityStorageException('Missing bundle for entity type ' . $this->entityTypeId);
++    }
++    $entity_class = $this->getEntityClass($bundle);
++    $entity = new $entity_class([], $this->entityTypeId, $bundle);
++    $this->initFieldValues($entity, $values);
++    return $entity;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getBundleFromClass($class_name) {
++    $bundle_for_class = NULL;
++    foreach ($this->entityTypeBundleInfo->getBundleInfo($this->entityTypeId) as $bundle => $bundle_info) {
++      if (!empty($bundle_info['class']) && $bundle_info['class'] === $class_name) {
++        // There is already a class for that bundle.
++        if (!empty($bundle_for_class)) {
++          throw new AmbiguousBundleClassException($class_name);
++        }
++        else {
++          $bundle_for_class = $bundle;
++        }
+       }
++    }
++    return $bundle_for_class;
++  }
+ 
++  /**
++   * Retrieves the bundle from an array of values.
++   *
++   * @param array $values
++   *   An array of values to set, keyed by field name.
++   *
++   * @return string|null
++   *   The bundle or NULL if not set.
++   */
++  protected function getBundleFromValues(array $values) {
++    $bundle = NULL;
++    if (!empty($this->bundleKey) && !empty($values[$this->bundleKey])) {
+       // Normalize the bundle value. This is an optimized version of
+       // \Drupal\Core\Field\FieldInputValueNormalizerTrait::normalizeValue()
+       // because we just need the scalar value.
+@@ -115,9 +179,37 @@ protected function doCreate(array $values) {
+         $bundle = reset($bundle_value);
+       }
+     }
+-    $entity = new $this->entityClass([], $this->entityTypeId, $bundle);
+-    $this->initFieldValues($entity, $values);
+-    return $entity;
++    return $bundle;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getBundleKey() {
++    return $this->bundleKey;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getEntityClass($bundle = NULL) {
++    $entity_class = parent::getEntityClass();
++
++    if (!empty($bundle)) {
++      // Return the bundle class if it has been defined for this bundle.
++      $bundle_info = $this->entityTypeBundleInfo->getBundleInfo($this->entityTypeId);
++      $bundle_class = $bundle_info[$bundle]['class'] ?? NULL;
++
++      // Bundle classes should extend the main entity class.
++      if ($bundle_class) {
++        if (!is_subclass_of($bundle_class, $entity_class)) {
++          throw new BundleClassInheritanceException($bundle_class, $entity_class);
++        }
++        return $bundle_class;
++      }
++    }
++
++    return $entity_class;
+   }
+ 
+   /**
+diff --git a/core/lib/Drupal/Core/Entity/EntityStorageBase.php b/core/lib/Drupal/Core/Entity/EntityStorageBase.php
+index 8b78be167a..db9bf6efaa 100644
+--- a/core/lib/Drupal/Core/Entity/EntityStorageBase.php
++++ b/core/lib/Drupal/Core/Entity/EntityStorageBase.php
+@@ -99,6 +99,13 @@ public function __construct(EntityTypeInterface $entity_type, MemoryCacheInterfa
+     $this->memoryCacheTag = 'entity.memory_cache:' . $this->entityTypeId;
+   }
+ 
++  /**
++   * {@inheritdoc}
++   */
++  public function getEntityClass($bundle = NULL) {
++    return $this->entityClass;
++  }
++
+   /**
+    * {@inheritdoc}
+    */
+@@ -205,7 +212,7 @@ protected function invokeHook($hook, EntityInterface $entity) {
+    * {@inheritdoc}
+    */
+   public function create(array $values = []) {
+-    $entity_class = $this->entityClass;
++    $entity_class = $this->getEntityClass();
+     $entity_class::preCreate($this, $values);
+ 
+     // Assign a new UUID if there is none yet.
+@@ -234,7 +241,8 @@ public function create(array $values = []) {
+    * @return \Drupal\Core\Entity\EntityInterface
+    */
+   protected function doCreate(array $values) {
+-    return new $this->entityClass($values, $this->entityTypeId);
++    $entity_class = $this->getEntityClass();
++    return new $entity_class($values, $this->entityTypeId);
+   }
+ 
+   /**
+@@ -353,17 +361,22 @@ protected function preLoad(array &$ids = NULL) {
+    *   Associative array of query results, keyed on the entity ID.
+    */
+   protected function postLoad(array &$entities) {
+-    $entity_class = $this->entityClass;
+-    $entity_class::postLoad($this, $entities);
+-    // Call hook_entity_load().
+-    foreach ($this->moduleHandler()->getImplementations('entity_load') as $module) {
+-      $function = $module . '_entity_load';
+-      $function($entities, $this->entityTypeId);
+-    }
+-    // Call hook_TYPE_load().
+-    foreach ($this->moduleHandler()->getImplementations($this->entityTypeId . '_load') as $module) {
+-      $function = $module . '_' . $this->entityTypeId . '_load';
+-      $function($entities);
++    $entities_by_class = $this->getEntitiesByClass($entities);
++
++    foreach ($entities_by_class as $entity_class => &$items) {
++      $entity_class::postLoad($this, $items);
++
++      // Call hook_entity_load().
++      foreach ($this->moduleHandler()->getImplementations('entity_load') as $module) {
++        $function = $module . '_entity_load';
++        $function($items, $this->entityTypeId);
++      }
++
++      // Call hook_TYPE_load().
++      foreach ($this->moduleHandler()->getImplementations($this->entityTypeId . '_load') as $module) {
++        $function = $module . '_' . $this->entityTypeId . '_load';
++        $function($items);
++      }
+     }
+   }
+ 
+@@ -379,7 +392,9 @@ protected function postLoad(array &$entities) {
+   protected function mapFromStorageRecords(array $records) {
+     $entities = [];
+     foreach ($records as $record) {
+-      $entity = new $this->entityClass($record, $this->entityTypeId);
++      $entity_class = $this->getEntityClass();
++      /* @var $entity \Drupal\Core\Entity\EntityInterface */
++      $entity = new $entity_class($record, $this->entityTypeId);
+       $entities[$entity->id()] = $entity;
+     }
+     return $entities;
+@@ -394,6 +409,7 @@ protected function mapFromStorageRecords(array $records) {
+    *   The entity being saved.
+    *
+    * @return bool
++   *   TRUE if this entity exists in storage, FALSE otherwise.
+    */
+   abstract protected function has($id, EntityInterface $entity);
+ 
+@@ -406,27 +422,24 @@ public function delete(array $entities) {
+       return;
+     }
+ 
+-    // Ensure that the entities are keyed by ID.
+-    $keyed_entities = [];
+-    foreach ($entities as $entity) {
+-      $keyed_entities[$entity->id()] = $entity;
+-    }
++    $entities_by_class = $this->getEntitiesByClass($entities);
+ 
+     // Allow code to run before deleting.
+-    $entity_class = $this->entityClass;
+-    $entity_class::preDelete($this, $keyed_entities);
+-    foreach ($keyed_entities as $entity) {
+-      $this->invokeHook('predelete', $entity);
+-    }
++    foreach ($entities_by_class as $entity_class => &$items) {
++      $entity_class::preDelete($this, $items);
++      foreach ($items as $entity) {
++        $this->invokeHook('predelete', $entity);
++      }
+ 
+-    // Perform the delete and reset the static cache for the deleted entities.
+-    $this->doDelete($keyed_entities);
+-    $this->resetCache(array_keys($keyed_entities));
++      // Perform the delete and reset the static cache for the deleted entities.
++      $this->doDelete($items);
++      $this->resetCache(array_keys($items));
+ 
+-    // Allow code to run after deleting.
+-    $entity_class::postDelete($this, $keyed_entities);
+-    foreach ($keyed_entities as $entity) {
+-      $this->invokeHook('delete', $entity);
++      // Allow code to run after deleting.
++      $entity_class::postDelete($this, $items);
++      foreach ($items as $entity) {
++        $this->invokeHook('delete', $entity);
++      }
+     }
+   }
+ 
+@@ -605,4 +618,27 @@ public function getAggregateQuery($conjunction = 'AND') {
+    */
+   abstract protected function getQueryServiceName();
+ 
++  /**
++   * Group the given array of entities by their class name and ID.
++   *
++   * @param \Drupal\Core\Entity\EntityInterface[] $entities
++   *   The array of entities to index.
++   *
++   * @return \Drupal\Core\Entity\EntityInterface[][]
++   *   An array of the passed-in entities, grouped by their class name and ID.
++   */
++  protected function getEntitiesByClass(array $entities) {
++    $entity_classes = [];
++
++    foreach ($entities as $entity) {
++      $entity_class = get_class($entity);
++      if (!isset($entity_classes[$entity_class])) {
++        $entity_classes[$entity_class] = [];
++      }
++      $entity_classes[$entity_class][$entity->id()] = $entity;
++    }
++
++    return $entity_classes;
++  }
++
+ }
+diff --git a/core/lib/Drupal/Core/Entity/EntityStorageInterface.php b/core/lib/Drupal/Core/Entity/EntityStorageInterface.php
+index 71898e0026..6d4762be33 100644
+--- a/core/lib/Drupal/Core/Entity/EntityStorageInterface.php
++++ b/core/lib/Drupal/Core/Entity/EntityStorageInterface.php
+@@ -230,4 +230,16 @@ public function getEntityTypeId();
+    */
+   public function getEntityType();
+ 
++  /**
++   * Retrieves the class name used to create the entity.
++   *
++   * @param string|null $bundle
++   *   (optional) A specific entity type bundle identifier. Can be omitted in
++   *   the case of entity types without bundles, like User.
++   *
++   * @return string
++   *   The class name.
++   */
++  public function getEntityClass($bundle = NULL);
++
+ }
+diff --git a/core/lib/Drupal/Core/Entity/EntityTypeRepository.php b/core/lib/Drupal/Core/Entity/EntityTypeRepository.php
+index 0bc900dbbc..e1c1cd5d16 100644
+--- a/core/lib/Drupal/Core/Entity/EntityTypeRepository.php
++++ b/core/lib/Drupal/Core/Entity/EntityTypeRepository.php
+@@ -2,6 +2,7 @@
+ 
+ namespace Drupal\Core\Entity;
+ 
++use Drupal\Core\Entity\Exception\AmbiguousBundleClassException;
+ use Drupal\Core\Entity\Exception\AmbiguousEntityClassException;
+ use Drupal\Core\Entity\Exception\NoCorrespondingEntityClassException;
+ use Drupal\Core\StringTranslation\StringTranslationTrait;
+@@ -80,7 +81,8 @@ public function getEntityTypeFromClass($class_name) {
+ 
+     $same_class = 0;
+     $entity_type_id = NULL;
+-    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
++    $definitions = $this->entityTypeManager->getDefinitions();
++    foreach ($definitions as $entity_type) {
+       if ($entity_type->getOriginalClass() == $class_name  || $entity_type->getClass() == $class_name) {
+         $entity_type_id = $entity_type->id();
+         if ($same_class++) {
+@@ -89,6 +91,20 @@ public function getEntityTypeFromClass($class_name) {
+       }
+     }
+ 
++    // If no match was found check if it is a bundle class. This needs to be in
++    // a separate loop to avoid false positives, since an entity class can
++    // subclass another entity class.
++    if (!$entity_type_id) {
++      foreach ($definitions as $entity_type) {
++        if (is_subclass_of($class_name, $entity_type->getOriginalClass()) || is_subclass_of($class_name, $entity_type->getClass())) {
++          $entity_type_id = $entity_type->id();
++          if ($same_class++) {
++            throw new AmbiguousBundleClassException($class_name);
++          }
++        }
++      }
++    }
++
+     // Return the matching entity type ID if there is one.
+     if ($entity_type_id) {
+       $this->classNameEntityTypeMap[$class_name] = $entity_type_id;
+diff --git a/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php b/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
+index 53af033e4d..0d05bc9673 100644
+--- a/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
++++ b/core/lib/Drupal/Core/Entity/EntityTypeRepositoryInterface.php
+@@ -34,6 +34,8 @@ public function getEntityTypeLabels($group = FALSE);
+    *
+    * @throws \Drupal\Core\Entity\Exception\AmbiguousEntityClassException
+    *   Thrown when multiple subclasses correspond to the called class.
++   * @throws \Drupal\Core\Entity\Exception\AmbiguousBundleClassException
++   *   Thrown when multiple subclasses correspond to the called bundle class.
+    * @throws \Drupal\Core\Entity\Exception\NoCorrespondingEntityClassException
+    *   Thrown when no entity class corresponds to the called class.
+    *
+diff --git a/core/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php b/core/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php
+new file mode 100644
+index 0000000000..f556fabbc9
+--- /dev/null
++++ b/core/lib/Drupal/Core/Entity/Exception/AmbiguousBundleClassException.php
+@@ -0,0 +1,23 @@
++<?php
++
++namespace Drupal\Core\Entity\Exception;
++
++/**
++ * Exception thrown if a bundle class is defined for multiple bundles.
++ *
++ * @see \Drupal\Core\Entity\ContentEntityStorageBase::getBundleFromClass()
++ */
++class AmbiguousBundleClassException extends AmbiguousEntityClassException {
++
++  /**
++   * Constructs an AmbiguousBundleClassException.
++   *
++   * @param string $class
++   *   The bundle class which is defined for multiple bundles.
++   */
++  public function __construct(string $class) {
++    $message = sprintf('Multiple bundles are using the bundle class %s.', $class);
++    parent::__construct($message);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php b/core/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php
+new file mode 100644
+index 0000000000..4f0d1fd2ba
+--- /dev/null
++++ b/core/lib/Drupal/Core/Entity/Exception/BundleClassInheritanceException.php
+@@ -0,0 +1,25 @@
++<?php
++
++namespace Drupal\Core\Entity\Exception;
++
++/**
++ * Exception thrown if a bundle class does not extend the main entity class.
++ *
++ * @see \Drupal\Core\Entity\ContentEntityStorageBase::getEntityClass()
++ */
++class BundleClassInheritanceException extends \Exception {
++
++  /**
++   * Constructs a BundleClassInheritanceException.
++   *
++   * @param string $bundle_class
++   *   The bundle class which should extend the entity class.
++   * @param string $entity_class
++   *   The entity class which should be extended.
++   */
++  public function __construct(string $bundle_class, string $entity_class) {
++    $message = sprintf('Bundle class %s does not extend entity class %s.', $bundle_class, $entity_class);
++    parent::__construct($message);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php b/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
+index 98c5a41a32..4fe53ca1b6 100644
+--- a/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
++++ b/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueEntityStorage.php
+@@ -93,7 +93,8 @@ public static function createInstance(ContainerInterface $container, EntityTypeI
+   public function doCreate(array $values = []) {
+     // Set default language to site default if not provided.
+     $values += [$this->getEntityType()->getKey('langcode') => $this->languageManager->getDefaultLanguage()->getId()];
+-    $entity = new $this->entityClass($values, $this->entityTypeId);
++    $entity_class = $this->getEntityClass();
++    $entity = new $entity_class($values, $this->entityTypeId);
+ 
+     // @todo This is handled by ContentEntityStorageBase, which assumes
+     //   FieldableEntityInterface. The current approach in
+diff --git a/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php b/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
+index 696203a6c5..bfc879df40 100644
+--- a/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
++++ b/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php
+@@ -505,7 +505,8 @@ protected function mapFromStorageRecords(array $records, $load_from_revision = F
+     foreach ($values as $id => $entity_values) {
+       $bundle = $this->bundleKey ? $entity_values[$this->bundleKey][LanguageInterface::LANGCODE_DEFAULT] : FALSE;
+       // Turn the record into an entity class.
+-      $entities[$id] = new $this->entityClass($entity_values, $this->entityTypeId, $bundle, array_keys($translations[$id]));
++      $entity_class = $this->getEntityClass($bundle);
++      $entities[$id] = new $entity_class($entity_values, $this->entityTypeId, $bundle, array_keys($translations[$id]));
+     }
+ 
+     return $entities;
+diff --git a/core/lib/Drupal/Core/Entity/entity.api.php b/core/lib/Drupal/Core/Entity/entity.api.php
+index f941695da4..0547183656 100644
+--- a/core/lib/Drupal/Core/Entity/entity.api.php
++++ b/core/lib/Drupal/Core/Entity/entity.api.php
+@@ -846,6 +846,8 @@ function hook_entity_view_mode_info_alter(&$view_modes) {
+  *     the entity type and the bundle, the one for the bundle is used.
+  *   - translatable: (optional) A boolean value specifying whether this bundle
+  *     has translation support enabled. Defaults to FALSE.
++ *   - class: (optional) The fully qualified class name for this bundle. If
++ *     omitted the class from the entity type definition will be used.
+  *
+  * @see \Drupal\Core\Entity\EntityTypeBundleInfo::getBundleInfo()
+  * @see hook_entity_bundle_info_alter()
+@@ -866,6 +868,8 @@ function hook_entity_bundle_info() {
+  */
+ function hook_entity_bundle_info_alter(&$bundles) {
+   $bundles['user']['user']['label'] = t('Full account');
++  // Override the bundle class for the "article" node type in a custom module.
++  $bundles['node']['article']['class'] = 'Drupal\mymodule\Entity\Article';
+ }
+ 
+ /**
+diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml
+new file mode 100644
+index 0000000000..2bc73bd55d
+--- /dev/null
++++ b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.info.yml
+@@ -0,0 +1,7 @@
++name: 'Entity Bundle Class Test'
++type: module
++description: 'Support module for testing entity bundle classes.'
++package: Testing
++version: VERSION
++dependencies:
++  - drupal:entity_test
+diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module
+new file mode 100644
+index 0000000000..576143a4c1
+--- /dev/null
++++ b/core/modules/system/tests/modules/entity_test_bundle_class/entity_test_bundle_class.module
+@@ -0,0 +1,26 @@
++<?php
++
++/**
++ * @file
++ * Support module for testing entity bundle classes.
++ */
++
++use Drupal\entity_test_bundle_class\Entity\EntityTestBundleClass;
++use Drupal\entity_test_bundle_class\Entity\NonInheritingBundleClass;
++
++/**
++ * Implements hook_entity_bundle_info_alter().
++ */
++function entity_test_bundle_class_entity_bundle_info_alter(&$bundles) {
++  if (!empty($bundles['entity_test']['bundle_class'])) {
++    $bundles['entity_test']['bundle_class']['class'] = EntityTestBundleClass::class;
++  }
++
++  if (\Drupal::state()->get('entity_test_bundle_class_enable_ambiguous_entity_types', FALSE)) {
++    $bundles['entity_test']['entity_test_no_label']['class'] = EntityTestBundleClass::class;
++  }
++
++  if (\Drupal::state()->get('entity_test_bundle_class_non_inheriting', FALSE)) {
++    $bundles['entity_test']['bundle_class']['class'] = NonInheritingBundleClass::class;
++  }
++}
+diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php
+new file mode 100644
+index 0000000000..56291da832
+--- /dev/null
++++ b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/EntityTestBundleClass.php
+@@ -0,0 +1,11 @@
++<?php
++
++namespace Drupal\entity_test_bundle_class\Entity;
++
++use Drupal\entity_test\Entity\EntityTest;
++
++/**
++ * The bundle class for the bundle_class bundle of the entity_test entity.
++ */
++class EntityTestBundleClass extends EntityTest {
++}
+diff --git a/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php
+new file mode 100644
+index 0000000000..1ad9b67fd5
+--- /dev/null
++++ b/core/modules/system/tests/modules/entity_test_bundle_class/src/Entity/NonInheritingBundleClass.php
+@@ -0,0 +1,9 @@
++<?php
++
++namespace Drupal\entity_test_bundle_class\Entity;
++
++/**
++ * An invalid bundle class which does not inherit the main entity class.
++ */
++class NonInheritingBundleClass {
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php b/core/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php
+new file mode 100644
+index 0000000000..21a4958ff6
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Entity/BundleClassTest.php
+@@ -0,0 +1,104 @@
++<?php
++
++namespace Drupal\KernelTests\Core\Entity;
++
++use Drupal\Core\Entity\Exception\AmbiguousBundleClassException;
++use Drupal\Core\Entity\Exception\BundleClassInheritanceException;
++use Drupal\entity_test\Entity\EntityTest;
++use Drupal\entity_test_bundle_class\Entity\EntityTestBundleClass;
++
++/**
++ * Tests entity bundle classes.
++ *
++ * @group Entity
++ */
++class BundleClassTest extends EntityKernelTestBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = ['entity_test_bundle_class'];
++
++  /**
++   * The entity storage.
++   *
++   * @var \Drupal\Core\Entity\EntityStorageInterface
++   */
++  protected $storage;
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function setUp(): void {
++    parent::setUp();
++    $this->storage = $this->entityTypeManager->getStorage('entity_test');
++  }
++
++  /**
++   * Tests making use of a custom bundle field.
++   */
++  public function testEntitySubclass() {
++    entity_test_create_bundle('bundle_class');
++
++    // Verify statically created entity with bundle class returns correct class.
++    $entity = EntityTestBundleClass::create();
++    $this->assertInstanceOf(EntityTestBundleClass::class, $entity);
++
++    // Verify statically created entity with bundle class returns correct
++    // bundle.
++    $entity = EntityTestBundleClass::create(['type' => 'custom']);
++    $this->assertInstanceOf(EntityTestBundleClass::class, $entity);
++    $this->assertEquals('bundle_class', $entity->bundle());
++
++    // Verify that the entity storage creates the entity using the proper class.
++    $entity = $this->storage->create(['type' => 'bundle_class']);
++    $this->assertInstanceOf(EntityTestBundleClass::class, $entity);
++
++    // Verify that loading an entity returns the proper class.
++    $entity->save();
++    $id = $entity->id();
++    $this->storage->resetCache();
++    $entity = $this->storage->load($id);
++    $this->assertInstanceOf(EntityTestBundleClass::class, $entity);
++
++    // Verify that getEntityClass without bundle returns the default entity
++    // class.
++    $entity_class = $this->storage->getEntityClass(NULL);
++    $this->assertEquals(EntityTest::class, $entity_class);
++
++    // Verify that getEntityClass with a bundle returns the proper class.
++    $entity_class = $this->storage->getEntityClass('bundle_class');
++    $this->assertEquals(EntityTestBundleClass::class, $entity_class);
++
++    // Verify that getEntityClass with a non-existing bundle returns the entity
++    // class.
++    $entity_class = $this->storage->getEntityClass('custom');
++    $this->assertEquals(EntityTest::class, $entity_class);
++  }
++
++  /**
++   * Checks exception is thrown if multiple classes implement the same bundle.
++   */
++  public function testAmbiguousBundleClassException() {
++    $this->container->get('state')->set('entity_test_bundle_class_enable_ambiguous_entity_types', TRUE);
++    $this->entityTypeManager->clearCachedDefinitions();
++    $this->expectException(AmbiguousBundleClassException::class);
++    entity_test_create_bundle('bundle_class');
++
++    // Since we now have two entity types that returns the same class for the
++    // same bundle, we expect this to throw an exception.
++    EntityTestBundleClass::create();
++  }
++
++  /**
++   * Checks exception thrown if a bundle class doesn't extend the entity class.
++   */
++  public function testBundleClassShouldExtendEntityClass() {
++    $this->container->get('state')->set('entity_test_bundle_class_non_inheriting', TRUE);
++    $this->entityTypeManager->clearCachedDefinitions();
++    $this->expectException(BundleClassInheritanceException::class);
++    entity_test_create_bundle('bundle_class');
++    $this->storage->create(['type' => 'bundle_class']);
++  }
++
++}

--- a/symfony.lock
+++ b/symfony.lock
@@ -164,6 +164,9 @@
     "drupal/entity_reference_revisions": {
         "version": "1.9.0"
     },
+    "drupal/geofield": {
+        "version": "1.22.0"
+    },
     "drupal/google_tag": {
         "version": "1.4.0"
     },
@@ -211,9 +214,6 @@
     },
     "drupal/token": {
         "version": "1.9.0"
-    },
-    "drupal/yaml_content": {
-        "version": "1.0.0-alpha7"
     },
     "drush/drush": {
         "version": "10.4.2"
@@ -307,6 +307,9 @@
     },
     "phar-io/version": {
         "version": "3.1.0"
+    },
+    "phayes/geophp": {
+        "version": "1.2"
     },
     "phpcompatibility/php-compatibility": {
         "version": "9.3.5"
@@ -659,8 +662,5 @@
     },
     "webmozart/path-util": {
         "version": "2.3.0"
-    },
-    "weitzman/drupal-test-traits": {
-        "version": "1.5.0"
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -443,10 +443,7 @@
             "branch": "master",
             "version": "3.0",
             "ref": "0dc9cceda799fd3a08b96987e176a261028a3709"
-        },
-        "files": [
-            "phpcs.xml.dist"
-        ]
+        }
     },
     "stack/builder": {
         "version": "v1.0.6"

--- a/symfony.lock
+++ b/symfony.lock
@@ -26,6 +26,9 @@
     "composer/composer": {
         "version": "2.0.12"
     },
+    "composer/metadata-minifier": {
+        "version": "1.0.0"
+    },
     "composer/semver": {
         "version": "3.2.2"
     },
@@ -175,6 +178,12 @@
     },
     "drupal/metatag": {
         "version": "1.16.0"
+    },
+    "drupal/migrate_plus": {
+        "version": "5.1.0"
+    },
+    "drupal/migrate_tools": {
+        "version": "5.x-dev"
     },
     "drupal/paragraphs": {
         "version": "1.12.0"

--- a/symfony.lock
+++ b/symfony.lock
@@ -24,7 +24,7 @@
         "version": "1.2.9"
     },
     "composer/composer": {
-        "version": "2.0.12"
+        "version": "2.0.13"
     },
     "composer/metadata-minifier": {
         "version": "1.0.0"
@@ -90,7 +90,7 @@
         ]
     },
     "doctrine/cache": {
-        "version": "1.10.2"
+        "version": "1.11.0"
     },
     "doctrine/collections": {
         "version": "1.6.7"
@@ -102,7 +102,7 @@
         "version": "1.1.1"
     },
     "doctrine/inflector": {
-        "version": "1.4.3"
+        "version": "1.4.4"
     },
     "doctrine/instantiator": {
         "version": "1.4.0"
@@ -123,10 +123,10 @@
         "version": "1.3.0"
     },
     "drupal/coder": {
-        "version": "8.3.12"
+        "version": "8.3.13"
     },
     "drupal/components": {
-        "version": "2.2.0"
+        "version": "2.4.0"
     },
     "drupal/config_filter": {
         "version": "1.8.0"
@@ -147,16 +147,16 @@
         "version": "0.9.5"
     },
     "drupal/core": {
-        "version": "9.1.6"
+        "version": "9.1.8"
     },
     "drupal/core-dev": {
-        "version": "9.1.6"
+        "version": "9.1.8"
     },
     "drupal/core-recommended": {
-        "version": "9.1.6"
+        "version": "9.1.8"
     },
     "drupal/ctools": {
-        "version": "3.4.0"
+        "version": "3.5.0"
     },
     "drupal/devel": {
         "version": "4.1.1"
@@ -216,7 +216,7 @@
         "version": "1.9.0"
     },
     "drush/drush": {
-        "version": "10.4.2"
+        "version": "10.5.0"
     },
     "easyrdf/easyrdf": {
         "version": "1.1.1"
@@ -225,7 +225,7 @@
         "version": "2.1.22"
     },
     "enlightn/security-checker": {
-        "version": "v1.7.0"
+        "version": "v1.9.0"
     },
     "fabpot/goutte": {
         "version": "v3.3.1"
@@ -282,13 +282,13 @@
         "version": "1.10.2"
     },
     "nikic/php-parser": {
-        "version": "v4.10.4"
+        "version": "v4.10.5"
     },
     "paragonie/random_compat": {
         "version": "v9.99.100"
     },
     "pdepend/pdepend": {
-        "version": "2.9.0"
+        "version": "2.9.1"
     },
     "pear/archive_tar": {
         "version": "1.4.13"
@@ -324,7 +324,7 @@
         "version": "1.4.0"
     },
     "phpmd/phpmd": {
-        "version": "2.9.1"
+        "version": "2.10.1"
     },
     "phpspec/prophecy": {
         "version": "1.13.0"
@@ -458,10 +458,10 @@
         "version": "2.3.3"
     },
     "symfony/browser-kit": {
-        "version": "v4.4.20"
+        "version": "v4.4.22"
     },
     "symfony/config": {
-        "version": "v4.4.20"
+        "version": "v4.4.22"
     },
     "symfony/console": {
         "version": "4.4",
@@ -477,28 +477,28 @@
         ]
     },
     "symfony/css-selector": {
-        "version": "v4.4.20"
+        "version": "v4.4.22"
     },
     "symfony/debug": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/dependency-injection": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/dom-crawler": {
         "version": "v4.4.20"
     },
     "symfony/error-handler": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/event-dispatcher": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/event-dispatcher-contracts": {
         "version": "v1.1.9"
     },
     "symfony/filesystem": {
-        "version": "v4.4.21"
+        "version": "v4.4.22"
     },
     "symfony/finder": {
         "version": "v4.4.20"
@@ -519,10 +519,10 @@
         "version": "v2.3.1"
     },
     "symfony/http-foundation": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/http-kernel": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/lock": {
         "version": "4.4",
@@ -537,7 +537,7 @@
         ]
     },
     "symfony/mime": {
-        "version": "v5.1.8"
+        "version": "v5.1.11"
     },
     "symfony/phpunit-bridge": {
         "version": "5.1",
@@ -579,7 +579,7 @@
         "version": "v1.20.0"
     },
     "symfony/process": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/psr-http-message-bridge": {
         "version": "v2.0.2"
@@ -599,7 +599,7 @@
         ]
     },
     "symfony/serializer": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "symfony/service-contracts": {
         "version": "v2.2.0"
@@ -634,10 +634,10 @@
         ]
     },
     "symfony/var-dumper": {
-        "version": "v5.1.8"
+        "version": "v5.1.11"
     },
     "symfony/yaml": {
-        "version": "v4.4.16"
+        "version": "v4.4.19"
     },
     "theseer/tokenizer": {
         "version": "1.2.0"
@@ -652,7 +652,7 @@
         "version": "v1.0.2"
     },
     "unocha/common_design": {
-        "version": "v3.0.6"
+        "version": "v4.0.5"
     },
     "webflo/drupal-finder": {
         "version": "1.2.2"


### PR DESCRIPTION
Ticket: RW-12

This adds the nodes and vocabularies needed to port other features like field widgets and moderation as well as the base `reliefweb_migrate` that will be used for migrating content.

Currently contains 2 migration configs to add the main navigation and footer menus.