### PR TITLE
RW-125 remove rule to align subject select horizontally

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-user/rw-user.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-user/rw-user.css
@@ -78,6 +78,3 @@
   padding: 16px 0 32px;
   border-bottom: 1px solid #e6ecef;
 }
-.field--name-field-sender > .form-item {
-  display: flex;
-}


### PR DESCRIPTION
As per this comment, https://github.com/UN-OCHA/rwint9-site/pull/159#pullrequestreview-787680447
instead of matching styles to D7 form, place the label above the select element.
![Selection_119](https://user-images.githubusercontent.com/1835923/138728056-5c9fafce-a41e-4952-a8e7-03b30f3f7ea2.png)


