### PR TITLE
RW-25 Report attachments

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-report/rw-report.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-report/rw-report.css
@@ -4,85 +4,86 @@
  * Individual report pages. Those are made of the main content body with
  * eventual attachments.
  */
-/* Lists in content */
-.node--report--full li {
-  margin: 8px 0 0;
-}
+
 /* Attachments. */
-.node--report--full #attachments {
+.node--report--full .rw-report__content section {
+  padding-top: 0;
+}
+.node--report--full .rw-attachment {
   margin: 0 auto 24px auto;
   padding-top: 0;
 }
-.node--report--full #attachments.report {
+.node--report--full .rw-attachment.rw-attachment--report {
   max-width: 220px;
 }
 
 @media screen and (min-width: 480px) {
-  .node--report--full #attachments.report {
+  .node--report--full .rw-attachment.rw-attachment--report {
     float: right;
     margin-left: 24px;
   }
 }
-.node--report--full #attachments ul {
+.node--report--full .rw-attachment ul {
   margin: 0;
   padding: 0;
   list-style: none;
 }
-.node--report--full #attachments li {
+.node--report--full .rw-attachment li {
   margin: 0;
   padding: 16px 0;
   text-align: center;
   border: 1px solid var(--cd-reliefweb-brand-grey--light);
 }
-.node--report--full #attachments li + li {
+.node--report--full .rw-attachment li + li {
   margin-top: 24px;
 }
-.node--report--full #attachments img {
+.node--report--full .rw-attachment img {
   width: 100%;
   margin: -16px 0 8px 0;
   border-bottom: 1px solid var(--cd-reliefweb-brand-grey--light);
 }
-.node--report--full #attachments strong {
+.node--report--full .rw-attachment strong {
   display: block;
   padding: 0 16px;
 }
-.node--report--full #attachments strong:first-letter {
+.node--report--full .rw-attachment strong:first-letter {
   text-transform: capitalize;
 }
-.node--report--full #attachments span {
+.node--report--full .rw-attachment span {
   display: block;
   padding: 4px 16px 0 16px;
   font-size: 14px;
 }
 /* Interactive tool screenshots. */
-.node--report--full #interactive {
+.node--report--full .rw-attachment--interactive {
   padding-top: 0;
   text-align: center;
 }
-.node--report--full #interactive h3 {
+.node--report--full .rw-attachment--interactive h3 {
   margin: 0;
   padding: 0 0 20px 0;
   border: none;
   font-size: 16px;
   font-weight: normal;
 }
-.node--report--full #interactive figure a:after {
+.node--report--full .rw-attachment--interactive figure a[target="_blank"][rel~="noopener"]::after {
   display: none;
 }
-.node--report--full #interactive figure figcaption {
+.node--report--full .rw-attachment--interactive figure figcaption {
   padding: 4px;
   background: var(--cd-reliefweb-brand-grey--light);
 }
-.node--report--full #interactive figure img {
+.node--report--full .rw-attachment--interactive figure img {
   width: 100%;
+  margin: 0;
   border: 1px solid var(--cd-reliefweb-brand-grey--light);
 }
-.node--report--full #interactive figure a:hover img,
-.node--report--full #interactive figure a:active img,
-.node--report--full #interactive figure a:focus img {
+.node--report--full .rw-attachment--interactive figure a:hover img,
+.node--report--full .rw-attachment--interactive figure a:active img,
+.node--report--full .rw-attachment--interactive figure a:focus img {
   border-color: var(--cd-reliefweb-brand-blue--dark);
 }
-.node--report--full #interactive footer {
+.node--report--full .rw-attachment--interactive footer {
   padding-top: 4px;
 }
 
@@ -99,4 +100,9 @@
 .node--report--full .rw-entity-source-disclaimers dd {
   margin: 4px 0 0 0;
   padding: 0;
+}
+
+/* Lists in content */
+.node--report--full li {
+  margin: 8px 0 0;
 }

--- a/html/themes/custom/common_design_subtheme/templates/content/node--report--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--report--full.html.twig
@@ -158,12 +158,57 @@
       }) }}
     {% endif %}
 
-    {# @todo add attachments. #}
+    <div class="rw-report__content">
+
+{#      Report#}
+{#      <section id="attachments" class="rw-attachment rw-attachment--report">#}
+{#        <h3 class="visually-hidden">Attachments</h3>#}
+{#        <ul>#}
+{#          <li>#}
+{#            <a href="#" download="Asia-Pacific COVID-19 update 9 November 2021.pdf">#}
+{#              <img src="https://reliefweb.int/sites/reliefweb.int/files/styles/report-small/public/resources-pdf-previews/1589432-Asia-Pacific%20COVID-19%20update%209%20November%202021.png?itok=IYA05TKD" alt="">#}
+{#              <strong>Download document</strong>#}
+{#              <span>(PDF | 439.83 KB)</span>#}
+{#            </a>#}
+{#          </li>#}
+{#        </ul>#}
+{#      </section>#}
+
+{#      Interactive#}
+{#      <section id="interactive" class="rw-attachment rw-attachment--interactive">#}
+{#        <h3>Screenshot(s) of the interactive content as of 30 Apr 2021</h3>#}
+{#        <div class="rw-attachment__content">#}
+{#          <figure>#}
+{#            <a href="#" target="_blank" rel="noopener">#}
+{#              <img src="https://reliefweb.int/sites/reliefweb.int/files/styles/report-large/public/resources-pdf-previews/1575720-SOMALIA%20%20%20UNHCR%205W%20%20Who%20is%20doing%20What%20Where%20When%20for%20Whom%20.png?itok=4fIvGZts" alt="Screenshot 1">#}
+{#            </a>#}
+{#            <figcaption aria-hidden="true">Screenshot 1</figcaption>#}
+{#          </figure>#}
+{#        </div>#}
+{#        <footer class="rw-attachment__footer">#}
+{#          <a href="#" target="_blank" rel="noopener">View the interactive content page</a>#}
+{#        </footer>#}
+{#      </section>#}
+
+{#      Map or Infographic#}
+{#      <section id="attachments" class="rw-attachment rw-attachment--map">#}
+{#        <h3 class="visually-hidden">Attachments</h3>#}
+{#        <ul>#}
+{#          <li>#}
+{#            <a href="#" download="partner_presence.pdf">#}
+{#              <img src="https://reliefweb.int/sites/reliefweb.int/files/styles/report-large/public/resources-pdf-previews/1575739-partner_presence.png?itok=6nzWdeYx" alt="">#}
+{#              <strong>Download Map</strong>#}
+{#              <span>(PDF | 236.67 KB)</span>#}
+{#            </a>#}
+{#          </li>#}
+{#        </ul>#}
+{#      </section>#}
 
     {{ content.body.0|render|sanitize_html(false, 2) }}
 
     {{ node.getSourceDisclaimers() }}
 
+    </div>
   </div>
 
   <footer class="rw-article__footer">


### PR DESCRIPTION
- Update selectors from D7 to reflect BEM naming for D9 including `rw-attachment--` as class variants
- Add wrapper div inside existing `.rw-article__content` so the content body and the `.rw-attachment--report` respects their float rules.
- TEMP commented-out markup directly into Report node template override to test
