### PR TITLE
RW-31 column layouts

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
@@ -199,6 +199,7 @@ trait DocumentTrait {
 
     return [
       '#theme' => 'reliefweb_rivers_river',
+      '#id' => 'related',
       '#title' => $title,
       '#resource' => 'reports',
       '#entities' => $entities,

--- a/html/themes/custom/common_design_subtheme/components/rw-article/rw-article.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-article/rw-article.css
@@ -119,23 +119,33 @@
     /* Compensate the margin from the articles. */
     margin: 0 -8px;
   }
-  .rw-river--river-columns .rw-river__articles .rw-river-article {
+  .rw-river--river-columns--two .rw-river-article {
     flex: 1 0 40%;
     width: 100%;
   }
-  .rw-river--river-columns .rw-river__articles .rw-river-article--card {
+  .rw-river--river-columns .rw-river-article--card {
     margin-right: 8px;
     margin-left: 8px;
     padding: 16px;
     border: 1px solid #e6ecef;
   }
-  .rw-river--river-columns .rw-river__articles .rw-river-article:nth-child(2) {
-    margin-top: 0; /* Compensate for cd-flow top margin */
+  /* Remove top margin from cd-flow for second item in two column layout */
+  .rw-river--river-columns--two .rw-river-article:nth-child(2) {
+    margin-top: 0;
   }
-  .rw-river--river-columns.rw-river--appeals-response-plans .rw-river__articles .rw-river-article:nth-child(2) {
-    margin-top: var(--cd-flow-space); /* Compensate for cd-flow top margin */
+  /* Remove bottom border from second last item in two column layout */
+  .rw-river--river-columns--two .rw-river-article:nth-last-child(2) {
+    padding-bottom: 0;
+    border-bottom: none;
   }
   .rw-river--river-columns .pager {
     border-top: none;
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1023px) {
+  /* Add top margin to second item when two column layout doesn't start until desktop breakpoint */
+  .rw-river--river-columns--two.rw-river--river-columns--desktop .rw-river-article:nth-child(2) {
+    margin-top: var(--cd-flow-space);
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-article/rw-article.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-article/rw-article.css
@@ -105,3 +105,37 @@
   vertical-align: middle;
   background: var(--rw-icons--common--external-link--12--dark-grey);
 }
+
+@media screen and (min-width: 768px) {
+  .rw-river--river-columns {
+    --cd-flow-space: 1rem;
+  }
+  .rw-river--river-columns .rw-river__articles {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .rw-river--river-columns.rw-river--river-list {
+    width: auto;
+    /* Compensate the margin from the articles. */
+    margin: 0 -8px;
+  }
+  .rw-river--river-columns .rw-river__articles .rw-river-article {
+    flex: 1 0 40%;
+    width: 100%;
+  }
+  .rw-river--river-columns .rw-river__articles .rw-river-article--card {
+    margin-right: 8px;
+    margin-left: 8px;
+    padding: 16px;
+    border: 1px solid #e6ecef;
+  }
+  .rw-river--river-columns .rw-river__articles .rw-river-article:nth-child(2) {
+    margin-top: 0; /* Compensate for cd-flow top margin */
+  }
+  .rw-river--river-columns.rw-river--appeals-response-plans .rw-river__articles .rw-river-article:nth-child(2) {
+    margin-top: var(--cd-flow-space); /* Compensate for cd-flow top margin */
+  }
+  .rw-river--river-columns .pager {
+    border-top: none;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-article/rw-maps-inforgraphics.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-article/rw-maps-inforgraphics.css
@@ -62,9 +62,6 @@
       padding: 0 0 24px 0;
       border: none;
     }
-    .rw-river--maps-infographics .rw-river-article:last-child {
-      padding-bottom: 24px;
-    }
     .rw-river--maps-infographics article header {
       flex: 1 0 auto;
       padding: 16px 16px 0 16px;
@@ -105,17 +102,32 @@
     .rw-river--maps-infographics .rw-river__articles {
       grid-template-columns: repeat(3, 1fr);
     }
+
+    .rw-river--maps-infographics article {
+      padding-bottom: 0;
+    }
   }
 
   @media screen and (min-width: 768px) {
     .rw-river--maps-infographics .rw-river__articles {
       grid-template-columns: repeat(2, 1fr);
     }
+
+    .rw-river--maps-infographics article {
+      padding-bottom: 24px;
+    }
+    .rw-river--maps-infographics .rw-river-article:last-child {
+      padding-bottom: 0;
+    }
   }
 
   @media screen and (min-width: 900px) {
     .rw-river--maps-infographics .rw-river__articles {
       grid-template-columns: repeat(3, 1fr);
+    }
+
+    .rw-river--maps-infographics article {
+      padding-bottom: 0;
     }
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-blog/rw-blog.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-blog/rw-blog.css
@@ -36,9 +36,6 @@
  *
  * List of the blog posts.
  */
-.rw-river-page--blog {
-  --cd-flow-space: 1rem;
-}
 .rw-river-page--blog .rw-river-article--blog-post > h3 {
   margin: 0;
   font-weight: normal;
@@ -58,28 +55,4 @@
   padding-top: 0;
   text-align: center;
   border-bottom: none;
-}
-
-@media screen and (min-width: 768px) {
-  .rw-river-page--blog .rw-river__articles {
-    display: flex;
-    flex-wrap: wrap;
-    width: auto;
-    /* Compensate the margin from the articles. */
-    margin: 0 -8px;
-  }
-  .rw-river-page--blog .rw-river__articles .rw-river-article--blog-post {
-    flex: 1 0 40%;
-    width: 100%;
-    margin-right: 8px;
-    margin-left: 8px;
-    padding: 16px;
-    border: 1px solid #e6ecef;
-  }
-  .rw-river-page--blog .rw-river__articles .rw-river-article--blog-post:nth-child(2) {
-    margin-top: 0; /* Compensate for cd-flow top margin */
-  }
-  .rw-river-page--blog .pager {
-    border-top: none;
-  }
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-organizations/rw-organizations.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-organizations/rw-organizations.css
@@ -1,34 +1,9 @@
 /**
  * Organization landing page styling.
  */
-.rw-river-page--organizations {
-  --cd-flow-space: 1rem;
-}
-
 @media screen and (min-width: 768px) {
   .path-organizations section.rw-river .rw-river-results {
     text-align: center;
     border-bottom: none;
-  }
-  .path-organizations section.rw-river .rw-river__articles {
-    display: flex;
-    flex-wrap: wrap;
-    width: auto;
-    /* Compensate the margin from the rw-river__articles. */
-    margin: 0 -8px;
-  }
-  .path-organizations section.rw-river .rw-river__articles article {
-    flex: 1 0 40%;
-    width: 100%;
-    margin-right: 8px;
-    margin-left: 8px;
-    padding: 16px;
-    border: 1px solid #e6ecef;
-  }
-  .path-organizations .rw-river__articles .rw-river-article--source:nth-child(2) {
-    margin-top: 0; /* Compensate for cd-flow top margin */
-  }
-  .path-organizations .pager {
-    border-top: none;
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-related-content/rw-related-content.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-related-content/rw-related-content.css
@@ -3,48 +3,32 @@
  *
  * List of documents related to the main document.
  */
-.rw-document + .rw-river--type-reports {
+.rw-river--related {
   margin: 0;
   padding: 32px 0 24px;
   border-top: 1px solid #e6ecef;
 }
-.rw-document + .rw-river--type-reports h2 {
+.rw-river--related h2 {
   padding-bottom: 12px;
   border-bottom: 1px solid #eb1405;
   /* margin: 0 0 8px 0; */
   font-size: 24px;
 }
-.rw-document + .rw-river--type-reports .rw-river__articles {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-}
-.rw-document + .rw-river--type-reports .rw-river__articles article {
-  width: 100%;
-}
-
-@media screen and (min-width: 768px) {
-  .rw-document + .rw-river--type-reports .rw-river__articles {
-    width: auto;
-    /* Compensate the margin from the articles. */
-    margin: 0 -16px;
-  }
-  .rw-document + .rw-river--type-reports .rw-river__articles article {
-    flex: 1 0 40%;
-    margin-right: 16px;
-    margin-left: 16px;
-  }
-  .rw-document + .rw-river--type-reports .rw-river__articles article:nth-last-child(2) {
-    padding-bottom: 0;
-    border-bottom: none;
-  }
-  .rw-document + .rw-river--type-reports .rw-river__articles article:nth-child(2) {
-    margin-top: 0; /* Compensate for cd-flow top margin */
-  }
-}
-.rw-document + .rw-river--type-reports .rw-river__articles article footer {
+.rw-river--related article footer {
   display: flex;
   flex: 1 0 auto;
   flex-direction: column;
   justify-content: flex-end;
+}
+
+@media screen and (min-width: 768px) {
+  .rw-river--related .rw-river__articles {
+    width: auto;
+    /* Compensate the margin from the articles. */
+    margin: 0 -16px;
+  }
+  .rw-river--related .rw-river__articles article {
+    margin-right: 16px;
+    margin-left: 16px;
+  }
 }

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-page.html.twig
@@ -4,7 +4,7 @@
 
 {% if river == 'organizations' or river == 'blog' %}
   {% set content = content|merge({
-    '#attributes': create_attribute().addClass('rw-river--river-columns'),
+    '#attributes': create_attribute().addClass('rw-river--river-columns','rw-river--river-columns--two'),
   }) %}
 
 {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-page.html.twig
@@ -2,4 +2,11 @@
 
 {{ attach_library('common_design_subtheme/rw-page-title') }}
 
+{% if river == 'organizations' or river == 'blog' %}
+  {% set content = content|merge({
+    '#attributes': create_attribute().addClass('rw-river--river-columns'),
+  }) %}
+
+{% endif %}
+
 {% include '@reliefweb_rivers/reliefweb-rivers-page.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
@@ -16,7 +16,7 @@
   {% set article_attributes = article_attributes.addClass('rw-river-article--card') %}
 {% elseif id == 'maps-infographics' %}
   {% set article_attributes = article_attributes.addClass('rw-river-article--map') %}
-  {% set attributes = attributes.addClass('rw-river--river-columns','rw-river--river-columns--three') %}
+  {% set attributes = attributes.addClass('rw-river--river-columns') %}
 {% elseif id == 'appeals-response-plans' %}
   {% set article_attributes = article_attributes.addClass('rw-river-article--appeal') %}
   {% set attributes = attributes.addClass('rw-river--river-columns','rw-river--river-columns--two','rw-river--river-columns--desktop') %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
@@ -12,10 +12,16 @@
    templates rather than the following conditions. #}
 {% if id == 'headlines' %}
   {% set article_attributes = article_attributes.addClass('rw-river-article--headline') %}
+{% elseif id == 'river-list' %}
+  {% set article_attributes = article_attributes.addClass('rw-river-article--card') %}
 {% elseif id == 'maps-infographics' %}
   {% set article_attributes = article_attributes.addClass('rw-river-article--map') %}
+  {% set attributes = attributes.addClass('rw-river--river-columns') %}
 {% elseif id == 'appeals-response-plans' %}
   {% set article_attributes = article_attributes.addClass('rw-river-article--appeal') %}
+  {% set attributes = attributes.addClass('rw-river--river-columns') %}
+{% elseif id == 'related' %}
+  {% set attributes = attributes.addClass('rw-river--river-columns') %}
 {% endif %}
 
 {% include '@reliefweb_rivers/reliefweb-rivers-river.html.twig' %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-river.html.twig
@@ -16,12 +16,12 @@
   {% set article_attributes = article_attributes.addClass('rw-river-article--card') %}
 {% elseif id == 'maps-infographics' %}
   {% set article_attributes = article_attributes.addClass('rw-river-article--map') %}
-  {% set attributes = attributes.addClass('rw-river--river-columns') %}
+  {% set attributes = attributes.addClass('rw-river--river-columns','rw-river--river-columns--three') %}
 {% elseif id == 'appeals-response-plans' %}
   {% set article_attributes = article_attributes.addClass('rw-river-article--appeal') %}
-  {% set attributes = attributes.addClass('rw-river--river-columns') %}
+  {% set attributes = attributes.addClass('rw-river--river-columns','rw-river--river-columns--two','rw-river--river-columns--desktop') %}
 {% elseif id == 'related' %}
-  {% set attributes = attributes.addClass('rw-river--river-columns') %}
+  {% set attributes = attributes.addClass('rw-river--river-columns','rw-river--river-columns--two') %}
 {% endif %}
 
 {% include '@reliefweb_rivers/reliefweb-rivers-river.html.twig' %}


### PR DESCRIPTION
This is an attempt to consolidate the layout for

1. Blog list
2. Organizations list
3. Appeals and Response Plans block on Country page
4. Maps and Infographics block on Country page
5. Related block on Report page

As per this comment https://github.com/UN-OCHA/rwint9-site/pull/60#discussion_r691778092

The difficulty is the lack of shared layout rules these elements have, as explained here: https://github.com/UN-OCHA/rwint9-site/pull/60#issuecomment-903811208
