### PR TITLE
RW-257 User posting right/s

### DIFF
--- a/config/theme_switcher.rule.request_path.yml
+++ b/config/theme_switcher.rule.request_path.yml
@@ -12,5 +12,5 @@ admin_theme: common_design_subtheme
 visibility:
   request_path:
     id: request_path
-    pages: "/moderation/content/*\r\n/user/*/edit\r\n/user/*/notifications\r\n/user/*/bookmarks\r\n/user/*/posts\r\n/user/*/contact\r\n/admin/community-topics"
+    pages: "/moderation/content/*\r\n/user/*/edit\r\n/user/*/notifications\r\n/user/*/bookmarks\r\n/user/*/posts\r\n/user/*/contact\r\n/admin/community-topics\r\n/admin/reliefweb_revisions/history/*/*"
     negate: false

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -198,6 +198,7 @@ rw-moderation:
     - common_design_subtheme/rw-datepicker
     - common_design_subtheme/rw-icons
     - common_design_subtheme/rw-selection
+    - common_design_subtheme/rw-user-posting-right
 
 rw-moderation-information:
   css:
@@ -268,6 +269,7 @@ rw-revisions:
   dependencies:
    - common_design_subtheme/rw-icons
    - common_design_subtheme/rw-loading
+   - common_design_subtheme/rw-user-posting-right
 
 rw-river:
   css:
@@ -351,7 +353,12 @@ rw-user-information:
     theme:
       components/rw-user-information/rw-user-information.css: {}
   dependencies:
-   - common_design_subtheme/rw-user-posting-rights
+    - common_design_subtheme/rw-user-posting-right
+
+rw-user-posting-right:
+  css:
+    theme:
+      components/rw-user-posting-right/rw-user-posting-right.css: {}
 
 rw-user-posting-rights:
   css:

--- a/html/themes/custom/common_design_subtheme/components/rw-user-posting-right/rw-user-posting-right.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-user-posting-right/rw-user-posting-right.css
@@ -1,0 +1,31 @@
+/**
+ * User posting rights.
+ *
+ * Text showing the user posting rights for a source.
+ */
+.rw-user-posting-right {
+  margin-left: 2px;
+  padding: 2px 4px;
+  vertical-align: middle;
+  text-transform: uppercase;
+  border: 1px solid var(--cd-reliefweb-grey--light);
+  background: var(--cd-reliefweb-grey--light--bg);
+  font-size: 10px;
+  font-weight: bold;
+}
+.rw-user-posting-right[data-user-posting-right="blocked"] {
+  border-color: var(--cd-reliefweb-red);
+  background: var(--cd-reliefweb-red--bg);
+}
+.rw-user-posting-right[data-user-posting-right="unverified"] {
+  border-color: var(--cd-reliefweb-orange);
+  background: var(--cd-reliefweb-orange--bg);
+}
+.rw-user-posting-right[data-user-posting-right="allowed"] {
+  border-color: var(--cd-reliefweb-blue);
+  background: var(--cd-reliefweb-blue--bg);
+}
+.rw-user-posting-right[data-user-posting-right="trusted"] {
+  border-color: var(--cd-reliefweb-green);
+  background: var(--cd-reliefweb-green--bg);
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-user-posting-rights/rw-user-posting-rights.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-user-posting-rights/rw-user-posting-rights.css
@@ -1,36 +1,4 @@
 /**
- * User posting rights.
- *
- * Text showing the user posting rights for a source.
- */
-.rw-user-posting-right {
-  margin-left: 2px;
-  padding: 2px 4px;
-  vertical-align: middle;
-  text-transform: uppercase;
-  border: 1px solid var(--cd-reliefweb-grey--light);
-  background: var(--cd-reliefweb-grey--light--bg);
-  font-size: 10px;
-  font-weight: bold;
-}
-.rw-user-posting-right[data-user-posting-right="blocked"] {
-  border-color: var(--cd-reliefweb-red);
-  background: var(--cd-reliefweb-red--bg);
-}
-.rw-user-posting-right[data-user-posting-right="unverified"] {
-  border-color: var(--cd-reliefweb-orange);
-  background: var(--cd-reliefweb-orange--bg);
-}
-.rw-user-posting-right[data-user-posting-right="allowed"] {
-  border-color: var(--cd-reliefweb-blue);
-  background: var(--cd-reliefweb-blue--bg);
-}
-.rw-user-posting-right[data-user-posting-right="trusted"] {
-  border-color: var(--cd-reliefweb-green);
-  background: var(--cd-reliefweb-green--bg);
-}
-
-/**
  * User posting rights form.
  *
  * This is the form used to manage user posting rights per organization.

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_moderation/reliefweb-moderation-user-posting-right.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_moderation/reliefweb-moderation-user-posting-right.html.twig
@@ -1,4 +1,4 @@
-{{ attach_library('common_design_subtheme/rw-user-posting-rights') }}
+{{ attach_library('common_design_subtheme/rw-user-posting-right') }}
 
 {% set attributes = attributes.addClass('rw-user-posting-right') %}
 


### PR DESCRIPTION
RW-257
- split libraries for user posting right/s
- add as dependency where relevant

I've checked 
1. `node/3758093/edit` (Training user information)
2. `taxonomy/term/2007/user-posting-rights` Organization user posting rights
3. `taxonomy/term/2007/edit#edit-revision-information` or `taxonomy/term/2007/user-posting-rights` Organization revisions user posting rights
4. `moderation/content/training`

I don't see the class `rw-user-posting-right` applied to the revision history spans. @orakili Can you take a look? And also let me know if there are other places this component appears that I neglected to check.
![Selection_155](https://user-images.githubusercontent.com/1835923/141161830-97794a62-a4ee-4ffd-a476-9921ddabe265.png)


