### PR TITLE
[RW-214] Fix utility helpers

### DIFF
--- a/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSanitizer.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSanitizer.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\reliefweb_utility\Helpers;
 
+use Drupal\Component\Render\MarkupInterface;
 use Drupal\Component\Utility\UrlHelper;
 use League\CommonMark\CommonMarkConverter;
 
@@ -108,7 +109,7 @@ class HtmlSanitizer {
    * This also attempts to fix the heading hierarchy, at least preventing
    * the use of h1 and h2 in the sanitized content.
    *
-   * @param string $html
+   * @param string|\Drupal\Component\Render\MarkupInterface $html
    *   HTML string to sanitize.
    *
    * @return string
@@ -116,7 +117,7 @@ class HtmlSanitizer {
    */
   public function sanitizeHtml($html) {
     // Skip if html is not a string.
-    if (!is_string($html)) {
+    if (!is_string($html) && !($html instanceof MarkupInterface)) {
       return '';
     }
 

--- a/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSummarizer.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSummarizer.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\reliefweb_utility\Helpers;
 
+use Drupal\Component\Render\MarkupInterface;
 use Drupal\Component\Utility\Html;
 
 /**
@@ -12,7 +13,7 @@ class HtmlSummarizer {
   /**
    * Summarize and truncate a HTML text to a given length.
    *
-   * @param string $html
+   * @param string|\Drupal\Component\Render\MarkupInterface $html
    *   HTML to summarize.
    * @param int $length
    *   Maximum length of the text.
@@ -24,7 +25,7 @@ class HtmlSummarizer {
    *   Truncated text.
    */
   public static function summarize($html, $length = 600, $plain_text = TRUE) {
-    if (!is_string($html)) {
+    if (!is_string($html) && !($html instanceof MarkupInterface)) {
       return '';
     }
 

--- a/html/modules/custom/reliefweb_utility/src/Helpers/LocalizationHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/LocalizationHelper.php
@@ -127,8 +127,8 @@ class LocalizationHelper {
    *   Language for which to return a Collator. Defaults to the current
    *   language.
    *
-   * @return \Collator|null
-   *   Collator.
+   * @return \Collator|false
+   *   Collator or FALSE if there is no collator for the language.
    */
   public static function getCollator($language = NULL) {
     static $collators = [];
@@ -179,8 +179,8 @@ class LocalizationHelper {
    *   Language for which to return a Collator. Defaults to the current
    *   language.
    *
-   * @return \Collator
-   *   Collator.
+   * @return \Collator|null
+   *   Collator or NULL if the collator couldn't be created.
    */
   protected static function collatorCreate($language) {
     return collator_create($language);
@@ -188,6 +188,9 @@ class LocalizationHelper {
 
   /**
    * Get the last error code.
+   *
+   * @return int
+   *   Error code.
    */
   protected static function intlGetErrorCode() {
     return intl_get_error_code();


### PR DESCRIPTION
Ticket: RW-214

This allows the HtmlSanitizer and HtmlSummarizer helpers to accept a MarkupInterface as input.

This is for example the case when the summarizer is called for the topics on the `/topics` landing page.

Sneaked in a comment update for the localization helper.