### PR TITLE
fix code comments and avoid trivial errors

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -2,6 +2,9 @@
     "patches": {
         "drupal/core" : {
             "https://www.drupal.org/project/drupal/issues/3047110": "patches/core--drupal--3047110-taxonomy-term-moderation-class.patch"
+        },
+        "drupal/migrate_tools" : {
+            "Invalid placeholder: https://www.drupal.org/project/migrate_tools/issues/3256236": "https://www.drupal.org/files/issues/2021-12-28/invalid_placeholder-3256236-3.patch"
         }
     }
 }

--- a/html/modules/custom/reliefweb_docstore/reliefweb_docstore.module
+++ b/html/modules/custom/reliefweb_docstore/reliefweb_docstore.module
@@ -124,7 +124,7 @@ function reliefweb_docstore_file_validate_mime_type(File $file, $mime_type) {
 function reliefweb_docstore_reliefweb_utility_file_update_alter(File $file, &$apply) {
   $settings = \Drupal::config('reliefweb_docstore.settings');
 
-  // Get the ttachment and preview directories.
+  // Get the attachment and preview directories.
   $file_directory = $settings->get('file_directory') ?? 'attachments';
   $preview_directory = $settings->get('preview_directory') ?? 'previews';
   $directories = [preg_quote($file_directory), preg_quote($preview_directory)];

--- a/html/modules/custom/reliefweb_docstore/src/Plugin/Field/FieldType/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_docstore/src/Plugin/Field/FieldType/ReliefWebFile.php
@@ -476,12 +476,12 @@ class ReliefWebFile extends FieldItemBase {
     $values['uuid'] = static::generateUuid();
     $values['revision_id'] = mt_rand(1111, 9999);
     $values['file_uuid'] = static::generateUuid();
-    $valyes['file_name'] = $random->string(mt_rand(1, 250)) . '.' . $random->string(mt_rand(1, 4));
-    $valyes['file_mime'] = $random->string(mt_rand(32, 128));
-    $valyes['file_size'] = mt_rand(1111, 99999);
+    $values['file_name'] = $random->string(mt_rand(1, 250)) . '.' . $random->string(mt_rand(1, 4));
+    $values['file_mime'] = $random->string(mt_rand(32, 128));
+    $values['file_size'] = mt_rand(1111, 99999);
     $values['language'] = ['en', 'fr', 'sp'][mt_rand(0, 2)];
     $values['description'] = $random->sentences(mt_rand(1, 5));
-    $valyes['page_count'] = mt_rand(1, 100);
+    $values['page_count'] = mt_rand(1, 100);
     $values['preview_uuid'] = static::generateUuid();
     $values['preview_page'] = mt_rand(1, 100);
     $values['preview_rotation'] = mt_rand(0, 2);

--- a/html/modules/custom/reliefweb_docstore/src/Plugin/Field/FieldWidget/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_docstore/src/Plugin/Field/FieldWidget/ReliefWebFile.php
@@ -839,7 +839,7 @@ class ReliefWebFile extends WidgetBase {
   /**
    * Populate a field item with the data from a file entity.
    *
-   * @param \Drupal\reliefweb_docstore\Plugin\Field\FieldType\ReliefWebFile $item
+   * @param \Drupal\reliefweb_docstore\Plugin\Field\FieldType\ReliefWebFileType $item
    *   Field item.
    * @param \Drupal\file\Entity\File $file
    *   File entity.

--- a/html/modules/custom/reliefweb_homepage/src/Controller/Homepage.php
+++ b/html/modules/custom/reliefweb_homepage/src/Controller/Homepage.php
@@ -389,21 +389,23 @@ class Homepage extends ControllerBase {
       if ($node->hasField('field_image') && !$node->field_image->isEmpty()) {
         $image = MediaHelper::getImage($node->field_image);
 
-        return [
-          '#theme' => 'reliefweb_homepage_announcement',
-          '#id' => 'announcement',
-          '#url' => $node->field_link->uri,
-          '#image' => [
-            'url' => $image['uri'],
-            'title' => $node->label(),
-            'alt' => $node->body->value ?? $node->label(),
-            'width' => $image['width'],
-            'height' => $image['height'],
-          ],
-          '#cache' => [
-            'tags' => ['node_list:announcement'],
-          ],
-        ];
+        if (!empty($image)) {
+          return [
+            '#theme' => 'reliefweb_homepage_announcement',
+            '#id' => 'announcement',
+            '#url' => $node->field_link->uri,
+            '#image' => [
+              'url' => $image['uri'],
+              'title' => $node->label(),
+              'alt' => $node->body->value ?? $node->label(),
+              'width' => $image['width'],
+              'height' => $image['height'],
+            ],
+            '#cache' => [
+              'tags' => ['node_list:announcement'],
+            ],
+          ];
+        }
       }
     }
     return [];

--- a/html/modules/custom/reliefweb_utility/src/Helpers/LegacyHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/LegacyHelper.php
@@ -50,7 +50,7 @@ class LegacyHelper {
    *   The attachment UUID.
    */
   public static function generateAttachmentUuid($uri) {
-    // We strips the '%' characters for compatibility with the preview URLS.
+    // Strip the '%' characters for compatibility with the preview URLs.
     return static::generateFileUuid(str_replace('%', '', $uri));
   }
 

--- a/html/modules/custom/reliefweb_utility/src/Response/JsonResponse.php
+++ b/html/modules/custom/reliefweb_utility/src/Response/JsonResponse.php
@@ -105,7 +105,7 @@ class JsonResponse {
   }
 
   /**
-   * Get the status code.
+   * Get the reason phrase.
    *
    * @return string
    *   The reason phrase accompanying the response status code.


### PR DESCRIPTION
Some comment typos and fixes for minor errors.

I had to add `<config name="installed_paths" value="vendor/drupal/coder/coder_sniffer" />` to phpcs.xml to get the pre-commit hook to run. Not sure why that is.
