### PR TITLE
[RW-80] Global search

### DIFF
--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
@@ -212,6 +212,22 @@ function reliefweb_rivers_theme() {
         'groups' => [],
       ],
     ],
+    'reliefweb_rivers_search_results' => [
+      'variables' => [
+        // Page title.
+        'title' => t('Search Results'),
+        // Title attributes.
+        'title_attributes' => NULL,
+        // Render array. See "reliefweb_rivers_search" below.
+        'search' => NULL,
+        // Associative array with the type of resources as keys and the
+        // total of resources matching the search query and river title
+        // as values.
+        'totals' => [],
+        // List of sections constituing the page's content.
+        'sections' => [],
+      ],
+    ],
   ];
 
   // Add themes for the main river articles.

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
@@ -47,3 +47,10 @@ reliefweb_rivers.training.river:
     _controller: 'reliefweb_rivers.training.river:getPageContent'
   requirements:
     _permission: 'access content'
+reliefweb_rivers.search.results:
+  path: '/search/results'
+  defaults:
+    _title: 'Search results'
+    _controller: '\Drupal\reliefweb_rivers\Controller\SearchResults::getPageContent'
+  requirements:
+    _permission: 'access content'

--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchResults.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchResults.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Drupal\reliefweb_rivers\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\reliefweb_api\Services\ReliefWebApiClient;
+use Drupal\reliefweb_rivers\Parameters;
+use Drupal\reliefweb_rivers\RiverServiceBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for the reliefweb_rivers.search.results route.
+ */
+class SearchResults extends ControllerBase {
+
+  /**
+   * The ReliefWeb API client.
+   *
+   * @var \Drupal\reliefweb_api\Services\ReliefWebApiClient
+   */
+  protected $reliefWebApiClient;
+
+  /**
+   * Search query.
+   *
+   * @var string
+   */
+  protected $searchQuery;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\reliefweb_api\Services\ReliefWebApiClient $reliefweb_api_client
+   *   The reliefweb api client service.
+   */
+  public function __construct(ReliefWebApiClient $reliefweb_api_client) {
+    $this->reliefWebApiClient = $reliefweb_api_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('reliefweb_api.client')
+    );
+  }
+
+  /**
+   * Get the page content.
+   *
+   * @return array
+   *   Render array for the homepage.
+   */
+  public function getPageContent() {
+    $totals = [];
+    $sections = [];
+    $search = $this->getSearchQuery();
+
+    if (!empty($search)) {
+      // API queries.
+      $queries = [
+        'reports' => $this->getRiverApiQuery('report'),
+        'jobs' => $this->getRiverApiQuery('job'),
+        'training' => $this->getRiverApiQuery('training'),
+        'disasters' => $this->getRiverApiQuery('disaster'),
+        'organizations' => $this->getRiverApiQuery('source'),
+        'countries' => $this->getRiverApiQuery('country'),
+      ];
+
+      // @todo replace with a switch and formatPlural?
+      $labels = [
+        'reports' => [$this->t('report'), $this->t('reports')],
+        'jobs' => [$this->t('job'), $this->t('jobs')],
+        'training' => [$this->t('training'), $this->t('training')],
+        'disasters' => [$this->t('disaster'), $this->t('disasters')],
+        'organizations' => [$this->t('organization'), $this->t('organizations')],
+        'countries' => [$this->t('country'), $this->t('countries')],
+      ];
+
+      // Get the API data.
+      $results = $this->reliefWebApiClient
+        ->requestMultiple(array_filter($queries), TRUE);
+
+      // Parse the API results, building the page sections data.
+      foreach ($results as $index => $result) {
+        $query = $queries[$index];
+
+        if (empty($result['data'])) {
+          continue;
+        }
+
+        $total = $result['totalCount'];
+        $bundle = $query['bundle'];
+        $view = $query['view'] ?? '';
+        $exclude = $query['exclude'] ?? [];
+
+        $entities = RiverServiceBase::getRiverData($bundle, $result, $view, $exclude);
+        if (empty($entities)) {
+          continue;
+        }
+
+        $sections[$index] = [
+          '#theme' => 'reliefweb_rivers_river',
+          '#id' => $index,
+          '#title' => $query['title'],
+          '#results' => [
+            // @todo create helper that properly format plural AND format the
+            // number.
+            '#markup' => $this->formatPlural($total, '1 entry found', '@total entries found', [
+              '@total' => number_format($total),
+            ]),
+          ],
+          '#resource' => $query['resource'],
+          '#entities' => $entities,
+          '#more' => $query['more'] ?? NULL,
+        ];
+
+        $totals[$index] = [
+          'label' => $labels[$index][$total > 1 ? 1 : 0],
+          'total' => $total,
+        ];
+      }
+    }
+
+    return [
+      '#theme' => 'reliefweb_rivers_search_results',
+      '#title' => $this->t('Search results'),
+      '#search' => $this->getSearch(),
+      '#totals' => $totals,
+      '#sections' => $sections,
+    ];
+  }
+
+  /**
+   * Get the API payload to get the reports.
+   *
+   * @param string $bundle
+   *   Entity bundle of the river.
+   * @param int $limit
+   *   Number of headlines to return.
+   *
+   * @return array
+   *   API Payload.
+   */
+  public function getRiverApiQuery($bundle, $limit = 3) {
+    $service = RiverServiceBase::getRiverService($bundle);
+    $resource = $service->getResource();
+    $title = $service->getPageTitle();
+    $search = $this->getSearchQuery();
+
+    $payload = $service->getApiPayload();
+    $payload['query']['value'] = $this->getSearchQuery();
+
+    // The country river is not searchable, so ensure we get all the countries
+    // matching the query.
+    if ($bundle === 'country') {
+      $payload['limit'] = 1000;
+      $more = NULL;
+    }
+    // Otherwise add a link to the full river for the entity bundle, with the
+    // search query.
+    else {
+      $payload['limit'] = $limit;
+      $more = [
+        'url' => RiverServiceBase::getRiverUrl($bundle, [
+          'search' => $search,
+        ]),
+        'label' => $this->t('View all matching @resources', [
+          '@resources' => mb_strtolower($title),
+        ]),
+      ];
+    }
+
+    return [
+      'resource' => $resource,
+      'bundle' => $bundle,
+      'payload' => $payload,
+      'title' => $title,
+      'more' => $more,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSearch() {
+    return [
+      '#theme' => 'reliefweb_rivers_search',
+      '#path' => '/search/results',
+      '#label' => $this->t('Search ReliefWeb'),
+      '#query' => $this->getSearchQuery(),
+    ];
+  }
+
+  /**
+   * Get the search query from the URL parameter.
+   *
+   * @return string
+   *   Search query.
+   */
+  public function getSearchQuery() {
+    if (!isset($this->searchQuery)) {
+      $parameters = Parameters::getParameters();
+      if (isset($parameters['search'])) {
+        $this->searchQuery = trim($parameters['search']);
+      }
+      else {
+        $this->searchQuery = '';
+      }
+    }
+    return $this->searchQuery;
+  }
+
+}

--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchResults.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchResults.php
@@ -107,9 +107,9 @@ class SearchResults extends ControllerBase {
           '#results' => [
             // @todo create helper that properly format plural AND format the
             // number.
-            '#markup' => $this->formatPlural($total, '1 entry found', '@total entries found', [
+            '#markup' => '<p>' . $this->formatPlural($total, '1 entry found', '@total entries found', [
               '@total' => number_format($total),
-            ]),
+            ]) . '</p>',
           ],
           '#resource' => $query['resource'],
           '#entities' => $entities,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search-results.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search-results.html.twig
@@ -1,0 +1,34 @@
+{#
+
+/**
+ * @file
+ * Template for the search results page.
+ *
+ * Available variables:
+ * - attributes: wrapper attributes
+ * - search: see reliefweb-rivers-search.html.twig
+ * - totals: Associative array with the type of resources as keys and the
+ *   total of resources matching the search query and river title as values
+ * - sections: list of sections for the page. Each section is a render array.
+ */
+
+#}
+<div{{ attributes.addClass('rw-search-results') }}>
+  {{ search }}
+
+  {% if totals is not empty %}
+  <nav id="search-results-totals" class="rw-search-results__totals" aria-labelledby="search-results-totals-title">
+    <h2 id="search-results-totals-title" class="visually-hidden">{{ 'Results'|t }}</h2>
+    <ul class="rw-search-results__totals__list">
+      {% for target, item in totals %}
+        <li class="rw-search-results__totals__list__item"><a href="#{{ target }}">{{ '@total @label'|t({
+          '@total': item.total|number_format,
+          '@label': item.label,
+        }) }}</a></li>
+      {% endfor %}
+    </ul>
+  </nav>
+  {% endif %}
+
+  {{ sections }}
+</div>

--- a/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-results.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-results.css
@@ -25,8 +25,7 @@
   list-style: none;
   display: inline-block;
   padding: 0;
-  /* Compensate the margins of the <li> */
-  margin: -8px;
+  margin: 0;
 }
 .rw-search-results__totals li {
   float: left;

--- a/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-results.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-river/rw-river-results.css
@@ -16,3 +16,44 @@
     border-bottom: 1px solid #e6ecef;
   }
 }
+
+.rw-search-results__totals {
+  width: 100%;
+  text-align: center;
+}
+.rw-search-results__totals ul {
+  list-style: none;
+  display: inline-block;
+  padding: 0;
+  /* Compensate the margins of the <li> */
+  margin: -8px;
+}
+.rw-search-results__totals li {
+  float: left;
+  margin: 8px;
+}
+.rw-search-results__totals li a {
+  display: block;
+  padding: 12px 24px;
+  border-radius: 6px;
+  background: #e6ecef;
+  font-weight: bold;
+  font-size: 17px;
+}
+.rw-search-results__totals li:last-child {
+  margin-right: 0;
+}
+.rw-search-results section > h2 {
+  padding-left: 8px;
+  border-left: 8px solid #0988bb;
+  margin-bottom: 16px;
+}
+.rw-search-results section > h2 + p {
+  margin: 0 0 8px 0;
+}
+.rw-search-results section + section {
+  margin-top: 24px;
+}
+.rw-search-results h3 {
+  margin: 0 0 8px 0;
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-search/rw-search.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-search/rw-search.css
@@ -100,3 +100,7 @@
     background: var(--rw-icons--search--search--26--white);
   }
 }
+
+.rw-search-results .rw-river-article:first-child {
+  border-top: 1px solid #e6ecef;
+}

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-header.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-header.html.twig
@@ -2,7 +2,7 @@
 
   {% block header_content %}
     {% include '@common_design_subtheme/cd/cd-header/cd-global-header.html.twig' %}
-    {% include '@common_design/cd/cd-header/cd-site-header.html.twig' %}
+    {% include '@common_design_subtheme/cd/cd-header/cd-site-header.html.twig' %}
   {% endblock %}
 
 {% endembed %}

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
@@ -1,0 +1,38 @@
+<div class="cd-search">
+
+  <section{{ create_attribute()
+    .setAttribute('id', 'site-search')
+    .setAttribute('role', 'search')
+    .setAttribute('aria-labelledby', 'site-search-title')
+    .setAttribute('data-cd-toggable', 'Search'|t)
+    .setAttribute('data-cd-component', 'cd-search')
+    .setAttribute('data-cd-logo', 'search')
+    .setAttribute('data-cd-focus-target', 'site-search-input')
+    .addClass('cd-search__form')
+  }}>
+    <h2 id="site-search-title" class="visually-hidden"><?php rwpt("Content Search"); ?></h2>
+    <form action="/search/results" method="GET" accept-charset="UTF-8" class="cd-flow">
+      <div class="cd-form__item">
+        <label for="site-search-input" class="visually-hidden">{{ 'What are you looking for?'|t }}</label>
+        <input {{ create_attribute()
+          .setAttribute('type', 'search')
+          .setAttribute('name', 'search')
+          .setAttribute('id', 'site-search-input')
+          .setAttribute('autocomplete', 'off')
+          .setAttribute('placeholder', 'What are you looking for?'|t)
+          .setAttribute('size', '30')
+          .addClass('cd-search__input')
+        }}>
+      </div>
+      <div class="cd-form__item">
+        <button type="submit" value="search" class="cd-search__submit">
+          <svg class="cd-icon cd-icon--search" width="16" height="16">
+            <use xlink:href="#cd-icon--search"></use>
+          </svg>
+          <span class="visually-hidden">{{ 'Search|t' }}</span>
+        </button>
+      </div>
+    </form>
+  </section>
+
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-site-header.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-site-header.html.twig
@@ -1,0 +1,14 @@
+<div class="cd-site-header">
+  <div class="cd-container cd-site-header__inner">
+
+    {% include '@common_design/cd/cd-header/cd-logo.html.twig' %}
+
+    <div class="cd-site-header__actions">
+
+      {% include '@common_design_subtheme/cd/cd-header/cd-search.html.twig' %}
+
+      {% include '@common_design/cd/cd-header/cd-navigation.html.twig' %}
+
+    </div>
+  </div>
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-search-results.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-search-results.html.twig
@@ -1,0 +1,3 @@
+{{ attach_library('common_design_subtheme/rw-river-results') }}
+
+{% include '@reliefweb_rivers/reliefweb-rivers-search-results.html.twig' %}


### PR DESCRIPTION
Ticket: RW-80

This adds the search to the main header and the search results page (/search/results) which shows a list of resources (ex: reports, countries) matching the search query.

Note: for countries, the full list of matching countries is displayed as the country river is not searchable.