### PR TITLE
[RW-32] Country/disaster rivers

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Template\Attribute;
 
 /**
  * Implements hook_entity_bundle_info_alter().
@@ -41,7 +42,10 @@ function reliefweb_entities_theme() {
   return [
     'reliefweb_entities_sectioned_content' => [
       'variables' => [
+        // Section heading level.
         'level' => 2,
+        // Section attributes.
+        'attributes' => new Attribute(),
         // This is the table of content which is a render array using the
         // reliefweb_entities_table_of_contents theme.
         'contents' => NULL,
@@ -51,9 +55,16 @@ function reliefweb_entities_theme() {
     ],
     'reliefweb_entities_table_of_contents' => [
       'variables' => [
+        // Section headling level.
         'level' => 2,
+        // Section id.
         'id' => 'table-of-contents',
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
         'title' => t('Table of Content'),
+        // Section title attributes.
+        'title_attributes' => new Attribute(),
         // List of sections grouped by category. Each category has a title and
         // a list of sub-sections which are an array keyed by ids (to use for
         // anchors) and with the sub-section titles are values.
@@ -62,6 +73,8 @@ function reliefweb_entities_theme() {
     ],
     'reliefweb_entities_entity_country_slug' => [
       'variables' => [
+        // Wrapper attributes.
+        'attributes' => new Attribute(),
         // List of countries with the a url to either the country page or the
         // river filtered by the country, a name and a shortname.
         'countries' => [],
@@ -69,6 +82,8 @@ function reliefweb_entities_theme() {
     ],
     'reliefweb_entities_entity_meta' => [
       'variables' => [
+        // Wrapper attributes.
+        'attributes' => new Attribute(),
         // List of meta information for an article (ex: dates, sources etc.).
         // Each meta data has the following properties: type (simple, date,
         // date-range or taglist), label, value (simple, date, array with start
@@ -79,27 +94,48 @@ function reliefweb_entities_theme() {
     ],
     'reliefweb_entities_entity_description' => [
       'variables' => [
+        // Section heading level.
         'level' => 2,
+        // Section id.
         'id' => 'description',
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
         'title' => t('Description'),
+        // Section title attributes.
+        'title_attributes' => new Attribute(),
         // The description shold be a safe HTML string.
         'description' => '',
       ],
     ],
     'reliefweb_entities_entity_details' => [
       'variables' => [
+        // Section heading level.
         'level' => 2,
+        // Section id.
         'id' => 'details',
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
         'title' => t('Details'),
+        // Section title attributes.
+        'title_attributes' => new Attribute(),
         // Meta information, see "reliefweb_entities_entity_meta" above.
         'meta' => '',
       ],
     ],
     'reliefweb_entities_entity_social_media_links' => [
       'variables' => [
+        // Section heading level.
         'level' => 2,
+        // Section id.
         'id' => 'social-media',
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
         'title' => t('Social Media'),
+        // Section title attributes.
+        'title_attributes' => new Attribute(),
         // List of social media links with a url and title.
         'links' => [],
       ],

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-country-slug.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-country-slug.html.twig
@@ -5,6 +5,7 @@
  * Template file for the country slug of an entity.
  *
  * Available variables:
+ * - attributes: wrapper attributes
  * - countries: list of countries with the following properties:
  *   - url: url to either the country page or the river filtered by the country
  *   - name: country name
@@ -17,9 +18,7 @@
 {% endblock %}
 
 {% if countries %}
-  {% block wrapper %}
-    <p class="rw-entity-country-slug">
-  {% endblock %}
+<p{{ attributes.addClass('rw-entity-country-slug') }}>
   {% for item in countries|taglist(1, 'shortname') %}
     <a class="rw-entity-country-slug__link" href="{{ item.url }}">{{ item.shortname ?? item.name }}</a>
   {% endfor %}

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-description.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-description.html.twig
@@ -7,17 +7,23 @@
  * Available variables;
  * - level: heading level (defaults to 2)
  * - id: section id
+ * - attributes: section attributes
  * - title: section title
+ * - title_attributes: section title attributes
  * - description: entity description in HTML.
  */
 
 #}
-<section{{ create_attribute()
+<section{{ attributes
   .addClass([
     'rw-entity-description',
   ])
   .setAttribute('id', id)
 }}>
-<h{{ level }} class="rw-entity-description__title">{{ title }}</h{{ level }}>
+<h{{ level }}{{ title_attributes
+  .addClass([
+    'rw-entity-description__title'
+  ])
+}}>{{ title }}</h{{ level }}>
 <div class="rw-entity-description__text">{{ description|raw }}</div>
 </section>

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-details.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-details.html.twig
@@ -7,7 +7,9 @@
  * Available variables:
  * - level: headling leve (defaults to 2)
  * - id: section id
+ * - attributes: section attributes
  * - title: section title
+ * - title_attributes: section title attributes
  * - meta: associative array with a list of meta information (ex: dates,
  *   sources, etc.). Each items has the following properties:
  *   - type: simple, date, date-range or taglist
@@ -18,13 +20,17 @@
  */
 
 #}
-<section{{ create_attribute()
+<section{{ attributes
   .addClass([
     'rw-entity-details',
   ])
   .setAttribute('id', id)
 }}>
-  <h{{ level }} class="rw-entity-details__title">{{ title }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-entity-details__title'
+    ])
+  }}>{{ title }}</h{{ level }}>
 
   {{ render_var({
     '#theme': 'reliefweb_entities_entity_meta',

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-meta.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-meta.html.twig
@@ -4,7 +4,8 @@
  * @file
  * Template file for an entity meta information.
  *
- * Available variables;
+ * Available variables:
+ * - atreibutes: wrapper attributes
  * - meta: associative array with a list of meta information (ex: dates,
  *   sources, etc.). Each items has the following properties:
  *   - type: simple, link, date, date-range or taglist
@@ -22,7 +23,11 @@
 {% block library %}
 {% endblock %}
 
-<dl class="rw-meta rw-article-meta">
+<dl{{ attributes
+  .addClass([
+    'rw-entity-meta',
+  ])
+}}>
   {% set meta = meta|filter(data => data.value is not empty) %}
   {% set last = meta|keys|last %}
 

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-social-media-links.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-social-media-links.html.twig
@@ -8,17 +8,24 @@
  * Available variables:
  * - level: headling leve (defaults to 2)
  * - id: section id
+ * - attributes: section attributes
  * - title: section title
+ * - title_attributes: section title attributes
  * - links: list of social media links with a url and a title
 
 #}
-<section{{ create_attribute()
+<section{{ attributes
   .addClass([
     'rw-entity-social-media-links',
   ])
   .setAttribute('id', id)
 }}>
-  <h{{ level }} class="rw-entity-social-media-links__title">{{ title }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-entity-social-media-links__title',
+    ])
+  }}>{{ title }}</h{{ level }}>
+
   <ul class="rw-entity-social-media-links__list">
   {% for link in links %}
     <li class="rw-entity-social-media-links__list_item">

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-sectioned-content.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-sectioned-content.html.twig
@@ -14,7 +14,7 @@
 {# Propagrate the heading level. #}
 {% set contents = contents|merge({'#level': level}) %}
 {% set sections = sections|map(section => section|merge({'#level': level})) %}
-<div class="rw-sectioned-content">
+<div{{ attributes.addClass('rw-sectioned-content') }}>
 {{ contents }}
 {{ sections }}
 </div>

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-table-of-contents.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-table-of-contents.html.twig
@@ -8,7 +8,9 @@
  * - level: heading level (defaults to 2)
  * - id: section id (defaults to 'digital-sitrep')
  * - langcode: language iso 2 code (defaults to 'en')
+ * - attributes: section attributes
  * - title: table of content's title (defaults to 'Table of Content')
+ * - title_attributes: section title attributes
  * - sections: list of sections of the table of content. Eache section has a
  *   title and a list of sub-sections with ids as keys and titles as values.
  *
@@ -17,13 +19,18 @@
  */
 
  #}
-<nav{{ create_attribute()
+<nav{{ attributes
   .setAttribute('id', id)
   .addClass([
     'rw-toc',
   ])
 }} >
-  <h{{ level }} class="rw-toc__title">{{ title }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-toc__title'
+    ])
+  }}>{{ title }}</h{{ level }}>
+
   <ul>
   {%- for section in sections -%}
     <li class="rw-toc__section">

--- a/html/modules/custom/reliefweb_homepage/reliefweb_homepage.module
+++ b/html/modules/custom/reliefweb_homepage/reliefweb_homepage.module
@@ -5,6 +5,8 @@
  * Module file for the ReliefWeb Homepage module.
  */
 
+use Drupal\Core\Template\Attribute;
+
 /**
  * Implements hook_theme().
  */
@@ -12,22 +14,50 @@ function reliefweb_homepage_theme() {
   return [
     'reliefweb_homepage' => [
       'variables' => [
+        // Page title.
         'title' => t('ReliefWeb'),
+        // Title attributes.
+        'title_attributes' => new Attribute(),
+        // List of sections constituing the homepage's content.
         'sections' => [],
       ],
     ],
     'reliefweb_homepage_opportunities' => [
       'variables' => [
+        // Section heading level.
         'level' => 2,
+        // Section id.
         'id' => '',
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
+        'title' => t('Opportunities'),
+        // Section title attributes.
+        'title_attributes' => new Attribute(),
+        // Associative array keyed by type (job, training) and with the
+        // following properties:
+        // - type: job, training
+        // - url: url to the corresponding river
+        // - total: total number of opportunities for this type
+        // - title: label for the number of opportunities.
         'opportunities' => [],
       ],
     ],
     'reliefweb_homepage_announcement' => [
       'variables' => [
+        // Section heading level.
         'level' => 2,
+        // Section id.
         'id' => '',
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
+        'title' => t('Annoucement'),
+        // Section title attributes.
+        'title_attributes' => new Attribute(),
+        // Announcement URL.
         'url' => '',
+        // Announcement banner image.
         'image' => [
           'url' => '',
           'title' => '',

--- a/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-announcement.html.twig
+++ b/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-announcement.html.twig
@@ -7,6 +7,9 @@
  * Available variables:
  * - lavel: heading level (defaults to 2)
  * - id: id of the section (default to 'announcement')
+ * - attributes: section attributes
+ * - title: section title
+ * - title_attributes: section title attributes
  * - url: URL to the page the announcement links to
  * - image: array with a url, title, alt, width and height
  *
@@ -18,13 +21,21 @@
 {% block library %}
 {% endblock %}
 
-<section{{ create_attribute()
+{% set title = title ? title : 'Announcement'|t %}
+
+<section{{ attributes
   .setAttribute('id', id)
   .addClass([
     'rw-homepage-announcement',
   ])
 }}>
-  <h{{ level }} class="rw-homepage-announcement__title visually-hidden">{{ 'Announcement'|t }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-homepage-announcement__title',
+      'visually-hidden'
+    ])
+  }}>{{ title }}</h{{ level }}>
+
   <a class="rw-homepage-announcement__link" href="{{ url }}" target="_blank" rel="noopener">
     {{ render_var({
       '#theme': 'image_style',

--- a/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-opportunities.html.twig
+++ b/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-opportunities.html.twig
@@ -7,6 +7,9 @@
  * Available variables:
  * - level: heading level (defaults to 2)
  * - id: section id
+ * - attributes: section attributes
+ * - title: section title
+ * - title_attributes: section title attributes
  * - opportunities: associative array keyed by type (job, training) and with
  *   the following properties:
  *   - type: job, training
@@ -19,13 +22,20 @@
 {% block library %}
 {% endblock %}
 
-<section{{ create_attribute()
-  .setAttribute('id', id)
+{% set title = title ? title : 'Opportunities'|t %}
+
+<section{{ attributes
+  .setAttribute('id', id|clean_id)
   .addClass([
     'rw-homepage-opportunties',
   ])
 }}>
-  <h{{ level }} class="rw-homepage-opportunties__title">{{ 'Opportunities'|t }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-homepage-opportunties__title'
+    ])
+  }}>{{ title }}</h{{ level }}>
+
   <ul class="rw-homepage-opportunties__list">
   {% for item in opportunities %}
     <li class="rw-homepage-opportunties__list__item rw-homepage-opportunties__list__item--{{ item.type }}">

--- a/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage.html.twig
+++ b/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage.html.twig
@@ -5,6 +5,7 @@
  * Template for the ReliefWeb Homepage.
  *
  * Available variables:
+ * - attributes: wrapper attributes
  * - sections: list of sections for the page. Each section is a render array.
  */
 
@@ -13,6 +14,6 @@
 {% block library %}
 {% endblock %}
 
-<div class="rw-homepage-sections">
+<div{{ attributes.addClass('rw-homepage-sections') }}>
   {{ sections }}
 </div>

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
@@ -5,6 +5,8 @@
  * Integration of the ReliefWeb Rivers.
  */
 
+use Drupal\Core\Template\Attribute;
+
 /**
  * Implements hook_theme().
  */
@@ -16,22 +18,22 @@ function reliefweb_rivers_theme() {
         'river' => '',
         // The current river view.
         'view' => '',
+        // River attributes.
+        'attributes' => new Attribute(),
         // The river title.
         'title' => '',
-        // The article entities to display.
-        'entities' => [],
+        // River attributes.
+        'title_attributes' => new Attribute(),
         // Render array. See "reliefweb_rivers_views" below.
         'views' => [],
         // Render array. See "reliefweb_rivers_search" below.
         'search' => NULL,
-        // Render array. See "reliefweb_rivers_results" below.
-        'results' => NULL,
-        // Render array. See "reliefweb_rivers_advanced_search" below.
-        'advanced_search' => NULL,
         // Letter navigation/filtering.
         'letter_navigation' => NULL,
-        // The pager for the river.
-        'pager' => NULL,
+        // Render array. See "reliefweb_rivers_advanced_search" below.
+        'advanced_search' => NULL,
+        // Content of the river. See "reliefweb_rivers_river" below.
+        'content' => NULL,
         // Render array. See "reliefweb_rivers_links" below.
         'links' => [],
       ],
@@ -40,8 +42,12 @@ function reliefweb_rivers_theme() {
       'variables' => [
         // The headling level.
         'level' => 2,
+        // Section attributes.
+        'attributes' => new Attribute(),
         // Section title.
         'title' => t('Views'),
+        // Title attributes.
+        'title_attributes' => new Attribute(),
         // The list of alternative views for the river with url, title and
         // selected flag for each view.
         'views' => [],
@@ -51,8 +57,12 @@ function reliefweb_rivers_theme() {
       'variables' => [
         // The headling level.
         'level' => 2,
+        // Section attributes.
+        'attributes' => new Attribute(),
         // Section title.
         'title' => t('Search'),
+        // Title attributes.
+        'title_attributes' => new Attribute(),
         // The river path.
         'path' => '',
         // List (name => value) of query parameters to preserve.
@@ -63,22 +73,30 @@ function reliefweb_rivers_theme() {
         'query' => NULL,
       ],
     ],
-    'reliefweb_rivers_results' => [
+    'reliefweb_rivers_letter_navigation' => [
       'variables' => [
-        // The total number of resources matching the search query.
-        'total' => 0,
-        // The start of the result range.
-        'start' => 0,
-        // The end of the result range.
-        'end' => 0,
+        // The headling level.
+        'level' => 2,
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
+        'title' => t('Letter Navigation'),
+        // Title attributes.
+        'title_attributes' => new Attribute(),
+        // Associative array of letters with their label, url and active state.
+        'letters' => [],
       ],
     ],
     'reliefweb_rivers_advanced_search' => [
       'variables' => [
         // The headling level.
-        'level' => 3,
+        'level' => 2,
+        // Section attributes.
+        'attributes' => new Attribute(),
         // Section title.
         'title' => t('Refine the list with filters'),
+        // Title attributes.
+        'title_attributes' => new Attribute(),
         // The path to the river.
         'path' => '',
         // The sanitized advanced search parameter.
@@ -96,26 +114,6 @@ function reliefweb_rivers_theme() {
         'settings' => [],
       ],
     ],
-    'reliefweb_rivers_letter_navigation' => [
-      'variables' => [
-        // The headling level.
-        'level' => 3,
-        // Section title.
-        'title' => t('Letter Navigation'),
-        // Associative array of letters with their label, url and active state.
-        'letters' => [],
-      ],
-    ],
-    'reliefweb_rivers_links' => [
-      'variables' => [
-        // The headling level.
-        'level' => 3,
-        // Section title.
-        'title' => t('API and RSS links'),
-        // The API/RSS links for the river.
-        'links' => [],
-      ],
-    ],
     'reliefweb_rivers_river' => [
       'variables' => [
         // Heading level for the river section.
@@ -124,20 +122,40 @@ function reliefweb_rivers_theme() {
         'id' => '',
         // The API resource (ex: reports).
         'resource' => '',
+        // Section attributes.
+        'attributes' => new Attribute(),
         // Title of the river section.
-        'title' => '',
-        // The total number of entities for the river's search query.
-        'total' => 0,
+        'title' => t('List'),
+        // Title attributes.
+        'title_attributes' => new Attribute(),
+        // Results (optional). See "reliefweb_rivers_results" below.
+        'results' => NULL,
         // The article entities to display.
         'entities' => [],
-        // Array with the URL to the full river and a text.
+        // View more link (optional) URL to the full river and link text.
         'more' => NULL,
+        // Pager (optional). See "reliefweb_rivers_results" below.
+        'pager' => NULL,
+      ],
+    ],
+    'reliefweb_rivers_results' => [
+      'variables' => [
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // The total number of resources matching the search query.
+        'total' => 0,
+        // The start of the result range.
+        'start' => 0,
+        // The end of the result range.
+        'end' => 0,
       ],
     ],
     'reliefweb_rivers_river_article' => [
       'variables' => [
         // Heading level for the river article.
         'level' => 3,
+        // Article attributes.
+        'attributes' => new Attribute(),
         // The aricle entity's data as an associative array with id, bundle,
         // url, langcode, title etc.
         'entity' => NULL,
@@ -147,6 +165,8 @@ function reliefweb_rivers_theme() {
       'variables' => [
         // Heading level for the river article title.
         'level' => 3,
+        // Article title attributes.
+        'attributes' => new Attribute(),
         // Language code of the title.
         'langcode' => 'en',
         // An optional HTML safe prefix.
@@ -155,6 +175,35 @@ function reliefweb_rivers_theme() {
         'url' => '',
         // Title to the article.
         'title' => '',
+      ],
+    ],
+    'reliefweb_rivers_links' => [
+      'variables' => [
+        // The headling level.
+        'level' => 2,
+        // Section attributes.
+        'attributes' => new Attribute(),
+        // Section title.
+        'title' => t('API and RSS links'),
+        // Title attributes.
+        'title_attributes' => new Attribute(),
+        // The API/RSS links for the river.
+        'links' => [],
+      ],
+    ],
+    'reliefweb_rivers_country_list' => [
+      'variables' => [
+        // The headling level.
+        'level' => 2,
+        // Wrapper attributes.
+        'attributes' => new Attribute(),
+        // Associative array keyed by the first letters of the countries and
+        // each item is a list of countries starting with that letter. Each
+        // country has the following properties:
+        // - name: country name
+        // - status: country status (ongoing for humanitarian situations
+        // - url: url to the country page.
+        'groups' => [],
       ],
     ],
   ];

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
@@ -5,6 +5,20 @@ reliefweb_rivers.blog_post.river:
     _controller: 'reliefweb_rivers.blog_post.river:getPageContent'
   requirements:
     _permission: 'access content'
+reliefweb_rivers.country.river:
+  path: '/countries'
+  defaults:
+    _title: 'Countries'
+    _controller: 'reliefweb_rivers.country.river:getPageContent'
+  requirements:
+    _permission: 'access content'
+reliefweb_rivers.disaster.river:
+  path: '/disasters'
+  defaults:
+    _title: 'Disasters'
+    _controller: 'reliefweb_rivers.disaster.river:getPageContent'
+  requirements:
+    _permission: 'access content'
 reliefweb_rivers.job.river:
   path: '/jobs'
   defaults:

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -151,20 +151,15 @@ abstract class RiverServiceBase implements RiverServiceInterface {
    * {@inheritdoc}
    */
   public function getPageContent() {
-    // Get the resources for the search query.
-    $entities = $this->getApiData($this->limit);
-
     return [
       '#theme' => 'reliefweb_rivers_page',
       '#river' => $this->river,
       '#title' => $this->getPageTitle(),
       '#view' => $this->getSelectedView(),
-      '#entities' => $entities,
       '#views' => $this->getRiverViews(),
       '#search' => $this->getRiverSearch(),
       '#advanced_search' => $this->getRiverAdvancedSearch(),
-      '#results' => $this->getRiverResults(count($entities)),
-      '#pager' => $this->getRiverPager(),
+      '#content' => $this->getRiverContent(),
       '#links' => $this->getRiverLinks(),
     ];
   }
@@ -307,6 +302,23 @@ abstract class RiverServiceBase implements RiverServiceInterface {
   /**
    * {@inheritdoc}
    */
+  public function getRiverContent() {
+    // Get the resources for the search query.
+    $entities = $this->getApiData($this->limit);
+
+    return [
+      '#theme' => 'reliefweb_rivers_river',
+      '#id' => 'river-list',
+      '#title' => $this->t('List'),
+      '#results' => $this->getRiverResults(count($entities)),
+      '#entities' => $entities,
+      '#pager' => $this->getRiverPager(),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getRiverResults($count) {
     $total = 0;
     $start = 0;
@@ -399,7 +411,7 @@ abstract class RiverServiceBase implements RiverServiceInterface {
     }
 
     // Retrieve the API data.
-    $data = $this->apiClient->request($this->resource, $payload);
+    $data = $this->requestApi($payload);
 
     // Skip if there is no data.
     if (empty($data)) {
@@ -411,6 +423,13 @@ abstract class RiverServiceBase implements RiverServiceInterface {
 
     // Parse the API data and return the entities.
     return $this->parseApiData($data, $view);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function requestApi(array $payload) {
+    return $this->apiClient->request($this->resource, $payload);
   }
 
   /**

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceInterface.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceInterface.php
@@ -192,6 +192,20 @@ interface RiverServiceInterface {
   public function parseApiData(array $data, $view = '');
 
   /**
+   * Perform a request against the API for the river's resource.
+   *
+   * Note: this function is simply to ease the modification of the payload
+   * by inheriting classes before the actual request.
+   *
+   * @param array $payload
+   *   Request payload.
+   *
+   * @return array|null
+   *   API response's data.
+   */
+  public function requestApi(array $payload);
+
+  /**
    * Get the ISO 639-1 language code for the entity.
    *
    * Defaults to English if not defined.

--- a/html/modules/custom/reliefweb_rivers/src/Services/CountryRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/CountryRiver.php
@@ -3,6 +3,7 @@
 namespace Drupal\reliefweb_rivers\Services;
 
 use Drupal\reliefweb_rivers\RiverServiceBase;
+use Drupal\reliefweb_utility\Helpers\LocalizationHelper;
 use Drupal\reliefweb_utility\Helpers\UrlHelper;
 
 /**
@@ -33,6 +34,11 @@ class CountryRiver extends RiverServiceBase {
   /**
    * {@inheritdoc}
    */
+  protected $limit = 1000;
+
+  /**
+   * {@inheritdoc}
+   */
   public function getPageTitle() {
     return $this->t('Countries');
   }
@@ -40,8 +46,70 @@ class CountryRiver extends RiverServiceBase {
   /**
    * {@inheritdoc}
    */
+  public function getPageContent() {
+    $content = parent::getPageContent();
+    unset($content['#search']);
+
+    // Generate the list of letters for the letter navigation.
+    $letters = [];
+    foreach ($content['#content']['#groups'] as $letter => $countries) {
+      $letters[$letter] = [
+        'label' => $letter,
+        // Internal link. See 'reliefweb-rivers-country-list.html.twig'.
+        'url' => '#group-' . $letter,
+      ];
+    }
+    $letters['all'] = [
+      'label' => $this->t('All'),
+      'url' => '#',
+    ];
+
+    $content['#letter_navigation'] = [
+      '#theme' => 'reliefweb_rivers_letter_navigation',
+      '#title' => $this->t('Jump to letter'),
+      '#letters' => $letters,
+    ];
+
+    return $content;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRiverContent() {
+    // Get the resources for the search query.
+    $entities = $this->getApiData($this->limit);
+
+    // Group the countries by first letter.
+    $groups = [];
+    foreach ($entities as $entity) {
+      $letter = mb_strtoupper(mb_substr($entity['title'], 0, 1));
+
+      $groups[$letter][] = $entity;
+    }
+
+    // Sort the countries by alpha.
+    foreach ($groups as &$countries) {
+      LocalizationHelper::collatedSort($countries, 'title');
+    }
+
+    // Sort the groups by alpha.
+    LocalizationHelper::collatedKsort($groups);
+
+    return [
+      '#theme' => 'reliefweb_rivers_country_list',
+      '#groups' => $groups,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getViews() {
-    return [];
+    return [
+      'all' => $this->t('All Countries'),
+      'ongoing' => $this->t('Humanitarian Situations'),
+    ];
   }
 
   /**
@@ -55,7 +123,29 @@ class CountryRiver extends RiverServiceBase {
    * {@inheritdoc}
    */
   public function getApiPayload($view = '') {
-    return [];
+    $payload = [
+      'fields' => [
+        'include' => [
+          'id',
+          'url_alias',
+          'name',
+          'status',
+          'iso3',
+        ],
+      ],
+    ];
+
+    // Handle the filtered selection (view).
+    switch ($view) {
+      case 'ongoing':
+        $payload['filter'] = [
+          'field' => 'status',
+          'value' => 'current',
+        ];
+        break;
+    }
+
+    return $payload;
   }
 
   /**

--- a/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
@@ -35,6 +35,11 @@ class SourceRiver extends RiverServiceBase {
   /**
    * {@inheritdoc}
    */
+  protected $limit = 40;
+
+  /**
+   * {@inheritdoc}
+   */
   public function getPageTitle() {
     return $this->t('Organizations');
   }
@@ -56,23 +61,14 @@ class SourceRiver extends RiverServiceBase {
       $letters['all']['active'] = TRUE;
     }
 
-    // Get the resources for the search query.
-    $entities = $this->getApiData($this->limit);
-
-    return [
-      '#theme' => 'reliefweb_rivers_page',
-      '#river' => $this->river,
-      '#title' => $this->getPageTitle(),
-      '#entities' => $entities,
-      '#search' => $this->getRiverSearch(),
-      '#results' => $this->getRiverResults(count($entities)),
-      '#letter_navigation' => [
-        '#theme' => 'reliefweb_rivers_letter_navigation',
-        '#title' => $this->t('Filter by first letter'),
-        '#letters' => $letters,
-      ],
-      '#pager' => $this->getRiverPager(),
+    $content = parent::getPageContent();
+    $content['#letter_navigation'] = [
+      '#theme' => 'reliefweb_rivers_letter_navigation',
+      '#title' => $this->t('Filter by first letter'),
+      '#letters' => $letters,
     ];
+
+    return $content;
   }
 
   /**

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-advanced-search.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-advanced-search.html.twig
@@ -5,8 +5,10 @@
  * Template for the river advanced-search.
  *
  * Available variables:
- * - level: headling level (defaults to 3)
+ * - level: headling level (defaults to 2)
+ * - attributes: section attributes
  * - title: section title
+ * - title_attributes: title attributes
  * - path: the path to the river
  * - parameter: the sanitized advanced search parameter
  * - selection: the selected filters
@@ -27,17 +29,20 @@
 
 {# Attributes for the section. #}
 {%
-  set attributes = create_attribute()
-    .addClass(['rw-advanced-search'])
-    .setAttribute('id', 'river-advanced-search')
-    .setAttribute('data-advanced-mode', true)
-%}
-{%
   set attributes = selection is empty ? attributes.setAttribute('data-empty', '') : attributes
 %}
 
-<section{{ attributes }}>
-  <h{{ level }} id="river-advanced-search-title" class="rw-advanced-search__title">{{ title }}</h{{ level }}>
+<section{{ attributes
+  .addClass(['rw-advanced-search'])
+  .setAttribute('id', 'river-advanced-search')
+  .setAttribute('data-advanced-mode', true)
+}}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-advanced-search__title'
+    ])
+    .setAttribute('id', 'river-advanced-search-title')
+  }}>{{ title }}</h{{ level }}>
 
   <a href="/search-help" target="_blank" class="rw-advanced-search__help">{{ 'Search help'|t }}</a>
 

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-country-list.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-country-list.html.twig
@@ -1,0 +1,46 @@
+{#
+
+/**
+ * @file
+ * Template file for the country list for the country river page.
+ *
+ * Available variables;
+ * - level: heading level (defaults to 2)
+ * - attributes: wrapper list attributes
+ * - groups: associative array keyed by the first letters of the countries and
+ *   each item is a list of countries starting with that letter. Each country
+ *   has the following properties:
+ *   - name: country name
+ *   - status: country status (ongoing for humanitarian situations
+ *   - url: url to the country page
+ */
+
+#}
+
+{% block library %}
+{% endblock %}
+
+<ul{{ attributes
+  .addClass([
+    'rw-river',
+    'rw-river-country-list',
+  ])
+}}>
+  {% for letter, countries in groups %}
+  <li id="group-{{ letter }}" class="rw-river-country-list__group">
+    <h{{ level }} class="rw-river-country-list__group__title">{{ letter }}</h{{ level }}>
+    <ul class="rw-river-country-list__group__list">
+      {% set last = countries|length - 1 %}
+      {% for index, country in countries %}
+      <li{{ create_attribute()
+        .addClass([
+          'rw-river-country-list__country',
+          country.status == 'ongoing' ? 'rw-river-country-list__country--ongoing',
+          index == last ? 'rw-river-country-list__country--last',
+        ])
+      }}><a href="{{ country.url }}">{{ country.title }}</a></li>
+      {% endfor %}
+    </ul>
+  </li>
+  {% endfor %}
+</ul>

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-letter-navigation.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-letter-navigation.html.twig
@@ -7,7 +7,9 @@
  * Available variables:
  * - level: heading level (default to 3)
  * - id: section id (defaults to 'letter-navigation')
+ * - attributes: section attributes
  * - title: section title
+ * - title_attributes: title attributes
  * - letters: Associative array of letters with their label, url and active
  *   state
  */
@@ -15,7 +17,7 @@
 #}
 {% if letters is not empty %}
 {% set id = id|clean_id %}
-<nav{{ create_attribute()
+<nav{{ attributes
   .addClass([
     'rw-river-letter-navigation',
   ])
@@ -23,7 +25,14 @@
   .setAttribute('data-toggable', title)
   .setAttribute('aria-labelledby', id ~ '-title')
 }}>
-  <h{{ level }} id="{{ id ~ '-title' }}" class="reliefweb-river-letter-navigation__title visually-hidden">{{ title }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'reliefweb-river-letter-navigation__title',
+      'visually-hidden',
+    ])
+    .setAttribute('id',  id ~ '-title')
+  }}>{{ title }}</h{{ level }}>
+
   <ul class="rw-river-letter-navigation__list">
     {% for letter, data in letters %}
     <li class="rw-river-letter-navigation__list__item"><a{{ create_attribute()

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
@@ -7,59 +7,63 @@
  * Available variables:
  * - river: the river name
  * - view: the current river view
+ * - attributes: attributes for the river section
  * - title: the river title
- * - entities: list of article entities constituting the river
+ * - title_attrinutes: attributes for the river title
  * - views: list of alternative views for the river
  * - search: see reliefweb-rivers-search.html.twig
- * - results: see reliefweb-rivers-results.html.twig
- * - advanced_search: see reliefweb-rivers-advanced-search.html.twig
  * - letter_navigation: see reliefweb-rivers-letter-navigation.html.twig
- * - pager: the pager for the river
+ * - advanced_search: see reliefweb-rivers-advanced-search.html.twig
+ * - content: the content of the river
  * - links: see reliefweb-rivers-links.html.twig
+ *
+ * @todo disable the cd-page-title block on river pages.
  */
 
 #}
-<section{{ create_attribute()
+<section{{ attributes
   .addClass([
     'rw-river-page',
-    'rw-river-page--' ~ river,
-    view ? 'rw-river-page--' ~ river ~ '--' ~ view,
+    'rw-river-page--' ~ river|clean_class,
+    view ? 'rw-river-page--' ~ river|clean_class ~ '--' ~ view|clean_class,
   ])
 }}>
-  <header class="rw-river-page__header">
-    <h1 class="rw-river-page__title page-title visually-hidden">{{ title }}</h1>
+  {% block header %}
+    <header class="rw-river-page__header">
+      <h1{{ title_attributes
+        .addClass([
+          'rw-river-page__title',
+          'visually-hidden',
+        ])
+      }}>{{ title }}</h1>
 
-    {{ views }}
-  </header>
+      {{ views }}
+    </header>
+  {% endblock %}
 
-  {{ search }}
+  {% block search %}
+    {{ search }}
+  {% endblock %}
 
-  {{ letter_navigation }}
+  {% block letter_navigation %}
+    {{ letter_navigation }}
+  {% endblock %}
 
-  {# @todo review if that should/could be combined with the
-     reliefweb_rivers_river template #}
-  <section class="rw-river-page__list">
-    <h2 class="rw-river-page__list__title visually-hidden">{{ 'List'|t }}</h2>
-
-    {{ results }}
-
+  {% block advanced_search %}
     {{ advanced_search }}
+  {% endblock %}
 
-    <div class="rw-river__articles">
-      {% for entity in entities %}
-        {{ render_var({
-          '#theme': 'reliefweb_rivers_river_article__' ~ entity.bundle,
-          '#level': 3,
-          '#entity': entity,
-        }) }}
-      {% endfor %}
-    </div>
+  {% block content %}
+    {{ content|merge({
+      '#title_attributes': create_attribute().addClass('visually-hidden')
+    }) }}
+  {% endblock %}
 
-    {# @todo review if we can add some title. #}
-    {{ pager }}
-  </section>
-
-  <footer class="rw-river-page__footer">
-    {{ links }}
-  </footer>
+  {% block footer %}
+    {% if links is not empty %}
+      <footer class="rw-river-page__footer">
+        {{ links }}
+      </footer>
+    {% endif %}
+  {% endblock %}
 </section>

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-results.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-results.html.twig
@@ -5,6 +5,7 @@
  * Template for the river results.
  *
  * Available variables:
+ * - attributes: section attributes
  * - total: total number of resources matching the search query and filters
  * - start: start of the result range
  * - end: end of the result range
@@ -12,7 +13,7 @@
 
 #}
 {% spaceless %}
-<div{{ create_attribute()
+<div{{ attributes
   .addClass([
     'rw-river-results',
     total is empty ? 'rw-river-results--empty',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--blog-post.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--blog-post.html.twig
@@ -6,6 +6,7 @@
  *
  * Available variables;
  * - level: heading level (defaults to 3)
+ * - attributes: article attributes
  * - entity: the article entity's data as an associative array with notably:
  *   - url: url to the full article/page
  *   - title: article title
@@ -21,7 +22,7 @@
 {% block library %}
 {% endblock %}
 
-<article{{ create_attribute()
+<article{{ attributes
   .addClass([
     'rw-river-article',
     'rw-river-article--' ~ entity.bundle|clean_class,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
@@ -6,6 +6,7 @@
  *
  * Available variables;
  * - level: heading level (defaults to 3)
+ * - attributes: article attributes
  * - entity: the article entity's data as an associative array with notably:
  *   - url: url to the full article/page
  *   - title: article title
@@ -21,7 +22,7 @@
 {% block library %}
 {% endblock %}
 
-<article{{ create_attribute()
+<article{{ attributes
   .addClass([
     'rw-river-article',
     'rw-river-article--' ~ entity.bundle,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--job.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--job.html.twig
@@ -6,6 +6,7 @@
  *
  * Available variables;
  * - level: heading level (defaults to 3)
+ * - attributes: article attributes
  * - entity: the article entity's data as an associative array with notably:
  *   - url: url to the full article/page
  *   - title: article title
@@ -17,7 +18,7 @@
  */
 
 #}
-<article{{ create_attribute()
+<article{{ attributes
   .addClass([
     'rw-river-article',
     'rw-river-article--' ~ entity.bundle,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
@@ -6,6 +6,7 @@
  *
  * Available variables;
  * - level: heading level (defaults to 3)
+ * - attributes: article attributes
  * - entity: the article entity's data as an associative array with notably:
  *   - url: url to the full article/page
  *   - title: article title
@@ -19,7 +20,7 @@
  */
 
 #}
-<article{{ create_attribute()
+<article{{ attributes
   .addClass([
     'rw-river-article',
     'rw-river-article--' ~ entity.bundle,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--source.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--source.html.twig
@@ -6,6 +6,7 @@
  *
  * Available variables;
  * - level: heading level (defaults to 3)
+ * - attributes: article attributes
  * - entity: the article entity's data as an associative array with notably:
  *   - url: url to the full article/page
  *   - title: article title
@@ -17,7 +18,7 @@
  */
 
 #}
-<article{{ create_attribute()
+<article{{ attributes
   .addClass([
     'rw-river-article',
     'rw-river-article--' ~ entity.bundle,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--training.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--training.html.twig
@@ -6,6 +6,7 @@
  *
  * Available variables;
  * - level: heading level (defaults to 3)
+ * - attributes: article attributes
  * - entity: the article entity's data as an associative array with notably:
  *   - url: url to the full article/page
  *   - title: article title
@@ -17,7 +18,7 @@
  */
 
 #}
-<article{{ create_attribute()
+<article{{ attributes
   .addClass([
     'rw-river-article',
     'rw-river-article--' ~ entity.bundle,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article-title.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article-title.html.twig
@@ -6,6 +6,7 @@
  *
  * Available variables:
  * - level: the heading level (defaults to 3)
+ * - attributes: attributes for the heading
  * - langcode: the language of the title (defaults to 'en')
  * - prefix: an optional HTML safe prefix
  * - url: url to the article
@@ -17,7 +18,13 @@
 {% block library %}
 {% endblock %}
 
-<h{{ level }} lang="{{ langcode }}" class="rw-river-article__title">
+<h{{ level }}{{ attributes
+  .addClass([
+    'rw-river-article__title',
+    prefix ? 'rw-river-article__title--with-prefix',
+  ])
+  .setAttribute('lang', langcode)
+}}>
   {%- if prefix is not empty -%}
     <span class="rw-river-article__title__prefix">{{ prefix }}</span>
   {%- endif -%}

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article.html.twig
@@ -10,6 +10,7 @@
  *
  * Available variables;
  * - level: heading level (defaults to 3)
+ * - attributes: article attributes
  * - entity: the article entity's data as an associative array with notably:
  *   - url: url to the full article/page
  *   - title: article title
@@ -21,7 +22,7 @@
  */
 
 #}
-<article{{ create_attribute()
+<article{{ attributes
   .addClass([
     'rw-river-article',
     'rw-river-article--' ~ entity.bundle,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
@@ -7,15 +7,16 @@
  * Available variables;
  * - level: heading level (defaults to 2)
  * - id: section id (HTML safe)
+ * - attributes: attributes for the section
  * - title: section title
- * - total: total number of entities for the river search query
+ * - title_attributes: attributes for the river title
+ * - results: (optional) see reliefweb-rivers-results.html.twig
  * - entities: list of article entities constituting the river
- * - more: if defined, it's an array with URL to the main river and a text
+ * - pager: (optional) the pager for the river
+ * - more: (optional) an array with URL to the main river and a text
  *
  * @todo provide a count variable to limit the number of items to display in the
  * river? Should that be determine in a preprocess function for example?
- *
- * @todo expand this template for the main rivers or use a separate one?
  */
 
 #}
@@ -23,17 +24,19 @@
 {% block library %}
 {% endblock %}
 
-<section {{ create_attribute()
-  .setAttribute('id', id|clean_id)
+{% set id = id|clean_id %}
+<section {{ attributes
+  .setAttribute('id', id)
   .addClass([
     'rw-river',
-    'rw-river--' ~ id|clean_id,
+    'rw-river--' ~ id,
   ])
 }}>
+  <h{{ level }}{{ title_attributes.addClass([
+    'rw-river__title',
+  ]) }}>{{ title }}</h{{ level }}>
 
-  {% block heading %}
-    <h{{ level }}>{{ title }}</h{{ level }}>
-  {% endblock %}
+  {{ results }}
 
   <div class="rw-river__articles">
     {% for entity in entities %}
@@ -46,8 +49,10 @@
   </div>
 
   {% if more is not empty and more.url %}
-  <footer class="rw-river__view-more view-more">
-    <a href="{{ more.url }}">{{ more.label ?? ('View more'|t) }}</a>
-  </footer>
+    <footer class="rw-river__view-more view-more">
+      <a href="{{ more.url }}">{{ more.label ?? ('View more'|t) }}</a>
+    </footer>
+  {% elseif pager is not empty %}
+    {{ pager }}
   {% endif %}
 </section>

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search.html.twig
@@ -6,7 +6,9 @@
  *
  * Available variables:
  * - level: heading level (defaults to 2)
+ * - attributes: section attributes
  * - title: section title (defaults to 'Search')
+ * - title_attributes: section title attributes
  * - path: river path
  * - parameters: list of query parameters to preserve.
  * - label: label and placeholder for the input
@@ -19,12 +21,18 @@
 {# Attach the search library to enhance the experience. #}
 {{ attach_library('reliefweb_rivers/search') }}
 
-<section{{ create_attribute()
+<section{{ attributes
   .addClass([
     'rw-river-search',
   ])
 }}>
-  <h{{ level }} class="rw-river-search__title visually-hidden">{{ title }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-river-search__title',
+      'visually-hidden',
+    ])
+  }}>{{ title }}</h{{ level }}>
+
   <form id="river-search-form" class="rw-river-search__form" action="{{ path }}" method="GET">
     {# Store the parameters to preserve when submitting the form. #}
     {% for name, value in parameters %}

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-views.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-views.html.twig
@@ -6,7 +6,9 @@
  *
  * Available variables:
  * - level: heading level (defaults to 2)
+ * - attributes: section attributes
  * - title: section title (defaults to 'Views')
+ * - title_attributes: section title attributes
  * - views: list of alternative views for the river. Each view has:
  *   - url: URL to the river for that view
  *   - title: view title
@@ -18,13 +20,18 @@
 
 #}
 {% if views is not empty %}
-<nav{{ create_attribute()
+<nav{{ attributes
   .addClass([
     'rw-river-views',
   ])
   .setAttribute('id', 'river-views')
 }}>
-  <h{{ level }} class="rw-river-views__title visually-hidden">{{ title }}</h{{ level }}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-river-views__title',
+      'visually-hidden',
+    ])
+  }}>{{ title }}</h{{ level }}>
 
   <ul id="rw-river-views__list">
     {% for id, view in views %}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -38,11 +38,22 @@ function common_design_subtheme_preprocess_taxonomy_term(&$variables) {
  *
  * Remove the default page title and local tasks blocks if they were already
  * rendered by a page title paragraph or when viewing full article terms.
+ *
+ * Do not render the page title block on river pages as they already have a
+ * visually hidden title (the selected main menu item acts as visual cue).
  */
 function common_design_subtheme_preprocess_page(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
   // Attempt to retrieve the term entity if the current page is a term page.
-  if (\Drupal::routeMatch()->getRouteName() === 'entity.taxonomy_term.canonical') {
+  if ($route_name === 'entity.taxonomy_term.canonical') {
     $term = common_design_subtheme_get_entity_from_route('taxonomy_term');
+  }
+  // Remove the page title block on river pages.
+  elseif (preg_match('#^reliefweb_rivers\.[^\.]+\.river$#', $route_name) === 1) {
+    common_design_hide_rendered_blocks_from_page($variables, [
+      'page_title_block',
+    ]);
   }
 
   // If the term variable is defined then we assume we are on a term page.

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-country-slug.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-country-slug.html.twig
@@ -1,12 +1,10 @@
+{% set attributes = attributes.addClass(['cd-tag', 'cd-tag--linked']) %}
+
 {% embed '@reliefweb_entities/reliefweb-entities-entity-country-slug.html.twig' %}
 
   {% block library %}
     {{ attach_library('common_design/cd-tag') }}
     {{ attach_library('common_design_subtheme/rw-country') }}
-  {% endblock %}
-
-  {% block wrapper %}
-    <p class="rw-entity-country-slug cd-tag cd-tag--linked">
   {% endblock %}
 
 {% endembed %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-meta.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-meta.html.twig
@@ -1,3 +1,5 @@
+{% set attributes = attributes.addClass(['rw-meta', 'rw-article-meta']) %}
+
 {% embed '@reliefweb_entities/reliefweb-entities-entity-meta.html.twig' %}
 
   {% block library %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage-opportunities.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage-opportunities.html.twig
@@ -1,3 +1,5 @@
+{% set title_attributes = title_attributes.addClass('cd-block-title') %}
+
 {% embed '@reliefweb_homepage/reliefweb-homepage-opportunities.html.twig' %}
 
   {% block library %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
@@ -1,14 +1,11 @@
+{% set title_attributes = title_attributes.addClass('cd-block-title') %}
+
 {% embed '@reliefweb_rivers/reliefweb-rivers-river.html.twig' %}
 
   {% block library %}
     {{ attach_library('common_design/cd-block-title') }}
     {{ attach_library('common_design_subtheme/rw-headlines') }}
     {{ attach_library('common_design_subtheme/rw-view-more') }}
-  {% endblock %}
-
-
-  {% block heading %}
-    <h{{ level }} class="cd-block-title">{{ title }}</h{{ level }}>
   {% endblock %}
 
 {% endembed %}


### PR DESCRIPTION
Ticket: RW-32, RW-40, RW-42

This adds the country and disaster rivers and consolidate most of the templates, adding an "attributes" and "title_attributes" variables when relevant to help adding classes when overriding a template in the subtheme.

This also ensures the opportunities block on the homepage uses the same styling for its title (RW-40) and by adding the disasters river, the "view all disasters" is back on the homepage (RW-42)