### PR TITLE
[RW-211] Add missing sortable headers to moderation page table

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -426,11 +426,26 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
     // Execute the query.
     $results = $this->executeQuery($filters, $limit);
 
+    // Get the headers with the one currently used for sorting flagged.
+    $headers = $this->getOrderInformation()['headers'];
+
+    // Compute the sort URL for the sortable headers.
+    $query = $this->request->query->all();
+    $remove = ['form_build_id', 'form_id', 'submit', 'page'];
+    $query = array_diff_key($query, array_flip($remove));
+    foreach ($headers as $header => $info) {
+      if (isset($info['sortable'])) {
+        $headers[$header]['url'] = Url::fromRoute('<current>', [
+          'order' => $header,
+          'sort' => ($info['sort'] ?? 'desc') === 'desc' ? 'asc' : 'desc',
+        ] + $query);
+      }
+    }
+
     return [
       '#theme' => 'reliefweb_moderation_table',
       '#totals' => $this->getTotals($results),
-      // Get the headers with the one currently used for sorting flagged.
-      '#headers' => $this->getOrderInformation()['headers'],
+      '#headers' => $headers,
       '#rows' => $this->getRows($results),
       '#empty' => $this->t('No results'),
       // @todo check if there are some parameters like `op` that should be

--- a/html/modules/custom/reliefweb_moderation/templates/reliefweb-moderation-table.html.twig
+++ b/html/modules/custom/reliefweb_moderation/templates/reliefweb-moderation-table.html.twig
@@ -23,7 +23,13 @@
           header.sortable ? 'rw-moderation-table__header--sortable',
           header.sort ? 'rw-moderation-table__header--sort--' ~ header.sort|clean_class,
         ])
-      }}>{{ header.label }}</th>
+      }}>
+        {% if header.sortable and header.url %}
+          {{ link(header.label, header.url) }}
+        {% else %}
+          {{ header.label }}
+        {% endif %}
+      </th>
     {% endfor %}
     </tr>
   </thead>

--- a/html/themes/custom/common_design_subtheme/components/rw-moderation/rw-moderation.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-moderation/rw-moderation.css
@@ -192,3 +192,16 @@
   white-space: pre;
   font-size: 15px;
 }
+.path-moderation .rw-moderation-list .rw-moderation-table__header--sort--asc:after,
+.path-moderation .rw-moderation-list .rw-moderation-table__header--sort--desc:after {
+  display: inline-block;
+  overflow: hidden;
+  width: 12px;
+  height: 12px;
+  content: "";
+  vertical-align: middle;
+  background: var(--rw-icons--toggle--up--12--dark-blue);
+}
+.path-moderation .rw-moderation-list .rw-moderation-table__header--sort--desc:after {
+  background: var(--rw-icons--toggle--down--12--dark-blue);
+}


### PR DESCRIPTION
Ticket: RW-211

This makes the sortable headers in the moderation page table links to order the results.

<img width="596" alt="Screen Shot 2021-10-14 at 14 32 07" src="https://user-images.githubusercontent.com/696348/137257611-1620ccbb-aeeb-4cf9-869c-68c5df86363e.png">
