### PR TITLE
[RW-34] Add class for core meta

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -83,6 +83,10 @@ function reliefweb_entities_theme() {
       'variables' => [
         // Wrapper attributes.
         'attributes' => NULL,
+        // Flag indicating the list of meta is the "core" meta information,
+        // usually displayed in river articles or below the title on article
+        // pages.
+        'core' => TRUE,
         // List of meta information for an article (ex: dates, sources etc.).
         // Each meta data has the following properties: type (simple, date,
         // date-range or taglist), label, value (simple, date, array with start

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-meta.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-meta.html.twig
@@ -5,7 +5,9 @@
  * Template file for an entity meta information.
  *
  * Available variables:
- * - atreibutes: wrapper attributes
+ * - attributes: wrapper attributes
+ * - core: flag indicating the list of meta is the "core" meta information,
+ *   usually displayed in river articles or below the title on article pages.
  * - meta: associative array with a list of meta information (ex: dates,
  *   sources, etc.). Each items has the following properties:
  *   - type: simple, link, date, date-range or taglist
@@ -15,13 +17,14 @@
  *   - sort: only for taglist - sort property for the tags
  *
  * @todo better date formatting to respect language format.
- * @todo review the spacing.
+ * @todo review the spacing notably for single values.
  */
 
 #}
 <dl{{ attributes
   .addClass([
     'rw-entity-meta',
+    core ? 'rw-entity-meta--core',
   ])
 }}>
   {% set meta = meta|filter(data => data.value is not empty) %}


### PR DESCRIPTION
Ticket: RW-34

This adds a flag to the "entity-meta" template to add a class to distinguish the "core" meta information in river articles and below the title on article pages from the "full" meta information in the sidebar of the article pages.