### PR TITLE
RW-31 Adjust template overrides to use twig include instead of embed

### DIFF
--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-country-slug.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-country-slug.html.twig
@@ -13,10 +13,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 {% if countries %}
 <p{{ attributes.addClass('rw-entity-country-slug') }}>
   {% for item in countries|taglist(1, 'shortname') %}

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-meta.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-meta.html.twig
@@ -19,10 +19,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 <dl{{ attributes
   .addClass([
     'rw-entity-meta',

--- a/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-announcement.html.twig
+++ b/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-announcement.html.twig
@@ -17,10 +17,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 <section{{ attributes
   .setAttribute('id', id)
   .addClass([

--- a/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-opportunities.html.twig
+++ b/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-opportunities.html.twig
@@ -18,10 +18,6 @@
  *   - title: label for the number of opportunities
  */
 #}
-
-{% block library %}
-{% endblock %}
-
 <section{{ attributes
   .setAttribute('id', id|clean_id)
   .addClass([

--- a/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage.html.twig
+++ b/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage.html.twig
@@ -10,10 +10,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 <div{{ attributes.addClass('rw-homepage-sections') }}>
   {{ sections }}
 </div>

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-country-list.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-country-list.html.twig
@@ -16,10 +16,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 <ul{{ attributes
   .addClass([
     'rw-river',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--blog-post.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--blog-post.html.twig
@@ -18,10 +18,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 <article{{ attributes
   .addClass([
     'rw-river-article',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
@@ -18,10 +18,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 <article{{ attributes
   .addClass([
     'rw-river-article',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article-title.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article-title.html.twig
@@ -14,10 +14,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 <h{{ level }}{{ attributes
   .addClass([
     'rw-river-article__title',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
@@ -20,10 +20,6 @@
  */
 
 #}
-
-{% block library %}
-{% endblock %}
-
 {% set id = id|clean_id %}
 <section {{ attributes
   .setAttribute('id', id)

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-country-slug.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-country-slug.html.twig
@@ -1,10 +1,6 @@
 {% set attributes = attributes.addClass(['cd-tag', 'cd-tag--linked']) %}
 
-{% embed '@reliefweb_entities/reliefweb-entities-entity-country-slug.html.twig' %}
+{{ attach_library('common_design/cd-tag') }}
+{{ attach_library('common_design_subtheme/rw-country') }}
 
-  {% block library %}
-    {{ attach_library('common_design/cd-tag') }}
-    {{ attach_library('common_design_subtheme/rw-country') }}
-  {% endblock %}
-
-{% endembed %}
+{% include '@reliefweb_entities/reliefweb-entities-entity-country-slug.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-meta.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-meta.html.twig
@@ -1,9 +1,5 @@
 {% set attributes = attributes.addClass(['rw-meta', 'rw-article-meta']) %}
 
-{% embed '@reliefweb_entities/reliefweb-entities-entity-meta.html.twig' %}
+{{ attach_library('common_design_subtheme/rw-meta') }}
 
-  {% block library %}
-    {{ attach_library('common_design_subtheme/rw-meta') }}
-  {% endblock %}
-
-{% endembed %}
+{% include '@reliefweb_entities/reliefweb-entities-entity-meta.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage-announcement.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage-announcement.html.twig
@@ -1,9 +1,4 @@
-{% embed '@reliefweb_homepage/reliefweb-homepage-announcement.html.twig' %}
+{{ attach_library('common_design_subtheme/rw-announcement') }}
 
-  {% block library %}
-    {{ attach_library('common_design_subtheme/rw-announcement') }}
-  {% endblock %}
-
-{% endembed %}
-
+{% include '@reliefweb_homepage/reliefweb-homepage-announcement.html.twig' %}
 

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage-opportunities.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage-opportunities.html.twig
@@ -1,11 +1,5 @@
 {% set title_attributes = title_attributes.addClass('cd-block-title') %}
 
-{% embed '@reliefweb_homepage/reliefweb-homepage-opportunities.html.twig' %}
+{{ attach_library('common_design_subtheme/rw-opportunities') }}
 
-  {% block library %}
-    {{ attach_library('common_design_subtheme/rw-opportunities') }}
-  {% endblock %}
-
-{% endembed %}
-
-
+{% include '@reliefweb_homepage/reliefweb-homepage-opportunities.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-homepage/reliefweb-homepage.html.twig
@@ -1,7 +1,3 @@
-{% embed '@reliefweb_homepage/reliefweb-homepage.html.twig' %}
+{{ attach_library('common_design_subtheme/rw-homepage') }}
 
-  {% block library %}
-    {{ attach_library('common_design_subtheme/rw-homepage') }}
-  {% endblock %}
-
-{% endembed %}
+{% include '@reliefweb_homepage/reliefweb-homepage.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article--blog-post.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article--blog-post.html.twig
@@ -1,7 +1,3 @@
-{% embed '@reliefweb_rivers/reliefweb-rivers-river-article--blog-post.html.twig' %}
+{{ attach_library('common_design_subtheme/rw-blog') }}
 
-  {% block library %}
-    {{ attach_library('common_design_subtheme/rw-blog') }}
-  {% endblock %}
-
-{% endembed %}
+{% include '@reliefweb_rivers/reliefweb-rivers-river-article--blog-post.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article--disaster.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article--disaster.html.twig
@@ -1,7 +1,3 @@
-{% embed '@reliefweb_rivers/reliefweb-rivers-river-article--disaster.html.twig' %}
+{{ attach_library('common_design_subtheme/rw-disasters') }}
 
-  {% block library %}
-    {{ attach_library('common_design_subtheme/rw-disasters') }}
-  {% endblock %}
-
-{% endembed %}
+{% include '@reliefweb_rivers/reliefweb-rivers-river-article--disaster.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article-title.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article-title.html.twig
@@ -1,7 +1,2 @@
-{% embed '@reliefweb_rivers/reliefweb-rivers-river-article-title.html.twig' %}
-
-  {% block library %}
-    {{ attach_library('common_design_subtheme/rw-article') }}
-  {% endblock %}
-
-{% endembed %}
+{{ attach_library('common_design_subtheme/rw-article') }}
+{% include '@reliefweb_rivers/reliefweb-rivers-river-article-title.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
@@ -1,11 +1,7 @@
 {% set title_attributes = title_attributes.addClass('cd-block-title') %}
 
-{% embed '@reliefweb_rivers/reliefweb-rivers-river.html.twig' %}
+{{ attach_library('common_design/cd-block-title') }}
+{{ attach_library('common_design_subtheme/rw-headlines') }}
+{{ attach_library('common_design_subtheme/rw-view-more') }}
 
-  {% block library %}
-    {{ attach_library('common_design/cd-block-title') }}
-    {{ attach_library('common_design_subtheme/rw-headlines') }}
-    {{ attach_library('common_design_subtheme/rw-view-more') }}
-  {% endblock %}
-
-{% endembed %}
+{% include '@reliefweb_rivers/reliefweb-rivers-river.html.twig' %}


### PR DESCRIPTION
Remove twig blocks for library attachment in custom module templates
And replace the Twig embed with Twig include for sub theme template overrides