### PR TITLE
[RW-262] Potential new source status

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
+++ b/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
@@ -580,10 +580,9 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
    *   Form state.
    */
   public function handlePotentialNewSourceSubmission(array $form, FormStateInterface $form_state) {
-    $entity_type = $form_state
-      ?->getFormObject()
-      ?->getEntity()
-      ?->getEntityType();
+    $entity = $form_state?->getFormObject()?->getEntity();
+    $entity_type = $entity?->getEntityType();
+    $bundle = $entity?->bundle();
 
     if (!empty($entity_type) && $entity_type instanceof ContentEntityTypeInterface) {
       $revision_log_field = $entity_type->getRevisionMetadataKey('revision_log_message');
@@ -604,7 +603,7 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
 
         // If the status is "published" or "pending", change as appropriate.
         if ($status === 'published' || $status === 'pending') {
-          $status = $this->state->get('reliefweb_no_source_status', 'pending');
+          $status = $this->state->get('reliefweb_no_source_status_' . $bundle, 'pending');
           $form_state->setValue(['moderation_state', 0, 'value'], $status);
         }
       }


### PR DESCRIPTION
Ticket: RW-262

This uses a different state variable for the status when saving a job or training with a potential new source as the jobs team seems to prefer to have the posts saved as "on-hold" while the training team seems to prefer to have them saved as "pending".