### PR TITLE
RW-31 more frontend QA

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-country-slug/rw-country-slug.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-country-slug/rw-country-slug.css
@@ -38,3 +38,8 @@
 .rw-entity-country-slug a:active {
   text-decoration: underline;
 }
+
+/* Hide country slug on Country pages */
+.taxonomy-term--country--full .rw-entity-country-slug {
+  display: none;
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-pager/rw-pager.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-pager/rw-pager.css
@@ -54,3 +54,16 @@
 .pager li.cd-pager__item--ellipsis:after {
   margin-left: 16px;
 }
+/* So the pager nav element expands the entire width of the cd-layout-content area. */
+@media screen and (min-width: 768px) {
+.rw-river-page--with-advanced-search .pager {
+    width: calc(100% + 340px);
+    margin-left: -340px;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .rw-river-page--with-advanced-search .pager {
+    width: calc(100% + 360px);
+    margin-left: -360px;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-revisions/rw-revisions.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-revisions/rw-revisions.css
@@ -116,6 +116,17 @@
   text-decoration: line-through;
   color: red;
 }
+.rw-revisions-history-entry__content__value .rw-revisions-checked::before {
+  content: "\2713 ";
+  display: inline-block;
+  border: 1px solid #e6ecef;
+  width: 12px;
+  height: 12px;
+  color: #2e3436;
+  line-height: 11px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
 .rw-revisions-history-entry__content__value .rw-revisions-added {
   color: green;
 }

--- a/html/themes/custom/common_design_subtheme/templates/navigation/pager.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/navigation/pager.html.twig
@@ -33,7 +33,7 @@
 {{ attach_library('common_design_subtheme/rw-pager') }}
 {% if items %}
   <nav class="pager" role="navigation" aria-labelledby="{{ heading_id }}">
-    <h4 id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</h4>
+    <h3 id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</h3>
     <ul class="cd-pager__items js-pager__items">
       {# Print first item if we are not on the first page. #}
       {% if items.first %}


### PR DESCRIPTION
Based on recent QA and discussion
-  RW-100 style checked/uncheck revision like D7
![Selection_150](https://user-images.githubusercontent.com/1835923/140200910-f695f828-b10a-4b58-9ec3-6732cafc3b3e.png)

- Hide country slug in all sections on Country pages

- Change pagination heading from h4 to h3
- On pages with `rw-river-page--with-advanced-search` change pagination width to span full width of container, despite its parent section width being restricted

**To Test:**
Pagination on `/organizations` should display as usual
On pages like `/updates` pagination should span full width and remain centered from 768px upwards
