### PR TITLE
RW-56 Layout rules for advanced search and rivers list

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -292,6 +292,11 @@ abstract class RiverServiceBase implements RiverServiceInterface {
   public function getRiverAdvancedSearch() {
     $advanced_search = $this->getAdvancedSearch();
 
+    $settings = $advanced_search->getSettings();
+    if (empty($settings['filters'])) {
+      return [];
+    }
+
     return [
       '#theme' => 'reliefweb_rivers_advanced_search',
       '#title' => $this->t('Refine the list with filters'),

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
@@ -26,6 +26,11 @@
     'rw-river-page',
     'rw-river-page--' ~ river|clean_class,
     view ? 'rw-river-page--' ~ river|clean_class ~ '--' ~ view|clean_class,
+    views ? 'rw-river-page--with-views',
+    search ? 'rw-river-page--with-search',
+    letter_navigation ? 'rw-river-page--with-letter-navigation',
+    advanced_search ? 'rw-river-page--with-advanced-search',
+    links ? 'rw-river-page--with-links',
   ])
 }}>
   <header class="rw-river-page__header">

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -128,6 +128,7 @@ rw-organizations:
 rw-river:
   css:
     theme:
+      components/rw-river/rw-river.css: {}
       components/rw-river/rw-river-results.css: {}
       components/rw-river/rw-river-views.css: {}
 

--- a/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-results.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-results.css
@@ -9,7 +9,7 @@
   font-weight: bold;
 }
 @media all and (min-width: 768px) {
-  #main-content section.river.with-filters .rw-river-results {
+  #main-content section.rw-river-page .rw-river-results {
     text-align: left;
     padding: 13px 0;
     border-bottom: 1px solid #e6ecef;

--- a/html/themes/custom/common_design_subtheme/components/rw-river/rw-river.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river/rw-river.css
@@ -4,7 +4,7 @@
     width: 300px;
   }
   /*#main-content section.rw-river-page .rw-river-results,*/
-  #main-content section.rw-river-page .rw-river {
+  #main-content section.rw-river-page:not(.rw-river-page--organizations) .rw-river--river-list {
     float: right;
     width: calc(100% - 340px);
   }
@@ -20,7 +20,7 @@
     width: 320px;
   }
   /*#main-content section.rw-river-page .rw-river-results,*/
-  #main-content section.rw-river-page .rw-river {
+  #main-content section.rw-river-page:not(.rw-river-page--organizations) .rw-river--river-list {
     width: calc(100% - 360px);
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-river/rw-river.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river/rw-river.css
@@ -1,0 +1,26 @@
+@media screen and (min-width : 768px) {
+  #main-content section.rw-river-page .rw-advanced-search {
+    float: left;
+    width: 300px;
+  }
+  /*#main-content section.rw-river-page .rw-river-results,*/
+  #main-content section.rw-river-page .rw-river {
+    float: right;
+    width: calc(100% - 340px);
+  }
+  /* Clear the floating above. */
+  #main-content section.rw-river-page #list:after {
+    content: "";
+    display: block;
+    clear: both;
+  }
+}
+@media screen and (min-width : 1024px) {
+  #main-content section.rw-river-page .rw-advanced-search {
+    width: 320px;
+  }
+  /*#main-content section.rw-river-page .rw-river-results,*/
+  #main-content section.rw-river-page .rw-river {
+    width: calc(100% - 360px);
+  }
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-river/rw-river.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river/rw-river.css
@@ -1,26 +1,27 @@
+/**
+ * 2 columns layout on tablet/desktop for rivers with advanced search.
+ */
 @media screen and (min-width : 768px) {
-  #main-content section.rw-river-page .rw-advanced-search {
+  #main-content section.rw-river-page--with-advanced-search .rw-advanced-search {
     float: left;
     width: 300px;
   }
-  /*#main-content section.rw-river-page .rw-river-results,*/
-  #main-content section.rw-river-page:not(.rw-river-page--organizations) .rw-river--river-list {
+  #main-content section.rw-river-page--with-advanced-search .rw-river--river-list {
     float: right;
     width: calc(100% - 340px);
   }
   /* Clear the floating above. */
-  #main-content section.rw-river-page #list:after {
+  #main-content section.rw-river-page--with-advanced-search #list:after {
     content: "";
     display: block;
     clear: both;
   }
 }
 @media screen and (min-width : 1024px) {
-  #main-content section.rw-river-page .rw-advanced-search {
+  #main-content section.rw-river-page--with-advanced-search .rw-advanced-search {
     width: 320px;
   }
-  /*#main-content section.rw-river-page .rw-river-results,*/
-  #main-content section.rw-river-page:not(.rw-river-page--organizations) .rw-river--river-list {
+  #main-content section.rw-river-page--with-advanced-search .rw-river--river-list {
     width: calc(100% - 360px);
   }
 }


### PR DESCRIPTION
- Add layout rules for advanced search and rivers list, update selectors.

There's still no vertical rhythm and I'm not sure if the generic `rw-river` css file is appropriate for the composition rules. It's a fine place for it in the meantime.

Currently, the Countries and Organizations river pages (maybe Topics also?) don't include the advance search, so the content column spans full width.
But the Organizations page shares the generic `reliefweb-rivers-page.html.twig` template, whereas the Countries page `reliefweb-rivers-country-list.html.twig` has its own template. 

The class `rw-river--river-list` is being used as a selector for the layout CSS. The Country page doesn't have this class so I've used `rw-river-page:not(.rw-river-page--organizations) .rw-river--river-list` to omit Organizations only.
