### PR TITLE
RW-263 Full text description remove italics

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
@@ -410,20 +410,6 @@ form > #actions legend + .form-type-checkbox.form-item-notifications-content-dis
   margin: 0;
 }
 
-/* Field with text that is not wrapped in description div */
-.field--name-body .text-full,
-.field--name-field-how-to-apply .text-full,
-.field--type-text-long .text-full, /* Generic selector? */
-.field--name-field-how-to-register .text-full {
-  font-size: 15px;
-  font-style: italic;
-  line-height: 24px;
-}
-.field--name-body .text-full,
-.field--type-text-long .text-full {
-  padding-top: 6px;
-}
-
 /* Text format wrapper */
 .form-type-textarea + .filter-wrapper.form-wrapper {
   margin-top: 0;

--- a/html/themes/custom/common_design_subtheme/templates/form/text-format-wrapper.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/form/text-format-wrapper.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Theme override for a text format-enabled form element.
+ *
+ * Available variables:
+ * - children: Text format element children.
+ * - description: Text format element description.
+ * - attributes: HTML attributes for the containing element.
+ * - aria_description: Flag for whether or not an ARIA description has been
+ *   added to the description container.
+ *
+ * @see template_preprocess_text_format_wrapper()
+ */
+#}
+<div class="js-text-format-wrapper js-form-item form-item">
+  {{ children }}
+  {% if description %}
+    <div{{ attributes.addClass('description') }}>{{ description }}</div>
+  {% endif %}
+</div>


### PR DESCRIPTION
Template override to add class `description` to field description div to use generic form styling and thus remove specific rule that conflicts with the main text areas.
