### PR TITLE
[RW-65] Fix advanced search styling and other issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
             "type": "package",
             "package": {
                 "name": "reliefweb/simple-datepicker",
-                "version": "v1.3.0",
+                "version": "v1.3.1",
                 "type":"drupal-library",
                 "source": {
                     "url": "https://github.com/UN-OCHA/rwint-simple-datepicker.git",
                     "type": "git",
-                    "reference": "v1.3.0"
+                    "reference": "v1.3.1"
                 }
             }
         }
@@ -70,7 +70,7 @@
         "drush/drush": "^10.4",
         "league/commonmark": "^1.6",
         "reliefweb/simple-autocomplete": "v1.3.0",
-        "reliefweb/simple-datepicker": "v1.3.0",
+        "reliefweb/simple-datepicker": "^1.3",
         "symfony/flex": "^1.12",
         "unocha/common_design": "^4.0.0",
         "webflo/drupal-finder": "^1.2.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5a9587f9ff5f19070f984a08a928fcd",
+    "content-hash": "24a1a5db9673c742b423c4512b12e47f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7205,11 +7205,11 @@
         },
         {
             "name": "reliefweb/simple-datepicker",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/rwint-simple-datepicker.git",
-                "reference": "v1.3.0"
+                "reference": "v1.3.1"
             },
             "type": "drupal-library"
         },

--- a/html/modules/custom/reliefweb_rivers/js/advanced-search.js
+++ b/html/modules/custom/reliefweb_rivers/js/advanced-search.js
@@ -1191,8 +1191,13 @@
       var filter = filters[i];
       options.push(createOption(filter.code, filter.name));
     }
-    var select = createElement('select', {'id': id}, options);
-    var label = createLabel(id, advancedSearch.labels.fieldSelector);
+    var select = createElement('select', {
+      'id': id,
+      'class': advancedSearch.classPrefix + 'field-selector'
+    }, options);
+    var label = createLabel(id, advancedSearch.labels.fieldSelector, {
+      'class': advancedSearch.classPrefix + 'field-selector-label'
+    });
 
     // Keep track of the field selector as it's used in many places.
     advancedSearch.fieldSelector = select;

--- a/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
+++ b/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
@@ -988,6 +988,7 @@ class AdvancedSearch {
     $language_manager = \Drupal::languageManager();
     $current_langcode = $language_manager->getCurrentLanguage()->getId();
     $default_langcode = $language_manager->getDefaultLanguage()->getId();
+    $langcodes = array_unique([$current_langcode, $default_langcode]);
 
     // Query to return the id, name and optionally shortname of the terms
     // for the filter's vocabulary.
@@ -998,7 +999,7 @@ class AdvancedSearch {
       // Only return publicly accessible terms.
       ->condition('td.status', 1)
       // Return the terms in the current and default languages.
-      ->condition('td.langcode', [$current_langcode, $default_langcode], 'IN');
+      ->condition('td.langcode', $langcodes, 'IN');
 
     // Exclude some terms.
     if (!empty($filter['exclude'])) {
@@ -1008,7 +1009,7 @@ class AdvancedSearch {
 
     // Filter by the given values if any.
     if (!empty($values)) {
-      $query->condition('td.tid', $values);
+      $query->condition('td.tid', $values, 'IN');
     }
 
     // Add the shortname if indicated.

--- a/html/themes/custom/common_design_subtheme/components/rw-advanced-search/rw-advanced-search.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-advanced-search/rw-advanced-search.css
@@ -1,7 +1,7 @@
 /**
  * Advanced search.
  */
-.rw-advanced-search {
+#main-content .rw-advanced-search {
   position: relative;
   /* Enough space for the add filter button so there is no resizing when
    * it's added via javascript. */
@@ -13,7 +13,7 @@
   /* var(--cd-reliefweb-light-grey) with 0.2 opacity on white. */
   background: #fafbfb;
 }
-.rw-advanced-search:before {
+#main-content .rw-advanced-search:before {
   position: absolute;
   top: -1px;
   bottom: -1px;
@@ -22,18 +22,18 @@
   content: "";
   background: var(--cd-reliefweb-blue);
 }
-.rw-advanced-search__title {
+#main-content .rw-advanced-search__title {
   margin: 0;
   padding-right: 32px;
   font-size: 16px;
   font-weight: normal;
   font-style: normal;
 }
-.rw-advanced-search__form__content {
+#main-content .rw-advanced-search__form__content {
   position: relative;
 }
 
-.rw-advanced-search__help {
+#main-content .rw-advanced-search__help {
   position: absolute;
   top: 12px;
   right: 12px;
@@ -50,9 +50,9 @@
   background: var(--rw-icons--common--help--12--dark-blue);
   background-color: var(--cd-reliefweb-light-grey);
 }
-.rw-advanced-search__help:active,
-.rw-advanced-search__help:hover,
-.rw-advanced-search__help:focus {
+#main-content .rw-advanced-search__help:active,
+#main-content .rw-advanced-search__help:hover,
+#main-content .rw-advanced-search__help:focus {
   background: var(--rw-icons--common--help--12--dark-red);
   background-color: var(--cd-reliefweb-light-grey);
 }
@@ -60,18 +60,18 @@
 /**
  * Advanced search filter selection.
  */
-.rw-advanced-search__selection {
+#main-content .rw-advanced-search__selection {
   margin: 12px 0;
   padding: 12px 0 4px 0;
   border: 1px solid var(--cd-reliefweb-light-grey);
   border-width: 1px 0 1px 0;
 }
-.rw-advanced-search__selection[data-selection="0"] {
+#main-content .rw-advanced-search__selection[data-selection="0"] {
   padding: 0;
   border-width: 0 0 1px 0;
 }
 /* Clear any floating from the selection content. */
-.rw-advanced-search__selection:after {
+#main-content .rw-advanced-search__selection:after {
   display: block;
   clear: both;
   width: 100%;
@@ -81,10 +81,10 @@
 /**
  * Advanced search filter selection - Operator switcher.
  */
-.rw-advanced-search__selection [data-field] {
+#main-content .rw-advanced-search__selection [data-field] {
   position: relative;
 }
-.rw-advanced-search__selection [data-operator] {
+#main-content .rw-advanced-search__selection [data-operator] {
   position: relative;
   display: inline-block;
   margin: 0 0 8px 0;
@@ -95,12 +95,12 @@
   font-size: 13px;
   font-weight: normal;
 }
-.rw-advanced-search__selection [data-operator*="with"] {
+#main-content .rw-advanced-search__selection [data-operator*="with"] {
   clear: both;
 }
-.rw-advanced-search__selection [data-operator*="with"]:before,
-.rw-advanced-search__selection [data-operator*="any"]:before,
-.rw-advanced-search__selection [data-operator*="all"]:before {
+#main-content .rw-advanced-search__selection [data-operator*="with"]:before,
+#main-content .rw-advanced-search__selection [data-operator*="any"]:before,
+#main-content .rw-advanced-search__selection [data-operator*="all"]:before {
   position: absolute;
   top: -1px;
   bottom: -1px;
@@ -109,7 +109,7 @@
   content: "";
   background: var(--cd-reliefweb-dark-red);
 }
-.rw-advanced-search__selection [data-operator] button[aria-expanded] {
+#main-content .rw-advanced-search__selection [data-operator] button[aria-expanded] {
   position: relative;
   margin: -4px -8px;
   padding: 4px 24px 4px 8px;
@@ -119,7 +119,7 @@
   font-size: inherit;
   font-weight: inherit;
 }
-.rw-advanced-search__selection [data-operator] button[aria-expanded]:after {
+#main-content .rw-advanced-search__selection [data-operator] button[aria-expanded]:after {
   position: absolute;
   top: 50%;
   right: 8px;
@@ -130,10 +130,10 @@
   content: "";
   background: var(--rw-icons--toggle--down--9--dark-blue);
 }
-.rw-advanced-search__selection [data-operator] button[aria-expanded="true"]:after {
+#main-content .rw-advanced-search__selection [data-operator] button[aria-expanded="true"]:after {
   background: var(--rw-icons--toggle--up--9--dark-blue);
 }
-.rw-advanced-search__selection [data-operator] ul {
+#main-content .rw-advanced-search__selection [data-operator] ul {
   position: absolute;
   z-index: 2;
   left: 0;
@@ -147,10 +147,10 @@
   -webkit-box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
 }
-.rw-advanced-search__selection [data-operator] button[aria-expanded="true"] + ul {
+#main-content .rw-advanced-search__selection [data-operator] button[aria-expanded="true"] + ul {
   display: block;
 }
-.rw-advanced-search__selection [data-operator] ul li {
+#main-content .rw-advanced-search__selection [data-operator] ul li {
   position: relative;
   margin: 0;
   padding: 8px 8px 8px 28px;
@@ -158,16 +158,16 @@
   white-space: nowrap;
   font-size: 14px;
 }
-.rw-advanced-search__selection [data-operator] ul li:last-child {
+#main-content .rw-advanced-search__selection [data-operator] ul li:last-child {
   margin: 0;
 }
-.rw-advanced-search__selection [data-operator] ul li[aria-selected] {
+#main-content .rw-advanced-search__selection [data-operator] ul li[aria-selected] {
   background: var(--cd-reliefweb-light-grey);
 }
-.rw-advanced-search__selection [data-operator] ul li[aria-disabled] {
+#main-content .rw-advanced-search__selection [data-operator] ul li[aria-disabled] {
   display: none;
 }
-.rw-advanced-search__selection [data-operator] ul li:before {
+#main-content .rw-advanced-search__selection [data-operator] ul li:before {
   position: absolute;
   top: 50%;
   left: 8px;
@@ -180,10 +180,10 @@
   border: none;
   background: var(--rw-icons--common--selected--12--dark-blue);
 }
-.rw-advanced-search__selection [data-operator] li[aria-selected]:before {
+#main-content .rw-advanced-search__selection [data-operator] li[aria-selected]:before {
   display: block;
 }
-.rw-advanced-search__selection [data-value] {
+#main-content .rw-advanced-search__selection [data-value] {
   display: block;
   clear: both;
   margin: 0 0 8px 0;
@@ -191,7 +191,7 @@
   font-size: 14px;
   line-height: 22px;
 }
-.rw-advanced-search__selection [data-value] button {
+#main-content .rw-advanced-search__selection [data-value] button {
   width: 28px;
   height: 28px;
   padding: 0 0 0 28px;
@@ -200,49 +200,49 @@
 /**
  * Adavanced search form.
  */
-.rw-advanced-search__form {
+#main-content .rw-advanced-search__form {
   position: relative;
 }
 /* Clear any floating from the actions. */
-.rw-advanced-search__form:after {
+#main-content .rw-advanced-search__form:after {
   display: block;
   clear: both;
   width: 100%;
   content: "";
 }
-.rw-advanced-search__actions {
+#main-content .rw-advanced-search__actions {
   margin: 12px 0 0 0;
   padding: 12px 0 0 0;
   text-align: center;
   border: 1px solid var(--cd-reliefweb-light-grey);
   border-width: 1px 0 0 0;
 }
-.rw-advanced-search[data-empty] .rw-advanced-search__actions {
+#main-content .rw-advanced-search[data-empty] .rw-advanced-search__actions {
   display: none;
 }
-.rw-advanced-search__actions button {
+#main-content .rw-advanced-search__actions button {
   height: 36px;
   padding: 0 14px;
   line-height: 36px;
 }
-.rw-advanced-search__actions button[data-clear] {
+#main-content .rw-advanced-search__actions button[data-clear] {
   color: var(--cd-reliefweb-dark-blue);
   border: none;
   background: transparent;
   font-size: 16px;
   font-weight: normal;
 }
-.rw-advanced-search__actions button[data-clear]:hover,
-.rw-advanced-search__actions button[data-clear]:active,
-.rw-advanced-search__actions button[data-clear]:focus {
+#main-content .rw-advanced-search__actions button[data-clear]:hover,
+#main-content .rw-advanced-search__actions button[data-clear]:active,
+#main-content .rw-advanced-search__actions button[data-clear]:focus {
   color: var(--cd-reliefweb-dark-red);
 }
-.rw-advanced-search__actions button[data-apply="true"] {
+#main-content .rw-advanced-search__actions button[data-apply="true"] {
   position: relative;
   padding-left: 40px;
   background: var(--cd-reliefweb-dark-red);
 }
-.rw-advanced-search__actions button[data-apply="true"]:before {
+#main-content .rw-advanced-search__actions button[data-apply="true"]:before {
   position: absolute;
   top: 50%;
   left: 12px;
@@ -256,7 +256,7 @@
 /**
  * Advanced search filter selector togglers.
  */
-.rw-advanced-search [data-toggler] {
+#main-content .rw-advanced-search button[data-toggler] {
   min-height: 32px;
   margin: 0;
   padding: 0;
@@ -265,10 +265,10 @@
   background: transparent;
   line-height: 20px;
 }
-.rw-advanced-search [data-toggler][data-hidden="true"] {
+#main-content .rw-advanced-search button[data-toggler][data-hidden="true"] {
   visibility: hidden;
 }
-.rw-advanced-search [data-toggler]:before {
+#main-content .rw-advanced-search button[data-toggler]:before {
   position: relative;
   display: inline-block;
   overflow: hidden;
@@ -284,16 +284,16 @@
   background-color: var(--cd-reliefweb-light-grey);
 }
 
-.rw-advanced-search [data-toggler]:hover,
-.rw-advanced-search [data-toggler]:active,
-.rw-advanced-search [data-toggler]:focus {
+#main-content .rw-advanced-search button[data-toggler]:hover,
+#main-content .rw-advanced-search button[data-toggler]:active,
+#main-content .rw-advanced-search button[data-toggler]:focus {
   text-decoration: underline;
 }
-.rw-advanced-search [data-toggler] span.label-suffix {
+#main-content .rw-advanced-search button[data-toggler] span.label-suffix {
   margin-left: 4px;
   font-weight: normal;
 }
-.rw-advanced-search [data-toggler="single"] {
+#main-content .rw-advanced-search button[data-toggler="single"] {
   /* Only displayed on large screens. */
   display: none;
   min-height: 38px;
@@ -303,7 +303,7 @@
 /**
  *  Advanced search filter selector.
  */
-.rw-advanced-search__filter-selector {
+#main-content .rw-advanced-search__filter-selector {
   position: absolute;
   z-index: 100;
   top: 0;
@@ -315,40 +315,40 @@
   -webkit-box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
   box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
 }
-.rw-advanced-search__filter-selector[data-hidden="true"] {
+#main-content .rw-advanced-search__filter-selector[data-hidden="true"] {
   display: none;
 }
 /* Clear the floating from the buttons. */
-.rw-advanced-search__filter-selector:after {
+#main-content .rw-advanced-search__filter-selector:after {
   display: block;
   clear: both;
   width: 100%;
   content: "";
 }
-.rw-advanced-search__filter-selector-title {
+#main-content .rw-advanced-search__filter-selector__title {
   margin: 0;
   font-size: 15px;
   font-weight: bold;
   font-style: normal;
 }
-.rw-advanced-search__filter-selector fieldset[disabled] {
+#main-content .rw-advanced-search__filter-selector fieldset[disabled] {
   display: none;
 }
-.rw-advanced-search__filter-selector legend,
-.rw-advanced-search__filter-selector label {
+#main-content .rw-advanced-search__filter-selector legend,
+#main-content .rw-advanced-search__filter-selector label {
   float: none;
   margin: 0;
   padding: 12px 0 0 0;
   font-size: 15px;
   font-weight: normal;
 }
-.rw-advanced-search__filter-selector [data-widget="date"] label {
+#main-content .rw-advanced-search__filter-selector [data-widget="date"] label {
   font-size: 14px;
   font-style: italic;
 }
-.rw-advanced-search__filter-selector input,
-.rw-advanced-search__filter-selector select,
-.rw-advanced-search__filter-selector > div > button {
+#main-content .rw-advanced-search__filter-selector input,
+#main-content .rw-advanced-search__filter-selector select,
+#main-content .rw-advanced-search__filter-selector > div > button {
   display: block;
   width: 100%;
   height: 36px;
@@ -356,15 +356,15 @@
   font-size: 15px;
   line-height: 36px;
 }
-.rw-advanced-search__filter-selector input {
+#main-content .rw-advanced-search__filter-selector input {
   padding: 8px;
   line-height: 1;
 }
-.rw-advanced-search__filter-selector > div > button {
+#main-content .rw-advanced-search__filter-selector > div > button {
   margin: 12px 0 0 0;
   padding: 0 14px;
 }
-.rw-advanced-search__filter-selector > div > button[data-cancel] {
+#main-content .rw-advanced-search__filter-selector > div > button[data-cancel] {
   float: left;
   width: 48%;
   color: var(--cd-reliefweb-dark-blue);
@@ -372,58 +372,61 @@
   background: transparent;
   font-weight: normal;
 }
-.rw-advanced-search__filter-selector > div > button[data-cancel]:hover,
-.rw-advanced-search__filter-selector > div > button[data-cancel]:active,
-.rw-advanced-search__filter-selector > div > button[data-cancel]:focus {
+#main-content .rw-advanced-search__filter-selector > div > button[data-cancel]:hover,
+#main-content .rw-advanced-search__filter-selector > div > button[data-cancel]:active,
+#main-content .rw-advanced-search__filter-selector > div > button[data-cancel]:focus {
   color: var(--cd-reliefweb-dark-red);
   border-color: var(--cd-reliefweb-dark-red);
   background: transparent;
 }
-.rw-advanced-search__filter-selector > div > button[data-add] {
+#main-content .rw-advanced-search__filter-selector > div > button[data-add] {
   float: right;
   width: 48%;
 }
-.rw-advanced-search__filter-selector [data-autocomplete] {
+#main-content .rw-advanced-search__filter-selector [data-autocomplete] {
   padding: 0;
 }
-.rw-advanced-search__filter-selector [data-autocomplete] > input {
+#main-content .rw-advanced-search__filter-selector [data-autocomplete] > input {
+  height: 36px;
+  padding: 8px;
   border: 1px solid var(--cd-reliefweb-light-grey);
+  box-sizing: border-box;
 }
 
 /**
  * Advanced search operator selector.
  */
-.rw-advanced-search__operator-selector [disabled] {
+#main-content .rw-advanced-search__operator-selector [disabled] {
   display: none;
 }
 
 /**
  * Advanced search simplified filters.
  */
-.rw-advanced-search__simplified-filters > div {
+#main-content .rw-advanced-search__simplified-filters > div {
   position: relative;
 }
-.rw-advanced-search__advanced-mode-switch-container {
+#main-content .rw-advanced-search__advanced-mode-switch-container {
   position: relative;
   margin: 12px 0 0 0;
   padding: 12px 0 0 0;
   border-top: 1px solid var(--cd-reliefweb-light-grey);
 }
-.rw-advanced-search__advanced-mode-switch-container * {
+#main-content .rw-advanced-search__advanced-mode-switch-container * {
   display: inline-block;
   vertical-align: top;
   font-weight: normal;
 }
-.rw-advanced-search__advanced-mode-switch-container input {
+#main-content .rw-advanced-search__advanced-mode-switch-container input {
   width: 16px;
   height: 16px;
   margin: 1px 8px 0 2px;
 }
-.rw-advanced-search__advanced-mode-switch-container label {
+#main-content .rw-advanced-search__advanced-mode-switch-container label {
   margin: 0 8px 0 0;
   font-size: 15px;
 }
-.rw-advanced-search__advanced-mode-switch-container .rw-advanced-search__help {
+#main-content .rw-advanced-search__advanced-mode-switch-container .rw-advanced-search__help {
   position: relative;
   top: auto;
   right: auto;
@@ -432,18 +435,18 @@
 /**
  * Advanced search - simplified mode.
  */
-.rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-operator] {
+#main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-operator] {
   margin-top: 8px;
 }
-.rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-field]:first-child [data-operator] {
+#main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-field]:first-child [data-operator] {
   margin-top: 0;
 }
-.rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-operator="and"],
-.rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-operator="or"] {
+#main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-operator="and"],
+#main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__selection [data-operator="or"] {
   display: none;
 }
-.rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__operator-selector,
-.rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__operator-selector-label {
+#main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__operator-selector,
+#main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__operator-selector-label {
   display: none;
 }
 
@@ -451,38 +454,38 @@
  * Advanced search - large screens.
  */
 @media all and (min-width: 768px) {
-  .rw-advanced-search {
+  #main-content .rw-advanced-search {
     margin: 0;
   }
-  .rw-advanced-search__title {
+  #main-content .rw-advanced-search__title {
     font-weight: bold;
   }
-  .rw-advanced-search__actions {
+  #main-content .rw-advanced-search__actions {
     margin: 0 0 12px 0;
     padding: 0 0 12px 0;
     border-width: 0 0 1px 0;
   }
   /* Show the single filter togglers. */
-  .rw-advanced-search [data-toggler="single"] {
+  #main-content .rw-advanced-search button[data-toggler="single"] {
     display: block;
   }
   /* Hide the combined filter toggler. */
-  .rw-advanced-search [data-toggler="combined"] {
+  #main-content .rw-advanced-search button[data-toggler="combined"] {
     display: none;
   }
-  .rw-advanced-search[data-advanced-mode] .rw-advanced-search__operator-selector,
-  .rw-advanced-search[data-advanced-mode] .rw-advanced-search__operator-selector-label {
+  #main-content .rw-advanced-search[data-advanced-mode] .rw-advanced-search__field-selector,
+  #main-content .rw-advanced-search[data-advanced-mode] .rw-advanced-search__field-selector-label {
     display: none;
   }
-  .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__filter-selector-title {
+  #main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__filter-selector__title {
     display: none;
   }
-  .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__filter-selector legend {
+  #main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__filter-selector legend {
     padding: 0;
     font-size: 15px;
     font-weight: bold;
   }
-  .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__filter-selector legend.visually-hidden + label {
+  #main-content .rw-advanced-search[data-advanced-mode="false"] .rw-advanced-search__filter-selector legend.visually-hidden + label {
     padding: 0 0 4px 0;
     font-size: 15px;
     font-weight: bold;

--- a/html/themes/custom/common_design_subtheme/components/rw-autocomplete/rw-autocomplete.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-autocomplete/rw-autocomplete.css
@@ -15,17 +15,17 @@
  *   </ul>
  * </div>
  */
-.rw-autocomplete {
+#main-content .rw-autocomplete {
   position: relative;
   width: 100%;
   /* The padding is for the button to show all options. */
   padding-right: 60px;
 }
-.rw-autocomplete-input {
+#main-content .rw-autocomplete-input {
   /* The show all button is attached to the input. */
   border-right: none;
 }
-.rw-autocomplete-show-all {
+#main-content .rw-autocomplete-show-all {
   position: absolute;
   top: 0;
   right: 0;
@@ -37,7 +37,7 @@
   text-indent: 60px;
 }
 /* Icon to show the collpased/expanded state of the show all button. */
-.rw-autocomplete-show-all:before {
+#main-content .rw-autocomplete-show-all:before {
   position: absolute;
   /* The positions combined with the margins center the icon horizontally and
    * vertically. */
@@ -51,11 +51,11 @@
   content: "";
   background: var(--rw-icons--toggle--down--18--white);
 }
-.rw-autocomplete[aria-expanded="true"] .rw-autocomplete-show-all:before {
+#main-content .rw-autocomplete[aria-expanded="true"] .rw-autocomplete-show-all:before {
   background: var(--rw-icons--toggle--up--18--white);
 }
 /* List of autocomplete suggestions. */
-.rw-autocomplete-selector {
+#main-content .rw-autocomplete-selector {
   position: absolute;
   /* Ensures the popup is above the content.
    * @todo Review the value. */
@@ -74,7 +74,7 @@
   background: white;
   box-shadow: 0 1px 4px 1px rgba(var(--cd-rgb-reliefweb-dark-grey), 0.3);
 }
-.rw-autocomplete-suggestion {
+#main-content .rw-autocomplete-suggestion {
   margin: 0;
   padding: 8px;
   /* Suggestions are clickable. */
@@ -86,10 +86,10 @@
   line-height: 1.5;
 }
 /* Currently selected suggestion. */
-.rw-autocomplete-suggestion[aria-selected] {
+#main-content .rw-autocomplete-suggestion[aria-selected] {
   background: var(--cd-reliefweb-light-grey);
 }
 /* Highlight the parts of the suggestions that match the query. */
-.rw-autocomplete-suggestion span {
+#main-content .rw-autocomplete-suggestion span {
   font-weight: bold;
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-datepicker/rw-datepicker.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-datepicker/rw-datepicker.css
@@ -27,14 +27,14 @@
  *     </div>
  *   </div>
  */
-.rw-datepicker-container {
+#main-content .rw-datepicker-container {
   position: relative;
   z-index: 10;
 }
-.rw-datepicker-container[data-hidden="true"] {
+#main-content .rw-datepicker-container[data-hidden="true"] {
   display: none;
 }
-.rw-datepicker-calendar {
+#main-content .rw-datepicker-calendar {
   position: absolute;
   top: 0;
   left: 0;
@@ -45,7 +45,7 @@
   background: white;
   box-shadow: 0 1px 4px 1px rgba(var(--cd-rgb-reliefweb-dark-grey), 0.3);
 }
-.rw-datepicker-calendar button {
+#main-content .rw-datepicker-calendar button {
   margin: 0;
   padding: 0;
   /* Disable text selection of the buttons in the calendar to avoid interfering
@@ -59,16 +59,17 @@
   color: var(--cd-reliefweb-dark-blue);
   border: none;
   background: none;
-  /* @todo review in regards to the standard cd-font sizes. */
+  line-height: 16px;
+  /* @todo review if we can use a CD variable. */
   font-size: 16px;
 }
-.rw-datepicker-calendar button:hover,
-.rw-datepicker-calendar button:focus,
-.rw-datepicker-calendar button:active {
+#main-content .rw-datepicker-calendar button:hover,
+#main-content .rw-datepicker-calendar button:focus,
+#main-content .rw-datepicker-calendar button:active {
   color: var(--cd-reliefweb-dark-blue);
   background: var(--cd-reliefweb-light-grey);
 }
-.rw-datepicker-title {
+#main-content .rw-datepicker-title {
   margin-bottom: 8px;
   padding-bottom: 8px;
   text-align: center;
@@ -76,7 +77,7 @@
   line-height: 24px;
 }
 /* Previous/next year/month buttons. */
-button.rw-datepicker-control {
+#main-content .rw-datepicker-container button.rw-datepicker-control {
   position: relative;
   display: inline-block;
   overflow: hidden;
@@ -86,7 +87,7 @@ button.rw-datepicker-control {
   vertical-align: top;
 }
 /* Arrow icons for the previous/next year/month. */
-button.rw-datepicker-control:before {
+#main-content .rw-datepicker-container button.rw-datepicker-control:before {
   position: absolute;
   top: 50%;
   right: 50%;
@@ -98,32 +99,36 @@ button.rw-datepicker-control:before {
   content: "";
   background: var(--rw-icons--common--arrow-right--12--dark-blue);
 }
-button.rw-datepicker-control.rw-datepicker-title-previous.rw-datepicker-title-month:before {
+#main-content .rw-datepicker-container button.rw-datepicker-control.rw-datepicker-title-previous.rw-datepicker-title-month:before {
   background: var(--rw-icons--common--arrow-left--12--dark-blue);
 }
-button.rw-datepicker-control.rw-datepicker-title-next.rw-datepicker-title-year:before {
+#main-content .rw-datepicker-container button.rw-datepicker-control.rw-datepicker-title-next.rw-datepicker-title-year:before {
   background: var(--rw-icons--common--double-arrow-right--12--dark-blue);
 }
-button.rw-datepicker-control.rw-datepicker-title-previous.rw-datepicker-title-year:before {
+#main-content .rw-datepicker-container button.rw-datepicker-control.rw-datepicker-title-previous.rw-datepicker-title-year:before {
   background: var(--rw-icons--common--double-arrow-left--12--dark-blue);
 }
 /* Selected month and year. */
-.rw-datepicker-title-date {
+#main-content .rw-datepicker-title-date {
   display: inline-block;
   width: 158px;
   padding: 0 4px;
+  line-height: 16px;
+  font-size: 16px;
 }
 /* Weekdays. */
-.rw-datepicker-header span {
+#main-content .rw-datepicker-header span {
   display: inline-block;
   width: 32px;
   height: 32px;
   margin: 2px;
   padding: 8px;
+  line-height: 16px;
   text-align: right;
+  font-size: 16px;
 }
 /* Days of the month. */
-.rw-datepicker-days button {
+#main-content .rw-datepicker-days button {
   width: 32px;
   height: 32px;
   margin: 2px;
@@ -132,20 +137,20 @@ button.rw-datepicker-control.rw-datepicker-title-previous.rw-datepicker-title-ye
   background: none;
 }
 /* Days outside of the selected month are disabled. */
-.rw-datepicker-days button[disabled],
-.rw-datepicker-days button[disabled]:hover,
-.rw-datepicker-days button[disabled]:focus,
-.rw-datepicker-days button[disabled]:active {
+#main-content .rw-datepicker-days button[disabled],
+#main-content .rw-datepicker-days button[disabled]:hover,
+#main-content .rw-datepicker-days button[disabled]:focus,
+#main-content .rw-datepicker-days button[disabled]:active {
   cursor: default;
   color: var(--cd-reliefweb-light-grey);
   background: none;
 }
 /* Highlight the current day. */
-.rw-datepicker-days button.rw-datepicker-today {
+#main-content .rw-datepicker-days button.rw-datepicker-today {
   color: var(--cd-reliefweb-dark-red);
 }
 /* Highlight the currently selected day(s). */
-.rw-datepicker-days button.rw-datepicker-selected-day {
+#main-content .rw-datepicker-days button.rw-datepicker-selected-day {
   color: white;
   background: var(--cd-reliefweb-dark-blue);
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-selection/rw-selection.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-selection/rw-selection.css
@@ -15,7 +15,7 @@
  * @todo It may possibly make more sense to use a <ol> for the list of selected
  * filters. That would require a modification to the JS scripts.
  */
-.rw-selection {
+#main-content .rw-selection {
   width: auto;
   min-width: 100%;
   /* This is compensate the margin of the descendants. */
@@ -23,7 +23,7 @@
   padding: 0;
   border: none;
 }
-.rw-selection [data-value] {
+#main-content .rw-selection [data-value] {
   position: relative;
   display: inline-block;
   margin: 4px;
@@ -34,10 +34,10 @@
   /* Better readability. */
   line-height: 24px;
 }
-.rw-selection [data-value] .label {
+#main-content .rw-selection [data-value] .label {
   font-weight: bold;
 }
-.rw-selection [data-value] button {
+#main-content .rw-selection [data-value] button {
   position: absolute;
   top: 0;
   right: 0;
@@ -51,12 +51,12 @@
   border: none;
   background: var(--cd-reliefweb-light-grey);
 }
-.rw-selection [data-value] button:hover,
-.rw-selection [data-value] button:focus,
-.rw-selection [data-value] button:active {
+#main-content .rw-selection [data-value] button:hover,
+#main-content .rw-selection [data-value] button:focus,
+#main-content .rw-selection [data-value] button:active {
   background: var(--cd-reliefweb-dark-blue);
 }
-.rw-selection [data-value] button:before {
+#main-content .rw-selection [data-value] button:before {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -69,9 +69,9 @@
   background: url(img/icons-sprite.svg) -84px 0 no-repeat;
   background: var(--rw-icons--common--close--12--dark-blue);
 }
-.rw-selection [data-value] button:hover:before,
-.rw-selection [data-value] button:focus:before,
-.rw-selection [data-value] button:active:before {
+#main-content .rw-selection [data-value] button:hover:before,
+#main-content .rw-selection [data-value] button:focus:before,
+#main-content .rw-selection [data-value] button:active:before {
   background-position-x: var(--rw-icons--common--12--white--x);
 }
 
@@ -97,10 +97,10 @@
  *   </div>
  * </div>
  */
-[data-selection-messages] .rw-selection [data-value] {
+#main-content [data-selection-messages] .rw-selection [data-value] {
   display: block;
 }
-[data-selection-messages] .rw-selection [data-value] .message {
+#main-content [data-selection-messages] .rw-selection [data-value] .message {
   overflow-wrap: break-word;
   overflow-y: auto;
   max-height: 220px;
@@ -113,11 +113,11 @@
   /* @todo review in regards to the standard cd-font sizes. */
   font-size: 15px;
 }
-[data-selection-messages] .rw-selection [data-value] .message .title {
+#main-content [data-selection-messages] .rw-selection [data-value] .message .title {
   display: block;
   margin-bottom: 8px;
 }
-[data-selection-messages] .rw-selection [data-value] .message ul,
-[data-selection-messages] .rw-selection [data-value] .message ol {
+#main-content [data-selection-messages] .rw-selection [data-value] .message ul,
+#main-content [data-selection-messages] .rw-selection [data-value] .message ol {
   padding: 0 0 0 24px;
 }


### PR DESCRIPTION
Ticket: RW-65

This fixes the styling of the advanced search, notably by re-introducing the `#main-content` scope so that the advanced search's button styling for example can apply. The base `#main-content form button` was indeed more specific.

This also updates the datepicker library to fix some class prefixing so need to run `composer install`.

Latsly, there is a tiny bug fix in the advanced search logic that I sneaked in there.

What is missing is the 2 columns style for the rivers with the advanced search on the left side of the article list on desktop/tablet, but that's out of the scope of this ticket. Follow-up ticket: RW-69