### PR TITLE
[RW-98] Enable taxonomy term preview

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -66,6 +66,7 @@ module:
   syslog: 0
   system: 0
   taxonomy: 0
+  taxonomy_term_preview: 0
   taxonomy_term_revision: 0
   text: 0
   theme_switcher: 0


### PR DESCRIPTION
Ticket: RW-98

Forgot to push the config to enable the taxonomy term preview module.