### PR TITLE
[RW-26] Add moderation statuses for nodes and terms

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,7 +1,8 @@
 {
     "patches": {
         "drupal/core" : {
-            "https://www.drupal.org/project/drupal/issues/2570593": "patches/core--drupal--2570593-bundle-entity-class.patch"
+            "https://www.drupal.org/project/drupal/issues/2570593": "patches/core--drupal--2570593-bundle-entity-class.patch",
+            "https://www.drupal.org/project/drupal/issues/3047110": "patches/core--drupal--3047110-taxonomy-term-moderation-class.patch"
         }
     }
 }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -6,6 +6,7 @@ module:
   breakpoint: 0
   components: 0
   config: 0
+  content_moderation: 0
   ctools: 0
   datetime: 0
   datetime_range: 0
@@ -60,6 +61,7 @@ module:
   update: 0
   user: 0
   views_ui: 0
+  workflows: 0
   pathauto: 1
   content_translation: 10
   views: 10

--- a/config/views.view.moderated_content.yml
+++ b/config/views.view.moderated_content.yml
@@ -1,0 +1,833 @@
+uuid: 8cf1242f-1f5c-4161-b081-c2661a1906a3
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - content_moderation
+  module:
+    - node
+    - user
+_core:
+  default_config_hash: Kjqf5d4F134C3zua0tXV7LA3m5OEeS_Fowa2dP9kk2I
+id: moderated_content
+label: 'Moderated content'
+module: views
+description: 'Find and moderate content.'
+tag: ''
+base_table: node_field_revision
+base_field: vid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'view any unpublished content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: true
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            title: title
+            type: type
+            name: name
+            moderation_state: moderation_state
+            changed: changed
+          info:
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            moderation_state:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: changed
+          empty_table: true
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_revision
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          label: 'Content type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        moderation_state:
+          id: moderation_state
+          table: node_field_revision
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Moderation state'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: content_moderation_state
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          plugin_id: field
+        changed:
+          id: changed
+          table: node_field_revision
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+        operations:
+          id: operations
+          table: node_revision
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: node
+          plugin_id: entity_operations
+      filters:
+        latest_translation_affected_revision:
+          id: latest_translation_affected_revision
+          table: node_revision
+          field: latest_translation_affected_revision
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: latest_translation_affected_revision
+        title:
+          id: title
+          table: node_field_revision
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_op
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        moderation_state:
+          id: moderation_state
+          table: node_field_revision
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            editorial-draft: editorial-draft
+            editorial-archived: editorial-archived
+          group: 1
+          exposed: true
+          expose:
+            operator_id: moderation_state_op
+            label: 'Moderation state'
+            description: ''
+            use_operator: false
+            operator: moderation_state_op
+            identifier: moderation_state
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: true
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: moderation_state_filter
+        langcode:
+          id: langcode
+          table: node_field_revision
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        moderation_state_1:
+          id: moderation_state_1
+          table: node_field_revision
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not in'
+          value:
+            editorial-published: editorial-published
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: moderation_state_filter
+      sorts: {  }
+      title: 'Moderated content'
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No moderated content available. Only pending versions of content, such as drafts, are listed here.'
+          plugin_id: text_custom
+      relationships:
+        nid:
+          id: nid
+          table: node_field_revision
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: 'Get the actual content from a content revision.'
+          required: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+        uid:
+          id: uid
+          table: node_field_revision
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  moderated_content:
+    display_plugin: page
+    id: moderated_content
+    display_title: 'Moderated content'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/moderated
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/workflows.workflow.announcement.yml
+++ b/config/workflows.workflow.announcement.yml
@@ -1,0 +1,57 @@
+uuid: 4623b658-0f0f-47e7-97fa-3c4df0f59aa2
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+  module:
+    - content_moderation
+id: announcement
+label: Announcement
+type: content_moderation
+type_settings:
+  states:
+    archive:
+      published: false
+      default_revision: true
+      label: Archived
+      weight: 2
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    archive:
+      label: Archive
+      from:
+        - archive
+        - draft
+        - published
+      to: archive
+      weight: 2
+    draft:
+      label: 'Save as Draft'
+      from:
+        - archive
+        - draft
+        - published
+      to: draft
+      weight: 0
+    published:
+      label: Publish
+      from:
+        - archive
+        - draft
+        - published
+      to: published
+      weight: 1
+  entity_types:
+    node:
+      - announcement
+  default_moderation_state: draft

--- a/config/workflows.workflow.blog_post.yml
+++ b/config/workflows.workflow.blog_post.yml
@@ -1,0 +1,42 @@
+uuid: cb4b2c24-b1dd-41aa-9d6f-289dd2787ded
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.blog_post
+  module:
+    - content_moderation
+id: blog_post
+label: 'Blog post'
+type: content_moderation
+type_settings:
+  states:
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    draft:
+      label: 'Save as Draft'
+      from:
+        - draft
+        - published
+      to: draft
+      weight: 0
+    published:
+      label: Publish
+      from:
+        - draft
+        - published
+      to: published
+      weight: 1
+  entity_types:
+    node:
+      - blog_post
+  default_moderation_state: draft

--- a/config/workflows.workflow.book.yml
+++ b/config/workflows.workflow.book.yml
@@ -1,0 +1,42 @@
+uuid: aca5bd31-efc3-47e2-82c5-6bfdf417e9e2
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.book
+  module:
+    - content_moderation
+id: book
+label: 'Book page'
+type: content_moderation
+type_settings:
+  states:
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    draft:
+      label: 'Save as Draft'
+      from:
+        - draft
+        - published
+      to: draft
+      weight: 0
+    published:
+      label: Publish
+      from:
+        - draft
+        - published
+      to: published
+      weight: 1
+  entity_types:
+    node:
+      - book
+  default_moderation_state: draft

--- a/config/workflows.workflow.country.yml
+++ b/config/workflows.workflow.country.yml
@@ -1,0 +1,62 @@
+uuid: f33f0b79-f497-4d84-9647-9896416f0ce2
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.country
+  module:
+    - content_moderation
+id: country
+label: Country
+type: content_moderation
+type_settings:
+  states:
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    normal:
+      published: true
+      default_revision: true
+      label: Normal
+      weight: 2
+    ongoing:
+      published: true
+      default_revision: true
+      label: Ongoing
+      weight: 3
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    draft:
+      label: 'Save as Draft'
+      from:
+        - draft
+        - normal
+        - ongoing
+      to: draft
+      weight: -2
+    normal:
+      label: 'Save as Normal'
+      from:
+        - draft
+        - normal
+        - ongoing
+      to: normal
+      weight: -1
+    ongoing:
+      label: 'Save as Ongoing'
+      from:
+        - draft
+        - normal
+        - ongoing
+      to: ongoing
+      weight: 0
+  entity_types:
+    taxonomy_term:
+      - country
+  default_moderation_state: normal

--- a/config/workflows.workflow.disaster.yml
+++ b/config/workflows.workflow.disaster.yml
@@ -1,0 +1,139 @@
+uuid: b1ab62d4-a5b1-4e2e-970c-02414f4a616b
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.disaster
+  module:
+    - content_moderation
+id: disaster
+label: Disaster
+type: content_moderation
+type_settings:
+  states:
+    alert:
+      published: true
+      default_revision: true
+      label: Alert
+      weight: 2
+    alert_archive:
+      published: false
+      default_revision: true
+      label: 'Alert Archive'
+      weight: 6
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    draft_archive:
+      published: false
+      default_revision: true
+      label: 'Draft Archive'
+      weight: 5
+    external:
+      published: true
+      default_revision: true
+      label: External
+      weight: 7
+    external_archive:
+      published: false
+      default_revision: true
+      label: 'External Archive'
+      weight: 8
+    ongoing:
+      published: true
+      default_revision: true
+      label: Ongoing
+      weight: 3
+    past:
+      published: true
+      default_revision: true
+      label: 'Past Disaster'
+      weight: 4
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    alert:
+      label: 'Save as Alert'
+      from:
+        - alert
+        - alert_archive
+        - draft
+        - draft_archive
+        - external
+        - external_archive
+        - ongoing
+        - past
+      to: alert
+      weight: -3
+    archive_alert:
+      label: 'Archive Alert'
+      from:
+        - alert
+      to: alert_archive
+      weight: 1
+    archive_draft:
+      label: 'Archive Draft'
+      from:
+        - draft
+      to: draft_archive
+      weight: 0
+    archive_external:
+      label: 'Archive External'
+      from:
+        - external
+      to: external_archive
+      weight: 3
+    archive_ongoing:
+      label: 'Archive Ongoing'
+      from:
+        - ongoing
+      to: past
+      weight: 2
+    draft:
+      label: 'Save as Draft'
+      from:
+        - alert
+        - alert_archive
+        - draft
+        - draft_archive
+        - external
+        - external_archive
+        - ongoing
+        - past
+      to: draft
+      weight: -4
+    external:
+      label: 'Save as External'
+      from:
+        - alert
+        - alert_archive
+        - draft
+        - draft_archive
+        - external
+        - external_archive
+        - ongoing
+        - past
+      to: external
+      weight: -1
+    ongoing:
+      label: 'Save as Ongoing'
+      from:
+        - alert
+        - alert_archive
+        - draft
+        - draft_archive
+        - external
+        - external_archive
+        - ongoing
+        - past
+      to: ongoing
+      weight: -2
+  entity_types:
+    taxonomy_term:
+      - disaster
+  default_moderation_state: draft

--- a/config/workflows.workflow.job.yml
+++ b/config/workflows.workflow.job.yml
@@ -1,0 +1,114 @@
+uuid: e1ab65a5-debf-44c7-9a27-b73a7cf3cbad
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.job
+  module:
+    - content_moderation
+id: job
+label: Job
+type: content_moderation
+type_settings:
+  states:
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    duplicate:
+      published: false
+      default_revision: true
+      label: Duplicate
+      weight: 5
+    expired:
+      published: false
+      default_revision: true
+      label: Expired
+      weight: 6
+    on_hold:
+      published: false
+      default_revision: true
+      label: On-hold
+      weight: 3
+    pending:
+      published: false
+      default_revision: true
+      label: Pending
+      weight: 2
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+    refused:
+      published: false
+      default_revision: true
+      label: Refused
+      weight: 4
+  transitions:
+    draft:
+      label: 'Save as Draft'
+      from:
+        - draft
+        - on_hold
+        - pending
+      to: draft
+      weight: 0
+    duplicate:
+      label: 'Mark as Duplicate'
+      from:
+        - draft
+        - duplicate
+        - on_hold
+        - pending
+        - published
+        - refused
+      to: duplicate
+      weight: 5
+    expired:
+      label: 'Mark as Expired'
+      from:
+        - published
+      to: expired
+      weight: 6
+    on_hold:
+      label: 'Put on-hold'
+      from:
+        - draft
+        - on_hold
+        - pending
+        - published
+      to: on_hold
+      weight: 3
+    pending:
+      label: 'Save as Pending'
+      from:
+        - draft
+        - on_hold
+        - pending
+      to: pending
+      weight: 2
+    published:
+      label: Publish
+      from:
+        - on_hold
+        - pending
+        - published
+      to: published
+      weight: 1
+    refused:
+      label: Refuse
+      from:
+        - draft
+        - duplicate
+        - on_hold
+        - pending
+        - published
+        - refused
+      to: refused
+      weight: 4
+  entity_types:
+    node:
+      - job
+  default_moderation_state: draft

--- a/config/workflows.workflow.report.yml
+++ b/config/workflows.workflow.report.yml
@@ -1,0 +1,162 @@
+uuid: 6e2d898b-dcf2-4e74-970c-32d96b8e1a4d
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.report
+  module:
+    - content_moderation
+id: report
+label: Report
+type: content_moderation
+type_settings:
+  states:
+    archive:
+      published: false
+      default_revision: true
+      label: Archived
+      weight: 6
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    duplicate:
+      published: false
+      default_revision: true
+      label: Duplicate
+      weight: 4
+    embargoed:
+      published: false
+      default_revision: true
+      label: Embargoed
+      weight: 5
+    on_hold:
+      published: false
+      default_revision: true
+      label: On-hold
+      weight: 2
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+    reference:
+      published: false
+      default_revision: true
+      label: Reference
+      weight: 7
+    to_review:
+      published: true
+      default_revision: true
+      label: 'To review'
+      weight: 3
+  transitions:
+    archived:
+      label: Archive
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: archive
+      weight: 2
+    draft:
+      label: 'Save as Draft'
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: draft
+      weight: -4
+    duplicate:
+      label: 'Mark as duplicate'
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: duplicate
+      weight: 0
+    embargoed:
+      label: 'Save as Embargoed'
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: embargoed
+      weight: 1
+    on_hold:
+      label: 'Put on-hold'
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: on_hold
+      weight: -1
+    published:
+      label: Publish
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: published
+      weight: -2
+    reference:
+      label: 'Save as reference'
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: reference
+      weight: 3
+    to_review:
+      label: 'To review'
+      from:
+        - archive
+        - draft
+        - duplicate
+        - embargoed
+        - on_hold
+        - published
+        - reference
+        - to_review
+      to: to_review
+      weight: -3
+  entity_types:
+    node:
+      - report
+  default_moderation_state: draft

--- a/config/workflows.workflow.source.yml
+++ b/config/workflows.workflow.source.yml
@@ -1,0 +1,119 @@
+uuid: c4ec4234-f641-4931-9af7-01bbe5c040b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.source
+  module:
+    - content_moderation
+id: source
+label: Source
+type: content_moderation
+type_settings:
+  states:
+    active:
+      published: true
+      default_revision: true
+      label: Active
+      weight: 2
+    archive:
+      published: false
+      default_revision: true
+      label: Archive
+      weight: 4
+    blocked:
+      published: false
+      default_revision: true
+      label: Blocked
+      weight: 5
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    duplicate:
+      published: false
+      default_revision: true
+      label: Duplicate
+      weight: 6
+    inactive:
+      published: true
+      default_revision: true
+      label: Inactive
+      weight: 3
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    active:
+      label: 'Save as Active'
+      from:
+        - active
+        - archive
+        - blocked
+        - draft
+        - duplicate
+        - inactive
+      to: active
+      weight: 1
+    archive:
+      label: Archive
+      from:
+        - active
+        - archive
+        - blocked
+        - draft
+        - duplicate
+        - inactive
+      to: archive
+      weight: 3
+    blocked:
+      label: Block
+      from:
+        - active
+        - archive
+        - blocked
+        - draft
+        - duplicate
+        - inactive
+      to: blocked
+      weight: 4
+    draft:
+      label: 'Save as Draft'
+      from:
+        - active
+        - archive
+        - blocked
+        - draft
+        - duplicate
+        - inactive
+      to: draft
+      weight: 0
+    duplicate:
+      label: 'Mark as Duplicate'
+      from:
+        - active
+        - archive
+        - blocked
+        - draft
+        - duplicate
+        - inactive
+      to: duplicate
+      weight: 5
+    inactive:
+      label: 'Save as Inactive'
+      from:
+        - active
+        - archive
+        - blocked
+        - draft
+        - duplicate
+        - inactive
+      to: inactive
+      weight: 2
+  entity_types:
+    taxonomy_term:
+      - source
+  default_moderation_state: active

--- a/config/workflows.workflow.topic.yml
+++ b/config/workflows.workflow.topic.yml
@@ -1,0 +1,42 @@
+uuid: 24124a88-35a9-48d2-b4cf-649fcdfbe23b
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.topic
+  module:
+    - content_moderation
+id: topic
+label: Topic
+type: content_moderation
+type_settings:
+  states:
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    draft:
+      label: 'Save as Draft'
+      from:
+        - draft
+        - published
+      to: draft
+      weight: 0
+    published:
+      label: Publish
+      from:
+        - draft
+        - published
+      to: published
+      weight: 1
+  entity_types:
+    node:
+      - topic
+  default_moderation_state: draft

--- a/config/workflows.workflow.training.yml
+++ b/config/workflows.workflow.training.yml
@@ -1,0 +1,114 @@
+uuid: 343312b6-cb79-46c8-b334-807e0c384502
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.training
+  module:
+    - content_moderation
+id: training
+label: Training
+type: content_moderation
+type_settings:
+  states:
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    duplicate:
+      published: false
+      default_revision: true
+      label: Duplicate
+      weight: 5
+    expired:
+      published: false
+      default_revision: true
+      label: Expired
+      weight: 6
+    on_hold:
+      published: false
+      default_revision: true
+      label: On-hold
+      weight: 3
+    pending:
+      published: false
+      default_revision: true
+      label: Pending
+      weight: 2
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+    refused:
+      published: false
+      default_revision: true
+      label: Refused
+      weight: 4
+  transitions:
+    draft:
+      label: 'Save as Draft'
+      from:
+        - draft
+        - on_hold
+        - pending
+      to: draft
+      weight: 0
+    duplicate:
+      label: 'Mark as Duplicate'
+      from:
+        - draft
+        - duplicate
+        - on_hold
+        - pending
+        - published
+        - refused
+      to: duplicate
+      weight: 5
+    expired:
+      label: 'Mark as Expired'
+      from:
+        - published
+      to: expired
+      weight: 6
+    on_hold:
+      label: 'Put on-hold'
+      from:
+        - draft
+        - on_hold
+        - pending
+        - published
+      to: on_hold
+      weight: 3
+    pending:
+      label: 'Save as Pending'
+      from:
+        - draft
+        - on_hold
+        - pending
+      to: pending
+      weight: 2
+    published:
+      label: Publish
+      from:
+        - on_hold
+        - pending
+        - published
+      to: published
+      weight: 1
+    refused:
+      label: Refuse
+      from:
+        - draft
+        - duplicate
+        - on_hold
+        - pending
+        - published
+        - refused
+      to: refused
+      weight: 4
+  entity_types:
+    node:
+      - training
+  default_moderation_state: draft

--- a/patches/core--drupal--3047110-taxonomy-term-moderation-class.patch
+++ b/patches/core--drupal--3047110-taxonomy-term-moderation-class.patch
@@ -1,0 +1,21 @@
+diff --git a/core/modules/taxonomy/taxonomy.module b/core/modules/taxonomy/taxonomy.module
+index 34dd8bcc6f..501874d5bd 100644
+--- a/core/modules/taxonomy/taxonomy.module
++++ b/core/modules/taxonomy/taxonomy.module
+@@ -48,16 +48,6 @@ function taxonomy_help($route_name, RouteMatchInterface $route_match) {
+   }
+ }
+ 
+-/**
+- * Implements hook_entity_type_alter().
+- */
+-function taxonomy_entity_type_alter(array &$entity_types) {
+-  // @todo Moderation is disabled for taxonomy terms until integration is
+-  //   enabled for them.
+-  //   @see https://www.drupal.org/project/drupal/issues/3047110
+-  $entity_types['taxonomy_term']->setHandlerClass('moderation', '');
+-}
+-
+ /**
+  * Entity URI callback.
+  */


### PR DESCRIPTION
Ticket: RW-26

This enables the `content_moderation` module and adds workflows with moderation statuses to the relevant nodes and terms.