### PR TITLE
[RW-24][RW-28] Key Content, Appeals and Useful Links

### DIFF
--- a/html/modules/custom/reliefweb_api/src/Services/ReliefWebApiClient.php
+++ b/html/modules/custom/reliefweb_api/src/Services/ReliefWebApiClient.php
@@ -260,6 +260,12 @@ class ReliefWebApiClient {
               '@payload' => print_r($queries[$index]['payload'], TRUE),
             ]);
           }
+
+          // Ensure the URL aliases of the resources point to the current site.
+          // @todo remove as it's mostly for development?
+          static::updateApiAliases($data);
+
+          // Add the resulting data with same index as the query.
           $results[$index] = $data;
         }
       }
@@ -411,6 +417,26 @@ class ReliefWebApiClient {
     // not worthy.
     $tags[] = 'taxonomy_term_list';
     return $tags;
+  }
+
+  /**
+   * Update the host of the resource URL aliases.
+   *
+   * @param array $data
+   *   API data.
+   */
+  public static function updateApiAliases(array &$data) {
+    $host = \Drupal::request()->getHost();
+
+    if ($host !== 'reliefweb.int') {
+      foreach ($data['data'] as &$item) {
+        if (!empty($item['fields']['url_alias'])) {
+          $alias = $item['fields']['url_alias'];
+          $alias = str_replace('reliefweb.int', $host, $alias);
+          $item['fields']['url_alias'] = $alias;
+        }
+      }
+    }
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -139,6 +139,23 @@ function reliefweb_entities_theme() {
         'links' => [],
       ],
     ],
+    'reliefweb_entities_entity_useful_links' => [
+      'variables' => [
+        // Section heading level.
+        'level' => 2,
+        // Section id.
+        'id' => 'useful-links',
+        // Section attributes.
+        'attributes' => NULL,
+        // Section title.
+        'title' => t('Useful Links'),
+        // Section title attributes.
+        'title_attributes' => NULL,
+        // Whether to
+        // List of links.
+        'links' => [],
+      ],
+    ],
   ];
 }
 

--- a/html/modules/custom/reliefweb_entities/src/BundleEntityInterface.php
+++ b/html/modules/custom/reliefweb_entities/src/BundleEntityInterface.php
@@ -8,6 +8,14 @@ namespace Drupal\reliefweb_entities;
 interface BundleEntityInterface {
 
   /**
+   * Get the API resources for the entity bundle.
+   *
+   * @return string
+   *   API resource.
+   */
+  public function getApiResource();
+
+  /**
    * Get the content of the full entity page for the bundle.
    *
    * Note: this may differs from one bundle to another.

--- a/html/modules/custom/reliefweb_entities/src/Entity/Country.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Country.php
@@ -22,6 +22,13 @@ class Country extends Term implements BundleEntityInterface, EntityModeratedInte
   /**
    * {@inheritdoc}
    */
+  public function getApiResource() {
+    return 'countries';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getPageContent() {
     $sections = $this->getPageSections();
     $contents = $this->getPageTableOfContents();
@@ -43,14 +50,21 @@ class Country extends Term implements BundleEntityInterface, EntityModeratedInte
     $sections['digital-sitrep'] = $this->getDigitalSitrepSection();
     $sections['key-figures'] = $this->getKeyFiguresSection();
 
+    $queries = [];
+
     // Profile sections. Only display if show profile is selected.
     if (!empty($this->field_profile->value)) {
       $sections['overview'] = $this->getEntityDescription();
+      $sections['useful-links'] = $this->getUsefulLinksSection();
+
+      // Retrieve the Key Content and Appeals and Response Plans.
+      $queries['key-content'] = $this->getKeyContentApiQuery();
+      $queries['appeals-response-plans'] = $this->getAppealsResponsePlansApiQuery();
     }
 
     // Get data from the API.
     // @todo move those the Reports etc. river services.
-    $queries = [
+    $queries += [
       'most-read' => $this->getMostReadApiQuery(),
       'updates' => $this->getLatestUpdatesApiQuery(),
       'maps-infographics' => $this->getLatestMapsInfographicsApiQuery(),

--- a/html/modules/custom/reliefweb_entities/src/Entity/Source.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Source.php
@@ -24,6 +24,13 @@ class Source extends Term implements BundleEntityInterface, EntityModeratedInter
   /**
    * {@inheritdoc}
    */
+  public function getApiResource() {
+    return 'sources';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getPageContent() {
     $sections = $this->getPageSections();
     $contents = $this->getPageTableOfContents();

--- a/html/modules/custom/reliefweb_entities/src/SectionedContentInterface.php
+++ b/html/modules/custom/reliefweb_entities/src/SectionedContentInterface.php
@@ -24,17 +24,6 @@ interface SectionedContentInterface {
   public function getPageTableOfContents();
 
   /**
-   * Get the base ReliefWeb API query payload for the resource.
-   *
-   * @param string $resource
-   *   ReliefWeb API resource.
-   *
-   * @return array
-   *   API payload.
-   */
-  public function getReliefWebApiPayload($resource);
-
-  /**
    * Get the section data for the given ReliefWeb API queries.
    *
    * @param array $queries
@@ -45,23 +34,6 @@ interface SectionedContentInterface {
    *   queries keyed by section id.
    */
   public function getSectionsFromReliefWebApiQueries(array $queries);
-
-  /**
-   * Parse the data returned by the ReliefWeb API.
-   *
-   * @param string $bundle
-   *   The entity bundle for the data.
-   * @param array $data
-   *   The ReliefWeb API data.
-   * @param string $view
-   *   Current river view.
-   *
-   * @return array
-   *   List of articles to display.
-   *
-   * @see \Drupal\reliefweb_rivers\Services\RiverInterface.php
-   */
-  public function parseReliefWebApiData($bundle, array $data, $view = '');
 
   /**
    * Consolidate content sections.
@@ -80,6 +52,36 @@ interface SectionedContentInterface {
    *   Render array with the table of contents and sections.
    */
   public function consolidateSections(array $contents, array $sections, array $labels);
+
+  /**
+   * Get payload for the key content reports.
+   *
+   * @param string $code
+   *   Filter code for the river link (ex: PC if the entity is a country, or
+   *   D if it's a disaster).
+   * @param int $limit
+   *   Number of resource items to return.
+   *
+   * @return array
+   *   Query data with the API resource and payload, a callback to parse the
+   *   API data and a url to the corresponding river.
+   */
+  public function getKeyContentApiQuery($code = 'PC', $limit = 3);
+
+  /**
+   * Get payload for the appeals and response plans.
+   *
+   * @param string $code
+   *   Filter code for the river link (ex: PC if the entity is a country, or
+   *   D if it's a disaster).
+   * @param int $limit
+   *   Number of resource items to return.
+   *
+   * @return array
+   *   Query data with the API resource and payload, a callback to parse the
+   *   API data and a url to the corresponding river.
+   */
+  public function getAppealsResponsePlansApiQuery($code = 'PC', $limit = 3);
 
   /**
    * Get payload for the most read documents.
@@ -111,8 +113,6 @@ interface SectionedContentInterface {
    * @return array
    *   Query data with the API resource and payload, a callback to parse the
    *   API data and a url to the corresponding river.
-   *
-   * @todo move that to a trait or an ancestor class?
    */
   public function getLatestUpdatesApiQuery($code = 'PC', $limit = 3);
 
@@ -175,5 +175,25 @@ interface SectionedContentInterface {
    *   API data and a url to the corresponding river.
    */
   public function getLatestDisastersApiQuery($code = 'C', $limit = 100);
+
+  /**
+   * Get the section with the useful links for the entity (country/disaster).
+   *
+   * @preturn array
+   *   Render array for the useful links section.
+   */
+  public function getUsefulLinksSection();
+
+  /**
+   * Get the country/disaster profile.
+   *
+   * This includes the Key Content, Appeals and Response Plans and useful links.
+   *
+   * @see \Drupal\reliefweb_entities::getProfileFields()
+   *
+   * @todo replace API query with logic using the actual profile fields on the
+   * entity once ported.
+   */
+  public function getProfileFields();
 
 }

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-useful-links.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-useful-links.html.twig
@@ -1,0 +1,42 @@
+{#
+
+/**
+ * @file
+ * Template file for the useful links block.
+ *
+ * Available variables:
+ * - level: heading level (defaults to 2)
+ * - id: sectiond id
+ * - attributes: section attributes
+ * - title: section title
+ * - title_attributes: section title attributes
+ * - links: list of links with a URL, title and optional logo URL.
+ */
+
+ #}
+<section{{ attributes
+  .addClass([
+    'rw-entity-useful-links',
+  ])
+  .setAttribute('id', id)
+}}>
+  <h{{ level }}{{ title_attributes
+    .addClass([
+      'rw-entity-useful-links__title',
+    ])
+  }}>{{ title ?? 'Useful links'|t }}</h{{ level }}>
+
+  <ul class="rw-entity-useful-links__list">
+    {% for link in links %}
+      <li class="rw-entity-useful-links__list__item">
+        <a href="{{ link.url }}" target="_blank" rel="noopener" class="rw-entity-useful-links__link">
+        {%- if link.logo is not empty -%}
+          <img src="{{ link.logo }}" alt="{{ link.title }}" class="rw-entity-useful-links__link__logo">
+        {%- else -%}
+          {{ link.title }}
+        {%- endif -%}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</section>

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -479,4 +479,38 @@ abstract class RiverServiceBase implements RiverServiceInterface {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public static function getRiverData($bundle, array $data, $view = '', array $exclude = []) {
+    $entities = \Drupal::service('reliefweb_rivers.' . $bundle . '.river')
+      ->parseApiData($data, $view);
+
+    // If instructed so, remove some properties from the entities.
+    if (!empty($exclude)) {
+      $exclude = array_flip($exclude);
+      foreach ($entities as $index => $entity) {
+        $entities[$index] = array_diff_key($entity, $exclude);
+      }
+    }
+
+    return $entities;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getRiverApiPayload($bundle, $view = '', array $exclude = ['query']) {
+    $payload = \Drupal::service('reliefweb_rivers.' . $bundle . '.river')
+      ->getApiPayload($view);
+
+    // If instructed so, remove some properties from the payload.
+    if (!empty($exclude)) {
+      $exclude = array_flip($exclude);
+      $payload = array_diff_key($payload, $exclude);
+    }
+
+    return $payload;
+  }
+
 }

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceInterface.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceInterface.php
@@ -242,4 +242,36 @@ interface RiverServiceInterface {
    */
   public static function getRiverUrl($bundle, array $parameters = []);
 
+  /**
+   * Get the data of the river for given bundle and API data.
+   *
+   * @param string $bundle
+   *   Entity bundle of a river.
+   * @param array $data
+   *   ReliefWeb API data for the river.
+   * @param string $view
+   *   River view.
+   * @param array $exclude
+   *   Properties to exclude from the river entities.
+   *
+   * @return array
+   *   List of entities with data suitable for use in templates.
+   */
+  public static function getRiverData($bundle, array $data, $view = '', array $exclude = []);
+
+  /**
+   * Get the ReliefWeb API query payload for the bundle's river.
+   *
+   * @param string $bundle
+   *   Entity bundle of a river.
+   * @param string $view
+   *   River view.
+   * @param array $exclude
+   *   Elements to remove from the payload.
+   *
+   * @return array
+   *   ReliefWeb API payload.
+   */
+  public static function getRiverApiPayload($bundle, $view = '', array $exclude = ['query']);
+
 }

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
@@ -72,7 +72,7 @@
         },
         'source': {
           'type': 'taglist',
-          'label': entity.tags.source|length > 1 ? 'Source'|t : 'Sources'|t,
+          'label': entity.tags.source|length > 1 ? 'Sources'|t : 'Source'|t,
           'value': entity.tags.source,
           'count': 3,
           'sort': 'shortname',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
@@ -7,6 +7,7 @@
  * Available variables;
  * - level: heading level (defaults to 2)
  * - id: section id (HTML safe)
+ * - resource: the API resource type of the river's content
  * - attributes: attributes for the section
  * - title: section title
  * - title_attributes: attributes for the river title
@@ -26,6 +27,7 @@
   .addClass([
     'rw-river',
     'rw-river--' ~ id,
+    'rw-river--type-' ~ resource|clean_class,
   ])
 }}>
   <h{{ level }}{{ title_attributes.addClass([

--- a/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSanitizer.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSanitizer.php
@@ -89,9 +89,16 @@ class HtmlSanitizer {
    *   Sanitized HTML string.
    */
   public static function sanitizeFromMarkdown($text, $iframe = FALSE, $heading_offset = 2, array $allowed_attributes = []) {
+    // Add a space before the heading '#' which is fine as ReliefWeb doesn't use
+    // hash tags.
+    // @see https://talk.commonmark.org/t/heading-not-working/819/42
+    $text = preg_replace('/^(#+)(\S)/m', '$1 $2', $text);
+
+    // Convert markdown to HTML.
     // @todo add options notably to allow ID attributes.
     $converter = new CommonMarkConverter();
     $html = $converter->convertToHtml($text);
+
     return static::sanitize($html, $iframe, $heading_offset, $allowed_attributes);
   }
 


### PR DESCRIPTION
Tickets: [RW-24][RW-28]

This adds the Key Content, Appeals and Useful Links sections to the country and disaster pages. 

Note: this uses the API to get those profile fields and after the actual fields are ported, will use them.

This PR also does some code shuffling to reduce duplication by having the homepage, country and disaster pages get the API payload for their sections from the river services.

[RW-24]: https://humanitarian.atlassian.net/browse/RW-24
[RW-28]: https://humanitarian.atlassian.net/browse/RW-28