### PR TITLE
[RW-60] Display river page title when there are no alternative views

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -219,6 +219,10 @@ abstract class RiverServiceBase implements RiverServiceInterface {
    */
   public function getRiverViews() {
     $views = $this->getViews();
+    if (empty($views)) {
+      return [];
+    }
+
     $view = $this->getSelectedView();
     $default = $this->getDefaultView();
 

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
@@ -32,7 +32,7 @@
     <h1{{ title_attributes
       .addClass([
         'rw-river-page__title',
-        'visually-hidden',
+        views ? 'visually-hidden',
       ])
     }}>{{ title }}</h1>
 


### PR DESCRIPTION
Ticket: RW-60

This displays the river page title when there are no `views` to ensure we know on which page we are.

Note: this PR doesn't style this page title. Follow-up ticket for that: RW-68.