### PR TITLE
[RW-106] Add river article classes

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -149,6 +149,8 @@ function reliefweb_entities_theme() {
         'core' => FALSE,
         // Meta information, see "reliefweb_entities_entity_meta" above.
         'meta' => '',
+        // Meta information attributes.
+        'meta_attributes' => NULL,
       ],
     ],
     'reliefweb_entities_entity_social_media_links' => [

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-details.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-details.html.twig
@@ -19,6 +19,7 @@
  *   - value: simple, date, array with start and end date or list of tags
  *   - count: only for taglist - number of tags to display
  *   - sort: only for taglist - sort property for the tags
+ * - meta_attributes: meta information attributes.
  */
 
 #}
@@ -36,6 +37,7 @@
 
   {{ render_var({
     '#theme': 'reliefweb_entities_entity_meta',
+    '#attributes': meta_attributes,
     '#core': core,
     '#meta': meta,
   }) }}

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
@@ -163,6 +163,8 @@ function reliefweb_rivers_theme() {
         // The aricle entity's data as an associative array with id, bundle,
         // url, langcode, title etc.
         'entity' => NULL,
+        // Meta information attributes.
+        'meta_attributes' => NULL,
       ],
     ],
     'reliefweb_rivers_river_article_title' => [

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
@@ -132,6 +132,8 @@ function reliefweb_rivers_theme() {
         'results' => NULL,
         // The article entities to display.
         'entities' => [],
+        // Article attributes.
+        'article_attributes' => NULL,
         // View more link (optional) URL to the full river and link text.
         'more' => NULL,
         // Pager (optional). See "reliefweb_rivers_results" below.

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--blog-post.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--blog-post.html.twig
@@ -15,6 +15,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  */
 
 #}
@@ -53,6 +54,7 @@
   <footer class="rw-river-article__footer">
     {{ render_var({
       '#theme': 'reliefweb_entities_entity_meta',
+      '#attributes': meta_attributes,
       '#meta': {
         'posted': {
           'type': 'date',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--country.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--country.html.twig
@@ -15,6 +15,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  */
 
 #}

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
@@ -15,6 +15,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  */
 
 #}
@@ -43,6 +44,7 @@
   <footer class="rw-river-article__footer">
     {{ render_var({
       '#theme': 'reliefweb_entities_entity_meta',
+      '#attributes': meta_attributes,
       '#meta': {
         'status': {
           'type': 'simple',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--job.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--job.html.twig
@@ -15,6 +15,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  */
 
 #}
@@ -47,6 +48,7 @@
   <footer class="rw-river-article__footer">
     {{ render_var({
       '#theme': 'reliefweb_entities_entity_meta',
+      '#attributes': meta_attributes,
       '#meta': {
         'source': {
           'type': 'taglist',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
@@ -15,6 +15,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  *
  * @todo add back "image" for headlines.
  */
@@ -74,6 +75,7 @@
   <footer class="rw-river-article__footer">
     {{ render_var({
       '#theme': 'reliefweb_entities_entity_meta',
+      '#attributes': meta_attributes,
       '#meta': {
         'format': {
           'type': 'simple',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--source.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--source.html.twig
@@ -15,6 +15,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  */
 
 #}
@@ -44,6 +45,7 @@
     {% else %}
       {{ render_var({
         '#theme': 'reliefweb_entities_entity_meta',
+        '#attributes': meta_attributes,
         '#meta': {
           'publication': {
             'type': 'taglist',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--training.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--training.html.twig
@@ -15,6 +15,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  */
 
 #}
@@ -85,6 +86,7 @@
 
     {{ render_var({
       '#theme': 'reliefweb_entities_entity_meta',
+      '#attributes': meta_attributes,
       '#meta': meta|merge({
         'registration': {
           'type': 'date',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article.html.twig
@@ -19,6 +19,7 @@
  *   - bundle: entity bundle.
  *   - tags (optional): list of terms the entity is tagged with
  *   - various properties like posting date, status etc.
+ * - meta_attributes: meta information attributes.
  */
 
 #}
@@ -46,6 +47,7 @@
     <footer class="rw-river-article__footer">
       {{ render_var({
         '#theme': 'reliefweb_entities_entity_meta',
+        '#attributes': meta_attributes,
         '#meta': {
           'posted': {
             'type': 'date',

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
@@ -13,6 +13,7 @@
  * - title_attributes: attributes for the river title
  * - results: (optional) see reliefweb-rivers-results.html.twig
  * - entities: list of article entities constituting the river
+ * - article_attributes: attributes for the river articles
  * - pager: (optional) the pager for the river
  * - more: (optional) an array with URL to the main river and a text
  * - empty: message for when there are no results.
@@ -44,6 +45,7 @@
           '#theme': 'reliefweb_rivers_river_article__' ~ entity.bundle,
           '#level': level + 1,
           '#entity': entity,
+          '#attributes': article_attributes,
         }) }}
       {% endfor %}
     </div>

--- a/html/modules/custom/reliefweb_utility/reliefweb_utility.module
+++ b/html/modules/custom/reliefweb_utility/reliefweb_utility.module
@@ -16,14 +16,12 @@ use Drupal\file\FileInterface;
  */
 function reliefweb_utility_preprocess(array &$variables, $hook) {
   if (strpos($hook, 'reliefweb_') === 0) {
-    if (array_key_exists('attributes', $variables) && empty($variables['attributes'])) {
-      $variables['attributes'] = new Attribute();
-    }
-    if (array_key_exists('title_attributes', $variables) && empty($variables['title_attributes'])) {
-      $variables['title_attributes'] = new Attribute();
-    }
-    if (array_key_exists('description_attributes', $variables) && empty($variables['description_attributes'])) {
-      $variables['description_attributes'] = new Attribute();
+    foreach ($variables as $key => $value) {
+      if ($key === 'attributes' || strpos($key, '_attributes') !== FALSE) {
+        if (empty($value)) {
+          $variables[$key] = new Attribute();
+        }
+      }
     }
   }
 }

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article--report.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river-article--report.html.twig
@@ -1,3 +1,7 @@
 {{ attach_library('common_design_subtheme/rw-key-content') }}
 
+{% if attributes.hasClass('rw-river-article--map') or attributes.hasClass('rw-river-article--appeal') %}
+  {% set meta_attributes = meta_attributes.addClass('rw-entity-meta--stacked') %}
+{% endif %}
+
 {% include '@reliefweb_rivers/reliefweb-rivers-river-article--report.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
@@ -5,4 +5,15 @@
 {{ attach_library('common_design_subtheme/rw-river') }}
 {{ attach_library('common_design_subtheme/rw-view-more') }}
 
+{# Some logic to differentiate the types of styling to apply. We could also
+   provide some theme suggestions based on the section ID and use different
+   templates rather than the following conditions. #}
+{% if id == 'headlines' %}
+  {% set article_attributes = article_attributes.addClass('rw-river-article--headline') %}
+{% elseif id == 'maps-infographics' %}
+  {% set article_attributes = article_attributes.addClass('rw-river-article--map') %}
+{% elseif id == 'appeals-response-plans' %}
+  {% set article_attributes = article_attributes.addClass('rw-river-article--appeal') %}
+{% endif %}
+
 {% include '@reliefweb_rivers/reliefweb-rivers-river.html.twig' %}


### PR DESCRIPTION
Ticket: RW-106

This is to illustrate a way to add classes to river articles so that different styles can be applied (like headline, maps, appeals).

**Note**: there are already some classes to distinguish between articles with a summary, thumbnail etc., ex: `rw-river-article--with-summary`, which in the card: https://trello.com/c/uYummb5u was referenced as `compact`.

We could extend this article class approach and add a `meta_attributes` variable to the `reliefweb_rivers_river_article` theme and in the `reliefweb-rivers-river-article--report.html.twig` template override, we could add a class for the meta information based on the article class.

For example to add class to always show the entity meta info for the maps section on country page as stacked instead of inline:

```
{% if attributes.hasClass('rw-river-article--map') %}
  {% set meta_attributes = meta_attributes.addClass('rw-entity-meta--stacked') %}
{% endif %}
```

@left23 Let me know what you think and if you want I can extend this PR with the meta attributes.