### PR TITLE
[RW-252] Prevent display of text section with 'empty' content

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/SectionedContentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/SectionedContentTrait.php
@@ -135,7 +135,7 @@ trait SectionedContentTrait {
    *   Render array with the text content.
    */
   public function getEntityTextField($field_name, $id, $title, $iframe = TRUE, array $allowed_attributes = []) {
-    if (!$this->{$field_name}->isEmpty()) {
+    if (!$this->{$field_name}->isEmpty() && trim($this->{$field_name}->value) !== '') {
       return [
         '#theme' => [
           'reliefweb_entities_entity_text__' . $this->bundle() . '__' . $id,


### PR DESCRIPTION
Ticket: RW-252

This prevents the display of sections on country/disaster/topic etc. pages when their content is basically empty (ex: /topic/humanitarian-financing overview is just 2 blank lines so it shouldn't be displayed).