### PR TITLE
[RW-253] Fix active link in book navigation

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/Entity/Book.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Book.php
@@ -3,6 +3,7 @@
 namespace Drupal\reliefweb_entities\Entity;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\reliefweb_entities\BundleEntityInterface;
 use Drupal\reliefweb_entities\DocumentInterface;
@@ -90,18 +91,27 @@ class Book extends Node implements BundleEntityInterface, EntityModeratedInterfa
    *   TRUE of the active link was found and marked.
    */
   protected function markBookMenuActiveLink(array &$links) {
-    // This book's url which we assume is the active link when `getBookOutline`
-    // is called.
-    $url = 'entity:node/' . $this->id();
+    // We assume the current book is the active one when `getBookOutline` is
+    // called so we'll check the menu links for a link matching this book.
+    $id = $this->id();
 
     $found = FALSE;
     foreach ($links as &$link) {
-      if (isset($link['url']) && $link['url'] === $url) {
-        $found = $link['active'] = TRUE;
+      $url = $link['url'] ?? NULL;
+
+      if ($url instanceof Url && $url->isRouted() && $url->getRouteName() === 'entity.node.canonical') {
+        $route_parameters = $url->getRouteParameters();
+        if (isset($route_parameters['node']) && $route_parameters['node'] == $id) {
+          $link['active'] = TRUE;
+          return TRUE;
+        }
       }
-      elseif ($link['below']) {
+
+      // Check the menu children.
+      if (!empty($link['below'])) {
         $found = $this->markBookMenuActiveLink($link['below']);
       }
+
       // No need to proceed further if we found the active link.
       if ($found) {
         return TRUE;


### PR DESCRIPTION
Ticket: RW-253

This fixes the logic to determine the active link in the book navigation:

<img width="1192" alt="Screen Shot 2021-11-04 at 18 08 21" src="https://user-images.githubusercontent.com/696348/140287195-973d28c7-b7d9-48f8-9c80-29f11e7f0c45.png">

## Tests

Simply check that the highlighted entry in the book navigation corresponds to the current page.