### PR TITLE
[RW-31] Add attributes for the river results

### DIFF
--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
@@ -128,6 +128,8 @@ function reliefweb_rivers_theme() {
         'title' => t('List'),
         // Title attributes.
         'title_attributes' => NULL,
+        // Results attributes.
+        'results_attributes' => NULL,
         // River attributes.
         'river_attributes' => NULL,
         // Results (optional). See "reliefweb_rivers_results" below.

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-page.html.twig
@@ -51,7 +51,10 @@
   {{ advanced_search }}
 
   {{ content|merge({
-    '#title_attributes': create_attribute().addClass('visually-hidden')
+    '#title_attributes': create_attribute().addClass('visually-hidden'),
+    '#results_attributes': create_attribute().addClass([
+      advanced_search ? 'rw-river-results--with-advanced-search',
+    ]),
   }) }}
 
   {% if links is not empty %}

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river.html.twig
@@ -11,6 +11,8 @@
  * - attributes: attributes for the section
  * - title: section title
  * - title_attributes: attributes for the river title
+ * - results_attributes: attributes for the river results
+ * - river_attributes: attributes for the river article list
  * - results: (optional) see reliefweb-rivers-results.html.twig
  * - entities: list of article entities constituting the river
  * - article_attributes: attributes for the river articles
@@ -29,7 +31,7 @@
   .addClass([
     'rw-river',
     'rw-river--' ~ id,
-    'rw-river--type-' ~ resource|clean_class
+    resource ? 'rw-river--type-' ~ resource|clean_class
   ])
 }}>
   <h{{ level }}{{ title_attributes.addClass([
@@ -37,7 +39,9 @@
   ]) }}>{{ title }}</h{{ level }}>
 
   {% if entities is not empty %}
-    {{ results }}
+    {{ results|merge({
+      '#attributes': results_attributes,
+    }) }}
 
     <div{{ river_attributes.addClass([
       'rw-river__articles',


### PR DESCRIPTION
Ticket: RW-31

This adds attributes for the results in the river template and a class variant when in a river with filters in the sidebar to help styling the results: `rw-river-results--with-advanced-serarch`.