### PR TITLE
[RW-56] Fix toggler for description section

### DIFF
--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-description.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-description.html.twig
@@ -26,11 +26,9 @@
       'rw-entity-description__title'
     ])
   }}>{{ title }}</h{{ level }}>
-  <div class="rw-entity-description__wrapper">
-    <div{{ description_attributes
-      .addClass([
-        'rw-entity-description__text'
-      ])
-    }}>{{ description|raw }}</div>
-  </div>
+  <div{{ description_attributes
+    .addClass([
+      'rw-entity-description__text'
+    ])
+  }}>{{ description|raw }}</div>
 </section>

--- a/html/themes/custom/common_design_subtheme/components/rw-entity-description/rw-entity-description.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-entity-description/rw-entity-description.css
@@ -1,4 +1,4 @@
-#main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__wrapper {
+#main-content .rw-sectioned-content section.rw-entity-description {
   display: flex;
   flex-direction: column;
 }
@@ -9,7 +9,7 @@
   margin-top: 0;
 }
 /* Javascript enabled */
-.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__wrapper > button {
+.js #main-content .rw-sectioned-content section.rw-entity-description button {
   display: block;
   padding: 8px 12px;
   margin: 24px auto 0 auto;
@@ -20,34 +20,39 @@
   order: 3;
   fill: #055372;
 }
-.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__wrapper > button svg {
+.js #main-content .rw-sectioned-content section.rw-entity-description button svg {
   fill: currentColor;
 }
-.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__wrapper > button:hover,
-.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__wrapper > button:active,
-.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__wrapper > button:focus {
+.js #main-content .rw-sectioned-content section.rw-entity-description button:hover,
+.js #main-content .rw-sectioned-content section.rw-entity-description button:active,
+.js #main-content .rw-sectioned-content section.rw-entity-description button:focus {
   background: #055372;
   color: white;
 }
-.js #main-content .rw-sectioned-content section.rw-entity-description > .rw-entity-description__text > * {
-  display: none;
-}
-.js #main-content .rw-sectioned-content section.rw-entity-description > .rw-entity-description__text > *:nth-last-child(-n+3) {
+/* Overrides the default behavior when data-cd-hidden is set as the description
+ * is always displayed, only the number of paragraphs changes. */
+.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__text[data-cd-hidden] {
   display: block;
 }
-.js #main-content .rw-sectioned-content section.rw-entity-description > .rw-entity-description__text > *:nth-last-child(3) {
+.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__text > * {
+  display: none;
+}
+.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__text > *:nth-last-child(-n+3) {
+  display: block;
+}
+.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__text > *:nth-last-child(3) {
   margin-top: 0;
 }
-.js #main-content .rw-sectioned-content section.rw-entity-description > .rw-entity-description__text[data-hidden="false"] > * {
+.js #main-content .rw-sectioned-content section.rw-entity-description .rw-entity-description__text[data-cd-hidden="false"] > * {
   display: block;
 }
 /* Exception for sources, where we start at the top of the rw-entity-description. */
-.js #main-content .source.rw-sectioned-content section.rw-entity-description > .rw-entity-description__text > * {
+.js #main-content .taxonomy-term--source--full.rw-sectioned-content section.rw-entity-description .rw-entity-description__text > * {
   display: none;
 }
-.js #main-content .source.rw-sectioned-content section.rw-entity-description > .rw-entity-description__text > *:nth-child(-n+3) {
+.js #main-content .taxonomy-term--source--full.rw-sectioned-content section.rw-entity-description .rw-entity-description__text > *:nth-child(-n+3) {
   display: block;
 }
-.js #main-content .source.rw-sectioned-content section.rw-entity-description > .rw-entity-description__text[data-hidden="false"] > * {
+.js #main-content .taxonomy-term--source--full.rw-sectioned-content section.rw-entity-description .rw-entity-description__text[data-cd-hidden="false"] > * {
   display: block;
 }

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-description.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb-entities/reliefweb-entities-entity-description.html.twig
@@ -26,14 +26,25 @@
     }
     if (count > 3) {
       overview.setAttribute('data-cd-toggable', '{% trans %}Show full overview{% endtrans %}');
-      overview.setAttribute('data-cd-toggable', '{% trans %}Show full overview{% endtrans %}');
-      overview.setAttribute('data-cd-label-switch', '{% trans %}Hide full overview{% endtrans %}');
       overview.setAttribute('data-cd-toggable-expanded', '{% trans %}Hide full overview{% endtrans %}');
       overview.setAttribute('data-cd-toggable-keep', '');
-      overview.setAttribute('data-cd-focus-target', '{{ id }}');
-      overview.setAttribute('data-cd-icon', 'arrow-down')
-      overview.setAttribute('data-cd-component', 'rw-entity-description')
+      overview.setAttribute('data-cd-icon', 'arrow-down');
+      overview.setAttribute('data-cd-component', 'rw-entity-description');
+      overview.setAttribute('data-cd-replace', '{{ id }}-dummy');
+    }
 
+    // Scroll to the top of the description when expanding it.
+    if ('MutationObserver' in window) {
+      var observer = new MutationObserver(function (mutations) {
+        for (var mutation of mutations) {
+          if (mutation.type === 'attributes' &&
+              mutation.attributeName === 'data-cd-hidden' &&
+              mutation.target.getAttribute('data-cd-hidden') === 'false') {
+            mutation.target.parentNode.scrollIntoView();
+          }
+        }
+      });
+      observer.observe(overview, {attributes: true});
     }
   })();
 </script>


### PR DESCRIPTION
Ticket: RW-56

This makes a few changes to fix the toggling of the description section:

- Remove the wrapper and (ab)use the `data-cd-replace` attribute to force the addition of the toggler button.
- Update the css rules, notably make sure the description is always shown.
- Add a mutation observer to scroll to the top of the description when `data-cd-hidden` is set to `false`. This emulates what the `data-scroll-to` was doing. This could be replaced if we decide to add this attribute to the `cd-dropdown` upstream.