### PR TITLE
[RW-59] Style active letter navigation link

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -135,6 +135,8 @@ rw-river-letter-navigation:
   css:
     theme:
       components/rw-river-letter-navigation/rw-river-letter-navigation.css: {}
+  js:
+    components/rw-river-letter-navigation/rw-river-letter-navigation.js: {}
   dependencies:
     - common_design/cd-dropdown
 

--- a/html/themes/custom/common_design_subtheme/components/rw-river-letter-navigation/rw-river-letter-navigation.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river-letter-navigation/rw-river-letter-navigation.css
@@ -29,11 +29,11 @@
   padding: 0 8px;
   min-width: 40px;
   height: 40px;
-  line-height: 2.6;
+  line-height: 40px;
   text-align: center;
   text-transform: uppercase;
 }
-#main-content .rw-river-letter-navigation li a[data-active],
+#main-content .rw-river-letter-navigation li a.rw-river-letter-navigation__link--active,
 #main-content .rw-river-letter-navigation li a:focus,
 #main-content .rw-river-letter-navigation li a:active,
 #main-content .rw-river-letter-navigation li a:hover {

--- a/html/themes/custom/common_design_subtheme/components/rw-river-letter-navigation/rw-river-letter-navigation.js
+++ b/html/themes/custom/common_design_subtheme/components/rw-river-letter-navigation/rw-river-letter-navigation.js
@@ -6,7 +6,7 @@
    */
   function updateActiveFragmentLink() {
     var hash = location.hash || '#';
-    var links = document.querySelectorAll('[href^="#"]');
+    var links = document.querySelectorAll('.rw-river-letter-navigation__link[href^="#"]');
     for (var i = links.length - 1; i >= 0; i--) {
       var link = links[i];
       if (link.getAttribute('href') !== hash) {

--- a/html/themes/custom/common_design_subtheme/components/rw-river-letter-navigation/rw-river-letter-navigation.js
+++ b/html/themes/custom/common_design_subtheme/components/rw-river-letter-navigation/rw-river-letter-navigation.js
@@ -1,0 +1,27 @@
+(function () {
+  'use strict';
+
+  /**
+   * Update the active anchor link when the current url fragment changes.
+   */
+  function updateActiveFragmentLink() {
+    var hash = location.hash || '#';
+    var links = document.querySelectorAll('[href^="#"]');
+    for (var i = links.length - 1; i >= 0; i--) {
+      var link = links[i];
+      if (link.getAttribute('href') !== hash) {
+        link.classList.remove('rw-river-letter-navigation__link--active');
+      }
+      else {
+        link.classList.add('rw-river-letter-navigation__link--active');
+      }
+    }
+  }
+
+  // Update the active fragment link when the window hash changes.
+  window.addEventListener('hashchange', updateActiveFragmentLink);
+
+  // Initial update of the active fragment link.
+  updateActiveFragmentLink();
+
+})();


### PR DESCRIPTION
Ticket: RW-59

This adds back a piece of [javascript](https://github.com/UN-OCHA/rwint-site/blob/bfb100de099df2c02a2319e7e2b5af0e3c12b484/site/profiles/reliefweb/themes/kobe/js/site.js#L12-L28) that was used to style the active link in the /countries river page. 

It also updates the CSS rule to style this active link which was before using [data-active] but, now, uses `rw-river-letter-navigation__link--active`.

Finally a tiny change to center vertically the letters.