### PR TITLE
[RW-288] Explicit the routes to redirect legacy files

### DIFF
--- a/docker/etc/nginx/custom/01_legacy_file_redirections.conf
+++ b/docker/etc/nginx/custom/01_legacy_file_redirections.conf
@@ -1,92 +1,154 @@
-# Rewrite the file path.
+## This handles the redirections of the legacy files and images.
+##
+## For the derivative images, we only handle the redirections for the styles
+## used for the end users on the reliefweb.int site or used in the API.
+##
+## Note: we use an internal location `/@legacy-files` and not a named location
+## so that we can have nested locations to determine which lua file to call
+## and extract the necessary variables from the URI.
+
+## Rewrite the file path.
 location /sites/reliefweb.int/files/ {
   rewrite ^/sites/reliefweb.int/files/(.+)$ /sites/default/files/$1 last;
 }
 
-# Handle files.
-location /sites/default/files/ {
-  # Handle attachment redirections.
-  location ~ "^/sites/default/files/resources/(?<attachment_file>[^/]+)$" {
+## Legacy announcement images.
+location /sites/default/files/announcements/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/announcement-homepage/public/announcements/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## Legacy topic icons.
+location /sites/default/files/topic-icons/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/s/public/topic-icons/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## Legacy blog post images.
+location /sites/default/files/blog-post-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/m/public/blog-post-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/report-large/public/blog-post-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-small/public/blog-post-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-large/public/blog-post-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## legacy blog post attached images.
+location /sites/default/files/attached-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/m/public/attached-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-small/public/attached-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-large/public/attached-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## Legacy headline images.
+location /sites/default/files/headline-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/m/public/headline-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/report-medium/public/headline-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-small/public/headline-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-large/public/headline-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## Legacy report images.
+location /sites/default/files/report-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/m/public/report-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/report-large/public/report-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-small/public/report-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-large/public/report-images/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## Legacy attachments.
+location /sites/default/files/resources/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## Legacy attachment previews.
+location /sites/default/files/resources-pdf-previews/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/m/public/resources-pdf-previews/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/report-small/public/resources-pdf-previews/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/report-medium/resources-pdf-previews/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/report-large/public/resources-pdf-previews/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-small/public/resources-pdf-previews/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+location /sites/default/files/styles/attachment-large/public/resources-pdf-previews/ {
+  rewrite ^/sites/default/files/(.+)$ /@legacy-files/$1 last;
+}
+
+## Handle legacy file redirections.
+location /@legacy-files {
+  internal;
+
+  ## Handle legacy attachment redirections.
+  location ~ "^/@legacy-files/resources/(?<attachment_file>[^/]+)$" {
     rewrite_by_lua_file /etc/nginx/custom/lua/01_legacy_attachment_redirections.lua;
   }
 
-  # Handle preview redirections.
-  location ~ "^/sites/default/files/resources-pdf-previews/[0-9]+-(?<image_file>[^/]+).png$" {
+  ## Handle legacy preview redirections.
+  location ~ "^/@legacy-files/resources-pdf-previews/[0-9]+-(?<image_file>[^/]+).png$" {
     rewrite_by_lua_file /etc/nginx/custom/lua/01_legacy_preview_redirections.lua;
   }
 
-  # Handle preview derivative redirections.
-  location ~ "^/sites/default/files/styles/(?<image_style>[^/]+)/public/resources-pdf-previews/[0-9]+-(?<image_file>[^/]+).png$" {
+  ## Handle legacy preview derivative redirections.
+  location ~ "^/@legacy-files/styles/(?<image_style>[^/]+)/public/resources-pdf-previews/[0-9]+-(?<image_file>[^/]+).png$" {
     rewrite_by_lua_file /etc/nginx/custom/lua/01_legacy_preview_derivative_redirections.lua;
   }
 
-  # Handle image redirections.
-  location ~ "^/sites/default/files/(?<image_dir>[^/]+)/(?<image_file>[^/]+)$" {
+  ## Handle legacy image redirections.
+  location ~ "^/@legacy-files/(?<image_dir>[^/]+)/(?<image_file>[^/]+)$" {
     rewrite_by_lua_file /etc/nginx/custom/lua/01_legacy_image_redirections.lua;
   }
 
-  # Handle image derivative redirections.
-  location ~ "^/sites/default/files/styles/(?<image_style>[^/]+)/public/(?<image_dir>[^/]+)/(?<image_file>[^/]+)$" {
+  ## Handle legacy image derivative redirections.
+  location ~ "^/@legacy-files/(?<image_style>[^/]+)/public/(?<image_dir>[^/]+)/(?<image_file>[^/]+)$" {
     rewrite_by_lua_file /etc/nginx/custom/lua/01_legacy_image_derivative_redirections.lua;
   }
 
-  # This notably handles the new URLs using a UUID as file names.
-  # @todo is the `@drupal-legacy-files` necessary?
-  try_files $uri @drupal-legacy-files;
-}
-
-## This is similar to the fastcgi_drupal.conf but using the rewritten $uri
-## instead of the $request_uri. It uses to handle file redirections.
-##
-## Restrict access to the strictly necessary PHP files. Reducing the
-## scope for exploits. Handling of PHP code and the Drupal event loop.
-location @drupal-legacy-files {
-  #-*- mode: nginx; mode: flyspell-prog; ispell-local-dictionary: "american" -*-
-  ### fastcgi configuration for serving private files.
-  ## 1. Parameters.
-  fastcgi_param QUERY_STRING $args;
-  fastcgi_param REQUEST_METHOD $request_method;
-  fastcgi_param CONTENT_TYPE $content_type;
-  fastcgi_param CONTENT_LENGTH $content_length;
-
-  fastcgi_param SCRIPT_NAME /index.php;
-  ## Use the rewritten URI.
-  fastcgi_param REQUEST_URI $uri;
-  fastcgi_param DOCUMENT_URI $document_uri;
-  fastcgi_param DOCUMENT_ROOT $document_root;
-  fastcgi_param SERVER_PROTOCOL $server_protocol;
-
-  fastcgi_param GATEWAY_INTERFACE CGI/1.1;
-  fastcgi_param SERVER_SOFTWARE nginx/$nginx_version;
-
-  fastcgi_param REMOTE_ADDR $remote_addr;
-  fastcgi_param REMOTE_PORT $remote_port;
-  fastcgi_param SERVER_ADDR $server_addr;
-  fastcgi_param SERVER_PORT $server_port;
-  fastcgi_param SERVER_NAME $server_name;
-  ## PHP only, required if PHP was built with --enable-force-cgi-redirect
-  fastcgi_param REDIRECT_STATUS 200;
-  fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-  ## HTTPS 'on' parameter.  This requires Nginx version 1.1.11 or
-  ## later. The if_not_empty flag was introduced in 1.1.11.  See:
-  ## http://nginx.org/en/CHANGES. If using a version that doesn't
-  ## support this comment out the line below.
-  fastcgi_param HTTPS $fastcgi_https if_not_empty;
-  ## For Nginx versions below 1.1.11 uncomment the line below after commenting out the above.
-  #fastcgi_param HTTPS $fastcgi_https;
-
-  ## 2. Nginx FCGI specific directives.
-  fastcgi_buffers 256 4k;
-  fastcgi_intercept_errors on;
-  ## Allow 4 hrs - pass timeout responsibility to upstream.
-  fastcgi_read_timeout 14400;
-  fastcgi_index index.php;
-  ## Hide the Drupal cache headers.
-  fastcgi_hide_header 'X-Drupal-Cache';
-  fastcgi_hide_header 'X-Drupal-Dynamic-Cache';
-  ## Hide the Drupal header X-Generator.
-  fastcgi_hide_header 'X-Generator';
-
-  ## Pass the request.
-  fastcgi_pass phpcgi;
+  return 404;
 }


### PR DESCRIPTION
Ticket: RW-288

This makes the legacy file routes more explicit so that we let the default apps/drupal/drupal.conf handle serving the files. this notably prevents issues with the aggregated css/js.