### PR TITLE
[RW-160] Add datetime wrapper template

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/form/datetime-wrapper.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/form/datetime-wrapper.html.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * @file
+ * Theme override of a datetime form wrapper.
+ *
+ * Available variables:
+ * - content: The form element to be output, usually a datelist, or datetime.
+ * - title: The title of the form element.
+ * - title_attributes: HTML attributes for the title wrapper.
+ * - description: Description text for the form element.
+ * - required: An indicator for whether the associated form element is required.
+ *
+ * @see template_preprocess_datetime_wrapper()
+ *
+ * @todo move that to the CD base theme.
+ */
+#}
+{%
+  set title_classes = [
+    'label',
+    required ? 'js-form-required',
+    required ? 'form-required',
+  ]
+%}
+{% if title %}
+  <h4{{ title_attributes.addClass(title_classes) }}>{{ title }}</h4>
+{% endif %}
+{{ content }}
+{% if errors %}
+  <div class="form-item--error-message">
+    <strong>{{ errors }}</strong>
+  </div>
+{% endif %}
+{% if description %}
+  <div{{ description_attributes.addClass('description') }}>
+    {{ description }}
+  </div>
+{% endif %}


### PR DESCRIPTION
Ticket: RW-160

Missing piece from https://github.com/UN-OCHA/rwint9-site/pull/146: datetime wrapper template (straight from the `classy` theme).

This notably wraps the field description.