### PR TITLE
add process and destination configuration for migrations

### DIFF
--- a/config/migrate_plus.migration.reliefweb_media__image_topic.yml
+++ b/config/migrate_plus.migration.reliefweb_media__image_topic.yml
@@ -18,7 +18,11 @@ source:
   field: field_term_image
   entity_type: node
   bundle: topics
-process: null
+process:
+  field_media_image/target_id:
+    plugin: skip_on_empty
+    method: process
+    source: fid
 destination:
   default_bundle: image_topic
 migration_dependencies:

--- a/config/migrate_plus.migration.reliefweb_node__announcement.yml
+++ b/config/migrate_plus.migration.reliefweb_node__announcement.yml
@@ -23,5 +23,6 @@ process:
     plugin: skip_on_empty
     method: process
     source: field_link/0/url
-destination: null
+destination:
+  plugin: entity:node
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_node__blog_post.yml
+++ b/config/migrate_plus.migration.reliefweb_node__blog_post.yml
@@ -43,5 +43,6 @@ process:
     source: field_tags
     process:
       target_id: tid
-destination: null
+destination:
+  plugin: entity:node
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_node__book.yml
+++ b/config/migrate_plus.migration.reliefweb_node__book.yml
@@ -13,6 +13,12 @@ migration_group: reliefweb_node
 label: 'Migrate ReliefWeb book pages.'
 source:
   bundle: book
-process: null
-destination: null
+process:
+  field_attached_images:
+    plugin: sub_process
+    source: field_attached_images
+    process:
+      target_id: fid
+destination:
+  plugin: entity:node
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_node__job.yml
+++ b/config/migrate_plus.migration.reliefweb_node__job.yml
@@ -68,5 +68,6 @@ process:
     source: field_theme
     process:
       target_id: tid
-destination: null
+destination:
+  plugin: entity:node
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_node__report.yml
+++ b/config/migrate_plus.migration.reliefweb_node__report.yml
@@ -133,5 +133,6 @@ process:
     source: field_vulnerable_groups
     process:
       target_id: tid
-destination: null
+destination:
+  plugin: entity:node
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_node__topic.yml
+++ b/config/migrate_plus.migration.reliefweb_node__topic.yml
@@ -108,5 +108,6 @@ process:
           source: attributes
           index:
             - title
-destination: null
+destination:
+  plugin: entity:node
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_node__training.yml
+++ b/config/migrate_plus.migration.reliefweb_node__training.yml
@@ -112,5 +112,6 @@ process:
     source: field_training_type
     process:
       target_id: tid
-destination: null
+destination:
+  plugin: entity:node
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_taxonomy_term.yml
+++ b/config/migrate_plus.migration.reliefweb_taxonomy_term.yml
@@ -42,5 +42,6 @@ process:
     plugin: skip_on_empty
     method: process
     source: field_language_code/0/value
-destination: null
+destination:
+  plugin: 'entity:taxonomy_term'
 migration_dependencies: null

--- a/config/migrate_plus.migration.reliefweb_taxonomy_term__country.yml
+++ b/config/migrate_plus.migration.reliefweb_taxonomy_term__country.yml
@@ -57,7 +57,8 @@ process:
     plugin: skip_on_empty
     method: process
     source: field_timezone/0/value
-destination: null
+destination:
+  plugin: 'entity:taxonomy_term'
 migration_dependencies:
   required:
     - reliefweb_taxonomy_term

--- a/config/migrate_plus.migration.reliefweb_taxonomy_term__disaster.yml
+++ b/config/migrate_plus.migration.reliefweb_taxonomy_term__disaster.yml
@@ -79,7 +79,8 @@ process:
     plugin: default_value
     default_value: 0
     source: field_timezone/0/value
-destination: null
+destination:
+  plugin: 'entity:taxonomy_term'
 migration_dependencies:
   required:
     - reliefweb_taxonomy_term

--- a/config/migrate_plus.migration.reliefweb_taxonomy_term__source.yml
+++ b/config/migrate_plus.migration.reliefweb_taxonomy_term__source.yml
@@ -88,7 +88,8 @@ process:
     plugin: skip_on_empty
     method: process
     source: field_user_posting_rights
-destination: null
+destination:
+  plugin: 'entity:taxonomy_term'
 migration_dependencies:
   required:
     - reliefweb_taxonomy_term


### PR DESCRIPTION
Not sure what effect these errors have on the migration itself, but I was unable to visit pages like https://dev.reliefweb-int.ahconu.org/admin/structure/migrate/manage/reliefweb_node/migrations/reliefweb_node__book/process and https://dev.reliefweb-int.ahconu.org/admin/structure/migrate/manage/reliefweb_node/migrations/reliefweb_node__book/destination as the configuration is missing.

```
The website encountered an unexpected error. Please try again later.
TypeError: Drupal\migrate\Plugin\Migration::getProcessNormalized(): Argument #1 ($process) must be of type array, null given, called in /srv/www/html/core/modules/migrate/src/Plugin/Migration.php on line 630 in Drupal\migrate\Plugin\Migration->getProcessNormalized() (line 375 of core/modules/migrate/src/Plugin/Migration.php). 
```

This PR fixes those.