### PR TITLE
Various fixes

### DIFF
--- a/config/field.field.taxonomy_term.disaster.field_profile.yml
+++ b/config/field.field.taxonomy_term.disaster.field_profile.yml
@@ -15,7 +15,7 @@ required: false
 translatable: true
 default_value:
   -
-    value: 0
+    value: 1
 default_value_callback: ''
 settings:
   on_label: 'Yes'

--- a/html/modules/custom/reliefweb_entities/src/Entity/Country.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Country.php
@@ -150,4 +150,11 @@ class Country extends Term implements BundleEntityInterface, EntityModeratedInte
     return $client->getKeyFiguresBuild($iso3, $this->label());
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultModerationStatus() {
+    return 'normal';
+  }
+
 }

--- a/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
+++ b/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
@@ -588,7 +588,7 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
       $revision_log_field = $entity_type->getRevisionMetadataKey('revision_log_message');
 
       $log = $form_state->getValue([$revision_log_field, 0, 'value'], '');
-      $status = $form_state->getValue(['moderation_state', 0, 'value']);
+      $status = $this->getEntityModerationStatus($form_state);
 
       // Add the information about potential new source and update the status.
       if (!$form_state->isValueEmpty('field_source_none') &&
@@ -604,7 +604,7 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
         // If the status is "published" or "pending", change as appropriate.
         if ($status === 'published' || $status === 'pending') {
           $status = $this->state->get('reliefweb_no_source_status_' . $bundle, 'pending');
-          $form_state->setValue(['moderation_state', 0, 'value'], $status);
+          $this->setEntityModerationStatus($status, $form_state);
         }
       }
     }
@@ -850,7 +850,7 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
    *   Moderation status.
    */
   protected function getEntityModerationStatus(FormStateInterface $form_state) {
-    return $form_state->getValue(['moderation_state', 0, 'value']);
+    return $form_state->getValue(['moderation_status', 0, 'value']);
   }
 
   /**
@@ -865,7 +865,7 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
    *   Moderation status.
    */
   protected function setEntityModerationStatus($status, FormStateInterface $form_state) {
-    return $form_state->setValue(['moderation_state', 0, 'value'], $status);
+    return $form_state->setValue(['moderation_status', 0, 'value'], $status);
   }
 
   /**

--- a/html/modules/custom/reliefweb_entities/src/Services/ReportFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/ReportFormAlter.php
@@ -229,8 +229,14 @@ class ReportFormAlter extends EntityFormAlterServiceBase {
     $condition = [
       'select[name="field_source[]"]' => ['value' => ['1503']],
     ];
-    $widget['#states']['visible'] = $condition;
+    // We put the visibility state on the container to avoid styling issues with
+    // the surrounding elements but we need to to put the required state on the
+    // widget element for it to work properly.
+    $form['field_ocha_product']['#states']['visible'] = $condition;
     $widget['#states']['required'] = $condition;
+
+    // Remove the empty option.
+    unset($widget['#options']['_none']);
 
     // For the above to work we need the drupal states extension.
     // @todo remove if the equivalent is added to core.
@@ -272,7 +278,7 @@ class ReportFormAlter extends EntityFormAlterServiceBase {
     }
     // Remove the ocha product otherwise.
     elseif (!$selected && !empty($ocha_product)) {
-      $form_state->getValue(['field_ocha_product', 0, 'target_id'], NULL);
+      $form_state->setValue(['field_ocha_product', 0, 'target_id'], NULL);
     }
   }
 

--- a/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebEntityReferenceSelect.php
+++ b/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebEntityReferenceSelect.php
@@ -355,7 +355,7 @@ class ReliefWebEntityReferenceSelect extends OptionsSelectWidget {
     ];
     foreach ($this->getSetting('extra_data') as $field => $selected) {
       if (!empty($selected) && strpos($field, ':') !== FALSE) {
-        list($bundle, $field_name) = explode(':', $field);
+        [$bundle, $field_name] = explode(':', $field);
 
         $definitions = $this->getEntityFieldManager()
           ->getFieldDefinitions($entity_type_id, $bundle);
@@ -364,16 +364,8 @@ class ReliefWebEntityReferenceSelect extends OptionsSelectWidget {
           $definition = $definitions[$field_name];
           $type = $definition->getFieldStorageDefinition()->isBaseField() ? 'base' : 'bundle';
 
-          // The moderation is a special case. It's a base field but its not
-          // using the entity type's table. We add it to the list of bundle
-          // fields and execute the appropriate query in `getExtraData`.
-          if ($field_name === 'moderation_state') {
-            $attribute = 'data-moderation-status';
-            $type = 'bundle';
-          }
-          else {
-            $attribute = 'data-' . preg_replace('#^field_#', '', $field_name);
-          }
+          $attribute = 'data-' . preg_replace('#^field_#', '', $field_name);
+          $attribute = strtr($attribute, '_', '-');
 
           $fields[$type][$field] = [
             'attribute' => $attribute,

--- a/html/modules/custom/reliefweb_form/js/widget.autocomplete.js
+++ b/html/modules/custom/reliefweb_form/js/widget.autocomplete.js
@@ -286,8 +286,8 @@
           var options = disasterElement.getElementsByTagName('option');
           for (var i = 0, l = options.length; i < l; i++) {
             var option = options[i];
-            if (option.selected && option !== exclude && option.hasAttribute('data-disaster_type')) {
-              var types = option.getAttribute('data-disaster_type').split(',');
+            if (option.selected && option !== exclude && option.hasAttribute('data-disaster-type')) {
+              var types = option.getAttribute('data-disaster-type').split(',');
               for (var j = 0, m = types.length; j < m; j++) {
                 newTypes[types[j]] = true;
               }
@@ -323,9 +323,9 @@
         disasterSelection.addEventListener('click', function (event) {
           if (event.target && event.target.nodeName === 'BUTTON') {
             var option = findOption(disasterElement, event.target.parentNode.getAttribute('data-value'));
-            if (option !== false && option.hasAttribute('data-disaster_type')) {
+            if (option !== false && option.hasAttribute('data-disaster-type')) {
               var oldTypes = {};
-              var types = option.getAttribute('data-disaster_type').split(',');
+              var types = option.getAttribute('data-disaster-type').split(',');
               for (var i = 0, l = types.length; i < l; i++) {
                 oldTypes[types[i]] = true;
               }
@@ -356,7 +356,7 @@
         // Function to handle the changes to the country field.
         var changeHandler = function () {
           // Retrieve the selected disaster types.
-          var disasterTypes = getSelectedOptionAttributeValues(disasterElement, 'data-disaster_type');
+          var disasterTypes = getSelectedOptionAttributeValues(disasterElement, 'data-disaster-type');
 
           // Get the selected options from the country field.
           var available = getSelectedOptions(countryElement);

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -386,6 +386,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
 
     // Disable the moderation status widget and the default submit buttons.
     $form['actions']['submit']['#access'] = FALSE;
+    $form['actions']['overview']['#access'] = FALSE;
 
     // Move the preview button at the beginning if it exists.
     if (isset($form['actions']['preview'])) {

--- a/html/modules/custom/reliefweb_moderation/src/Services/CountryModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/CountryModeration.php
@@ -102,7 +102,6 @@ class CountryModeration extends ModerationServiceBase {
    */
   public function getStatuses() {
     return [
-      'draft' => $this->t('Draft'),
       'ongoing' => $this->t('Ongoing'),
       'normal' => $this->t('Normal'),
     ];
@@ -113,9 +112,6 @@ class CountryModeration extends ModerationServiceBase {
    */
   public function getEntityFormSubmitButtons($status, EntityModeratedInterface $entity) {
     return [
-      'draft' => [
-        '#value' => $this->t('Save as draft'),
-      ],
       'ongoing' => [
         '#value' => $this->t('Ongoing situation'),
       ],

--- a/html/modules/custom/reliefweb_moderation/src/Services/ReportModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/ReportModeration.php
@@ -211,6 +211,15 @@ class ReportModeration extends ModerationServiceBase {
   /**
    * {@inheritdoc}
    */
+  public function getFilterDefaultStatuses() {
+    $statuses = $this->getFilterStatuses();
+    unset($statuses['archive']);
+    return array_keys($statuses);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getEntityFormSubmitButtons($status, EntityModeratedInterface $entity) {
     $buttons = [
       'draft' => [

--- a/html/modules/custom/reliefweb_user_posts/src/Services/UserPostsService.php
+++ b/html/modules/custom/reliefweb_user_posts/src/Services/UserPostsService.php
@@ -138,8 +138,8 @@ class UserPostsService extends ModerationServiceBase {
       ],
       'status' => [
         'label' => $this->t('Status'),
-        'type' => '',
-        'specifier' => 'moderation_state',
+        'type' => 'property',
+        'specifier' => 'moderation_status',
         'sortable' => TRUE,
       ],
       'poster' => [


### PR DESCRIPTION
- RW-285/RW-348: fix various issues with the OCHA product field on reports
- RW-349: make show profile selected by default on disaster form
- RW-350: assign IDs for guideline path aliases that don't conflict with the other migrated url aliases
- RW-351: fix moderation status data attribute on forms
- RW-352: remove leftover of moderation_state to fix issues with status when saving a job/training with a potential new source
- RW-353: make the "archived" status unselected by default on the report moderation page
- RW-354: remove "draft" status for countries
- RW-355: remove "save and go to list" button on country, disaster and source forms