### PR TITLE
RW-129 subscription updates

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-guidelines/rw-guidelines.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-guidelines/rw-guidelines.css
@@ -1,11 +1,11 @@
 form[data-with-guidelines] button[data-guideline] {
   display: inline-block;
-  vertical-align: middle;
+  overflow: hidden;
   width: 20px;
   height: 20px;
-  padding: 0 0 0 12px;
   margin: -3px 0 0 8px;
-  overflow: hidden;
+  padding: 0 0 0 12px;
+  vertical-align: middle;
   border: 4px solid #e6ecef;
   border-radius: 50%;
   background: var(--rw-icons--common--help--12--dark-blue);
@@ -15,48 +15,48 @@ form[data-with-guidelines] button[data-guideline]:hover {
   background: var(--rw-icons--common--help--12--dark-red);
 }
 form[data-with-guidelines] .rw-guideline:before {
-  content: "";
   position: fixed;
+  z-index: 10000;
   top: 0;
-  left: 0;
   right: 0;
   bottom: 0;
+  left: 0;
   margin: 0;
   padding: 0;
+  content: "";
   background: rgba(1, 1, 1, 0.3);
-  z-index: 10000;
 }
 form[data-with-guidelines] .rw-guideline {
   position: fixed;
+  z-index: 1;
   top: 10vh;
   left: 25vw;
   width: 50vw;
   height: 80vh;
   border: 10px solid black;
   border: 10px solid rgba(0, 0, 0, 0.1);
-  z-index: 1;
 }
 form[data-with-guidelines] .rw-guideline > button[value="close"] {
   position: absolute;
-  width: 28px;
-  height: 28px;
+  z-index: 10002;
   top: -16px;
   left: -16px;
-  padding: 0 0 0 22px;
   overflow: hidden;
+  width: 28px;
+  height: 28px;
+  padding: 0 0 0 22px;
   border: 2px solid #2e3436;
   border-radius: 50%;
   background: white;
-  z-index: 10002;
 }
 form[data-with-guidelines] .rw-guideline > button[value="close"]:after {
-  content: "";
   position: absolute;
   top: 6px;
   left: 6px;
+  overflow: hidden;
   width: 12px;
   height: 12px;
-  overflow: hidden;
+  content: "";
   background: var(--rw-icons--common--close--18--dark-grey);
 }
 form[data-with-guidelines] .rw-guideline > button[value="close"]:hover {
@@ -67,13 +67,13 @@ form[data-with-guidelines] .rw-guideline > button[value="close"]:hover:after {
 }
 form[data-with-guidelines] .rw-guideline > div {
   position: relative;
+  z-index: 10001;
+  overflow-x: hidden;
+  overflow-y: auto;
   width: 100%;
   height: 100%;
   padding: 16px;
   background-color: white;
-  overflow-y: auto;
-  overflow-x: hidden;
-  z-index: 10001;
 }
 form[data-with-guidelines] .rw-guideline > div > h3 {
   text-align: center;

--- a/html/themes/custom/common_design_subtheme/templates/form/form--subscription-form.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/form/form--subscription-form.html.twig
@@ -11,6 +11,7 @@
  */
 #}
 
+{{ attach_library('common_design/cd-form') }}
 {{ attach_library('common_design_subtheme/rw-user') }}
 
 <form{{ attributes.addClass('cd-flow cd-form') }}>


### PR DESCRIPTION
Follow up from https://github.com/UN-OCHA/rwint9-site/pull/138
I noticed the select element was higher than the others.
`normalize.css` used `box-sizing: content-box` for `input[type=search]`
Adding cd-form to the form template overrides this with `border-box`

Also ran `npm run sass:lint-fix` and this caught the recent guidelines stylesheet.