### PR TITLE
[RW-204] Move xdebug out of main Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,8 +65,3 @@ COPY --from=builder /srv/www/patches /srv/www/patches
 COPY --from=builder /srv/www/scripts /srv/www/scripts
 COPY --from=builder /srv/www/docker/etc/nginx/apps/drupal/fastcgi_drupal.conf /etc/nginx/apps/drupal/fastcgi_drupal.conf
 COPY --from=builder /srv/www/docker/etc/nginx/apps/drupal/drupal.conf /etc/nginx/apps/drupal/drupal.conf
-
-RUN apk add php8-pecl-xdebug && \
-    echo 'zend_extension=xdebug;' >> /etc/php8/conf.d/90_xdebug.ini
-
-RUN mkdir -p /srv/www/html/build/logs

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,6 @@
+FROM unocha/rwint9-site:local
+
+RUN apk add php8-pecl-xdebug && \
+    echo 'zend_extension=xdebug;' >> /etc/php8/conf.d/90_xdebug.ini
+
+RUN mkdir -p /srv/www/html/build/logs

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - default
 
   drupal:
-    image: unocha/rwint9-site:local
+    build: ./
     hostname: rwint9-test-site
     container_name: rwint9-test-site
     depends_on:


### PR DESCRIPTION
Ticket: RW-204

**xdebug** was added part of the work on the tests (https://github.com/UN-OCHA/rwint9-site/pull/123) but it may not be appropriate to have the extension enabled on prod.

This PR proposes to add xdebug via a `tests/Dockerfile` that "extends" `docker/Dockerfile` so that it's only present for the tests.

@attiks @cafuego What do you think?