### PR TITLE
[RW-209] Fix report field_origin

### DIFF
--- a/config/field.field.node.report.field_origin.yml
+++ b/config/field.field.node.report.field_origin.yml
@@ -1,4 +1,4 @@
-uuid: 2e14cbe1-5a85-4274-9405-7b2c5434e240
+uuid: 8eda6012-82e5-4b7b-8522-cc6d46e035f0
 langcode: en
 status: true
 dependencies:
@@ -18,4 +18,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: list_integer

--- a/config/field.storage.node.field_origin.yml
+++ b/config/field.storage.node.field_origin.yml
@@ -1,4 +1,4 @@
-uuid: 689ecb45-ba0e-4c6d-b167-215de04dddec
+uuid: eff5127e-e198-4808-911a-6f294ad84846
 langcode: en
 status: true
 dependencies:
@@ -8,17 +8,17 @@ dependencies:
 id: node.field_origin
 field_name: field_origin
 entity_type: node
-type: list_string
+type: list_integer
 settings:
   allowed_values:
     -
-      value: '0'
+      value: 0
       label: URL
     -
-      value: '1'
+      value: 1
       label: 'Submit mailbox'
     -
-      value: '2'
+      value: 2
       label: 'Reliefweb product'
   allowed_values_function: ''
 module: options


### PR DESCRIPTION
Ticket: RW-209

This changes the "field_origin" field type to `list(integer)` to be compatible with the field in D7 so that the data is properly migrated. The previous field type `list(text)` was selected by mistake.