### PR TITLE
[RW-336] Fix entity access

### DIFF
--- a/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineModeration.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineModeration.php
@@ -163,6 +163,9 @@ class GuidelineModeration extends ModerationServiceBase {
       case 'delete':
         $access = $account->hasPermission('delete guideline entities');
         break;
+
+      default:
+        return AccessResult::neutral();
     }
 
     return $access ? AccessResult::allowed() : AccessResult::forbidden();

--- a/html/modules/custom/reliefweb_moderation/reliefweb_moderation.module
+++ b/html/modules/custom/reliefweb_moderation/reliefweb_moderation.module
@@ -5,7 +5,6 @@
  * Theme declaration etc. for the reliefweb_moderation module.
  */
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -153,16 +152,30 @@ function reliefweb_moderation_moderation_status_value_callback(EntityInterface $
 
 /**
  * Implements hook_entity_access().
+ *
+ * Drupal's AccessResultNeutral is actually not neutral depending on
+ * the context: route access check ("andIf" -> Neutral = Deny) versus
+ * entity only access check ("orIf" -> Neutral = Neutral). So to
+ * prevent showing a 403 due to us returning an AccessResultNeutral, we
+ * return NULL instead which will make ModuleHandler::invokeAll() ignore
+ * the result.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/2991698
+ * @see \Drupal\Core\Entity\EntityAccessControlHandler::processAccessHookResults()
+ * @see \Drupal\Core\Access\AccessManager\check()
+ * @see \Drupal\Core\Extension\ModuleHandler::invokeAll()
  */
 function reliefweb_moderation_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
   if ($entity instanceof EntityModeratedInterface) {
     $service = ModerationServiceBase::getModerationService($entity->bundle());
     if (!empty($service)) {
-      return $service->entityAccess($entity, $operation, $account);
+      $access_result = $service->entityAccess($entity, $operation, $account);
+      if (!$access_result->isNeutral()) {
+        return $access_result;
+      }
     }
   }
-  // No opinion.
-  return AccessResult::neutral();
+  return NULL;
 }
 
 /**

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -325,6 +325,9 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
                 $access = UserPostingRightsHelper::userHasPostingRights($account, $entity, $status);
               }
               break;
+
+            default:
+              return AccessResult::neutral();
           }
         }
 
@@ -353,10 +356,16 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
             case 'delete':
               $access = $account->hasPermission('delete terms in ' . $bundle);
               break;
+
+            default:
+              return AccessResult::neutral();
           }
         }
 
         break;
+
+      default:
+        return AccessResult::neutral();
     }
 
     return $access ? AccessResult::allowed() : AccessResult::forbidden();
@@ -492,7 +501,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
    */
   public function getFilterDefinition($name) {
     $filters = $this->getFilterDefinitions();
-    return isset($filters[$name]) ? $filters[$name] : NULL;
+    return $filters[$name] ?? NULL;
   }
 
   /**
@@ -1448,7 +1457,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
                   }
                 }
                 elseif ($widget === 'datepicker') {
-                  list($start, $end) = array_pad(explode('-', $value, 2), 2, NULL);
+                  [$start, $end] = array_pad(explode('-', $value, 2), 2, NULL);
                   $start = intval($start);
                   $end = intval($end);
                   // Should not happen.
@@ -1506,9 +1515,9 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
               }
               elseif ($widget === 'datepicker') {
                 foreach ($values as $value) {
-                  list($start, $end) = array_pad(explode('-', $value, 2), 2, NULL);
+                  [$start, $end] = array_pad(explode('-', $value, 2), 2, NULL);
                   $start = intval($start);
-                  $end = intval(isset($end) ? $end : $start + 86399);
+                  $end = intval($end ?? $start + 86399);
                   $this->addFilterCondition($definition, $condition, $field, [
                     $start,
                     $end,

--- a/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
@@ -193,18 +193,18 @@ class JobModeration extends ModerationServiceBase {
     $account = $account ?: $this->currentUser;
 
     $access_result = parent::entityAccess($entity, $operation, $account);
-    $access = $access_result->isAllowed();
 
-    // Allow deletion of draft, pending and on-hold only or of any documents
-    // for editors.
+    // Allow deletion of draft, pending and on-hold only if not an editor.
     if ($operation === 'delete') {
       $statuses = ['draft', 'pending', 'on-hold'];
       $access = $account->hasPermission('bypass node access') ||
                 $account->hasPermission('administer nodes') ||
-                ($access && in_array($entity->getModerationStatus(), $statuses));
+                $account->hasPermission('delete any ' . $entity->bundle() . ' content') ||
+                ($access_result->isAllowed() && in_array($entity->getModerationStatus(), $statuses));
+      $access_result = $access ? AccessResult::allowed() : AccessResult::forbidden();
     }
 
-    return $access ? AccessResult::allowed() : AccessResult::forbidden();
+    return $access_result;
   }
 
   /**

--- a/html/modules/custom/reliefweb_moderation/src/Services/ReportModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/ReportModeration.php
@@ -272,15 +272,17 @@ class ReportModeration extends ModerationServiceBase {
    */
   public function entityAccess(EntityModeratedInterface $entity, $operation = 'view', ?AccountInterface $account = NULL) {
     $access_result = parent::entityAccess($entity, $operation, $account);
-    $access = $access_result->isAllowed();
 
     if ($operation !== 'view') {
       // Normally editors can edit any kind of reports
       // but there are some exceptions like archived reports.
-      $access = $access && $this->isEditableStatus($entity->getModerationStatus(), $account);
+      $access = !$access_result->isForbidden() &&
+        $this->isEditableStatus($entity->getModerationStatus(), $account);
+
+      $access_result = $access ? $access_result : AccessResult::forbidden();
     }
 
-    return $access ? AccessResult::allowed() : AccessResult::forbidden();
+    return $access_result;
   }
 
   /**

--- a/html/modules/custom/reliefweb_utility/src/Helpers/UserHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/UserHelper.php
@@ -31,7 +31,9 @@ class UserHelper {
     }
     // Check the roles.
     elseif (!empty($roles)) {
-      $intersection = count(array_intersect($roles, $account->getRoles()));
+      $roles = array_map('strtolower', $roles);
+      $account_roles = array_map('strtolower', $account->getRoles());
+      $intersection = count(array_intersect($roles, $account_roles));
       return $all ? count($roles) === $intersection : $intersection > 0;
     }
     return FALSE;


### PR DESCRIPTION
Ticket: RW-336

It turns out that `AccessResultNeutral` [is not neutral](https://www.drupal.org/project/drupal/issues/2991698) when used in a route access check, so this ticket rewrites a bit the entity access in the moderation module to work around that inconsistency.