### PR TITLE
[RW-172] Fix moderation page query for compatibility with docksal mysql

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -1180,6 +1180,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
     // Wrap the query.
     $wrapper = $this->getDatabase()->select($query, 'subquery');
     $wrapper->addField('subquery', 'content_entity_id', 'entity_id');
+    $wrapper->addField('subquery', $sort_field_alias, 'sort');
 
     // Keep track of the subquery.
     // @todo review if that's still necessary.


### PR DESCRIPTION
Ticket: RW-172

This should fix the issue with doksal's mysql which has stricter settings (see [ONLY_FULL_GROUP_BY](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by)).