### PR TITLE
[RW-71] Ensure DSR and Key figures sections are not added when empty

### DIFF
--- a/html/modules/custom/reliefweb_dsr/src/Services/DSRClient.php
+++ b/html/modules/custom/reliefweb_dsr/src/Services/DSRClient.php
@@ -112,14 +112,14 @@ class DSRClient {
    */
   public function getDigitalSitrepBuild($iso3, $ongoing = FALSE) {
     $sitrep = $this->getDigitalSitrep($iso3, $ongoing);
+    if (empty($sitrep)) {
+      return [];
+    }
 
     // Create the render array.
-    $build = [];
-    if (!empty($sitrep)) {
-      $build['#theme'] = 'reliefweb_digital_situation_report';
-      foreach ($sitrep as $key => $value) {
-        $build['#' . $key] = $value;
-      }
+    $build = ['#theme' => 'reliefweb_digital_situation_report'];
+    foreach ($sitrep as $key => $value) {
+      $build['#' . $key] = $value;
     }
 
     // Cache the render array with the minimum max age. The data retrieved from

--- a/html/modules/custom/reliefweb_entities/src/Entity/Country.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Country.php
@@ -122,8 +122,7 @@ class Country extends Term implements BundleEntityInterface, EntityModeratedInte
   protected function getDigitalSitrepSection() {
     $client = \Drupal::service('reliefweb_dsr.client');
     $iso3 = $this->field_iso3->value;
-    // @todo use the term status once added back.
-    $ongoing = TRUE;
+    $ongoing = $this->getModerationStatus() === 'ongoing';
 
     return $client->getDigitalSitrepBuild($iso3, $ongoing);
   }

--- a/html/modules/custom/reliefweb_key_figures/src/Services/KeyFiguresClient.php
+++ b/html/modules/custom/reliefweb_key_figures/src/Services/KeyFiguresClient.php
@@ -130,25 +130,28 @@ class KeyFiguresClient {
    */
   public function getKeyFiguresBuild($iso3, $country) {
     $data = $this->getKeyFigures($iso3, $country);
+    if (empty($data['figures'])) {
+      return [];
+    }
 
     // Create the render array.
-    $build = [];
-    if (!empty($data['figures'])) {
-      $build['#theme'] = 'reliefweb_key_figures';
+    $build = ['#theme' => 'reliefweb_key_figures'];
 
-      // Limit the number of figures based on the "figures" query parameter.
-      $figures_parameter = $this->requestStack->getCurrentRequest()->query->get('figures');
-      $count = count($data['figures']);
-      $limit = $figures_parameter === 'all' ? $count : 6;
-      $data['figures'] = array_slice($data['figures'], 0, $limit);
+    // Limit the number of figures based on the "figures" query parameter.
+    $figures_parameter = $this->requestStack->getCurrentRequest()->query->get('figures');
+    $count = count($data['figures']);
+    $limit = $figures_parameter === 'all' ? $count : 6;
+    $data['figures'] = array_slice($data['figures'], 0, $limit);
 
-      foreach ($data as $key => $value) {
-        $build['#' . $key] = $value;
-      }
-
-      $build['#more'] = $count > $limit;
-      $build['#cache']['contexts'][] = 'url.query_args:figures';
+    foreach ($data as $key => $value) {
+      $build['#' . $key] = $value;
     }
+
+    $build['#more'] = $count > $limit;
+
+    // Add a cache context on the figure query parameter as the number of items
+    // in the render array depends on it.
+    $build['#cache']['contexts'][] = 'url.query_args:figures';
 
     // Cache the render array with the minimum max age. The data retrieved from
     // the API may be stored in cache for a longer duration.


### PR DESCRIPTION
Ticket: RW-71

This ensures that there is no DSR or Key Figures item in the Table of contents on country pages when those sections are empty. 

The render array cache, added even when the sections are empty was preventing the corresponding TOC element to be filtered out.

This also uses the proper country status for DSR.