### PR TITLE
Various fixes - part 3

### DIFF
--- a/config/filter.format.html.yml
+++ b/config/filter.format.html.yml
@@ -15,7 +15,7 @@ filters:
     status: true
     weight: -49
     settings:
-      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <th> <td> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/filter.format.html.yml
+++ b/config/filter.format.html.yml
@@ -15,7 +15,7 @@ filters:
     status: true
     weight: -49
     settings:
-      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src alt> <sup> <sub>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/filter.format.markdown.yml
+++ b/config/filter.format.markdown.yml
@@ -15,7 +15,7 @@ filters:
     status: true
     weight: -49
     settings:
-      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <th> <td> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/filter.format.markdown.yml
+++ b/config/filter.format.markdown.yml
@@ -15,7 +15,7 @@ filters:
     status: true
     weight: -49
     settings:
-      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub>'
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src alt> <sup> <sub>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/filter.format.token_markdown.yml
+++ b/config/filter.format.token_markdown.yml
@@ -21,7 +21,7 @@ filters:
     status: true
     weight: -48
     settings:
-      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub> <iframe longdesc name scrolling src title align height frameborder width allowfullscreen>'
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src alt> <sup> <sub> <iframe longdesc name scrolling src title align height frameborder width allowfullscreen>'
       filter_html_help: true
       filter_html_nofollow: false
   media_embed:

--- a/config/filter.format.token_markdown.yml
+++ b/config/filter.format.token_markdown.yml
@@ -21,7 +21,7 @@ filters:
     status: true
     weight: -48
     settings:
-      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <th> <td> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub> <iframe longdesc name scrolling src title align height frameborder width allowfullscreen>'
+      allowed_html: '<a href hreflang target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h1 id> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <table> <caption> <thead> <tbody> <tfoot> <tr> <th colspan rowspan> <td colspan rowspan> <div> <span> <p> <br> <strike> <ul> <img src> <sup> <sub> <iframe longdesc name scrolling src title align height frameborder width allowfullscreen>'
       filter_html_help: true
       filter_html_nofollow: false
   media_embed:

--- a/config/mimemail.settings.yml
+++ b/config/mimemail.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: rLKGzzC9TqjbEZiBoiyMpOSyZgldADa5SzvbA2gQDxE
 name: ReliefWeb
-mail: admin@reliefweb.int
+mail: donotreply@reliefweb.int
 simple_address: false
 sitestyle: true
 textonly: false

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -15,6 +15,7 @@ dependencies:
     - node
     - reliefweb_bookmarks
     - reliefweb_form
+    - reliefweb_moderation
     - reliefweb_subscriptions
     - reliefweb_user_posts
     - system
@@ -40,5 +41,8 @@ permissions:
   - 'use text format markdown_editor'
   - 'use text format token_markdown'
   - 'view media'
+  - 'view moderation information'
+  - 'view moderation information revision message'
+  - 'view moderation information status'
   - 'view own posts'
   - 'view own unpublished content'

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -44,5 +44,6 @@ permissions:
   - 'view moderation information'
   - 'view moderation information revision message'
   - 'view moderation information status'
+  - 'view moderation status'
   - 'view own posts'
   - 'view own unpublished content'

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -52,7 +52,6 @@ permissions:
   - 'access user contact forms'
   - 'access user profiles'
   - 'add content to books'
-  - 'administer book outlines'
   - 'administer community topics'
   - 'administer url aliases'
   - 'archive content'

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.guideline
     - filter.format.html
     - filter.format.markdown
     - media.type.image_announcement
@@ -25,6 +26,7 @@ dependencies:
     - book
     - contact
     - filter
+    - guidelines
     - media
     - node
     - path
@@ -52,6 +54,7 @@ permissions:
   - 'access user contact forms'
   - 'access user profiles'
   - 'add content to books'
+  - 'add guideline entities'
   - 'administer community topics'
   - 'administer url aliases'
   - 'archive content'
@@ -118,6 +121,7 @@ permissions:
   - 'edit any report content'
   - 'edit any topic content'
   - 'edit any training content'
+  - 'edit guideline entities'
   - 'edit homepage headlines'
   - 'edit own announcement content'
   - 'edit own blog_post content'
@@ -137,6 +141,18 @@ permissions:
   - 'edit terms in source'
   - 'edit terms in tag'
   - 'edit user posting rights'
+  - 'field_guideline create entities'
+  - 'field_guideline delete any entities'
+  - 'field_guideline delete own entities'
+  - 'field_guideline edit any entities'
+  - 'field_guideline edit own entities'
+  - 'field_guideline view revisions'
+  - 'guideline_list create entities'
+  - 'guideline_list delete any entities'
+  - 'guideline_list delete own entities'
+  - 'guideline_list edit any entities'
+  - 'guideline_list edit own entities'
+  - 'guideline_list view revisions'
   - 'revert announcement revisions'
   - 'revert blog_post revisions'
   - 'revert book revisions'
@@ -145,11 +161,14 @@ permissions:
   - 'revert term revision'
   - 'revert topic revisions'
   - 'revert training revisions'
+  - 'sort all guideline'
   - 'update any media'
   - 'update media'
   - 'use enhanced input forms'
+  - 'use text format guideline'
   - 'use text format html'
   - 'use text format markdown'
+  - 'view all guideline revisions'
   - 'view all media revisions'
   - 'view announcement revisions'
   - 'view any content'
@@ -161,9 +180,11 @@ permissions:
   - 'view other user posts'
   - 'view own unpublished content'
   - 'view own unpublished media'
+  - 'view published guideline entities'
   - 'view report revisions'
   - 'view term revision data'
   - 'view term revision list'
   - 'view topic revisions'
   - 'view training revisions'
+  - 'view unpublished guideline entities'
   - 'view user email addresses'

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -157,6 +157,7 @@ permissions:
   - 'view book revisions'
   - 'view entity history'
   - 'view job revisions'
+  - 'view moderation information revision message author'
   - 'view other user posts'
   - 'view own unpublished content'
   - 'view own unpublished media'

--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -25,6 +25,7 @@ dependencies:
     - book
     - filter
     - google_tag
+    - guidelines
     - taxonomy
     - taxonomy_term_revision
 id: webmaster
@@ -33,6 +34,7 @@ weight: 4
 is_admin: null
 permissions:
   - 'add content to books'
+  - 'add guideline entities'
   - 'administer google tag manager'
   - 'create new books'
   - 'create terms in career_category'
@@ -52,6 +54,8 @@ permissions:
   - 'create terms in training_format'
   - 'create terms in training_type'
   - 'create terms in vulnerable_group'
+  - 'delete all guideline revisions'
+  - 'delete guideline entities'
   - 'delete term revision'
   - 'delete terms in career_category'
   - 'delete terms in content_format'
@@ -70,6 +74,7 @@ permissions:
   - 'delete terms in training_format'
   - 'delete terms in training_type'
   - 'delete terms in vulnerable_group'
+  - 'edit guideline entities'
   - 'edit terms in career_category'
   - 'edit terms in content_format'
   - 'edit terms in country'
@@ -87,7 +92,28 @@ permissions:
   - 'edit terms in training_format'
   - 'edit terms in training_type'
   - 'edit terms in vulnerable_group'
+  - 'field_guideline create entities'
+  - 'field_guideline delete any entities'
+  - 'field_guideline delete own entities'
+  - 'field_guideline delete revisions'
+  - 'field_guideline edit any entities'
+  - 'field_guideline edit own entities'
+  - 'field_guideline revert revisions'
+  - 'field_guideline view revisions'
+  - 'guideline_list create entities'
+  - 'guideline_list delete any entities'
+  - 'guideline_list delete own entities'
+  - 'guideline_list delete revisions'
+  - 'guideline_list edit any entities'
+  - 'guideline_list edit own entities'
+  - 'guideline_list revert revisions'
+  - 'guideline_list view revisions'
+  - 'revert all guideline revisions'
   - 'revert term revision'
+  - 'sort all guideline'
   - 'use text format guideline'
+  - 'view all guideline revisions'
+  - 'view published guideline entities'
   - 'view term revision data'
   - 'view term revision list'
+  - 'view unpublished guideline entities'

--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -33,7 +33,6 @@ weight: 4
 is_admin: null
 permissions:
   - 'add content to books'
-  - 'administer book outlines'
   - 'administer google tag manager'
   - 'create new books'
   - 'create terms in career_category'

--- a/html/modules/custom/reliefweb_contact/reliefweb_contact.module
+++ b/html/modules/custom/reliefweb_contact/reliefweb_contact.module
@@ -5,6 +5,8 @@
  * Reliefweb contact module.
  */
 
+use Drupal\reliefweb_utility\Helpers\MailHelper;
+
 /**
  * Implements hook_mail_alter().
  */
@@ -31,10 +33,12 @@ function reliefweb_contact_mail_alter(&$message) {
     '@subject' => $contact_message->subject->value,
   ]);
 
-  // Clean body.
-  unset($message['body'][1]);
-  unset($message['body'][2]);
-  $message['body'][3] = check_markup($contact_message->message->value, 'plain_text');
+  // Replace the body from contact_mail() with the entered message content.
+  $message['body'] = [check_markup($contact_message->message->value, 'plain_text')];
+
+  // Plain text only.
+  $message['params']['plaintext'] = MailHelper::getPlainText($message['body']);
+  $message['params']['plain'] = TRUE;
 
   // Set sender headers.
   $message['from'] = $sender;

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
+use Drupal\reliefweb_utility\Helpers\MailHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\taxonomy\TermInterface;
@@ -429,6 +430,28 @@ function reliefweb_entities_entity_presave(EntityInterface $entity) {
           }
         }
       }
+    }
+  }
+}
+
+/**
+ * Implements hook_mail().
+ *
+ * Populate the subject and body of the message sent after publishing a report.
+ */
+function reliefweb_entities_mail($key, array &$message, array $parameters) {
+  if ($key === 'report_publication_notification') {
+    $message['subject'] = $parameters['subject'];
+    $message['body'][] = $parameters['content'];
+    // Plain text only.
+    $message['params']['plaintext'] = MailHelper::getPlainText($message['body']);
+    $message['params']['plain'] = TRUE;
+    // Use the submit mailbox as sender and add it also as CC to track the
+    // notifications.
+    $submit = \Drupal::state()->get('reliefweb_submit_email');
+    if (!empty($submit)) {
+      $message['headers']['From'] = $submit;
+      $message['headers']['CC'] = $submit;
     }
   }
 }

--- a/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
@@ -14,7 +14,7 @@ use Drupal\reliefweb_utility\Helpers\MediaHelper;
 /**
  * Trait implementing most methods of the DocumentInterface.
  *
- * @see Drupal\reliefweb_entities\DocuemntInterface
+ * @see Drupal\reliefweb_entities\DocumentInterface
  */
 trait DocumentTrait {
 

--- a/html/modules/custom/reliefweb_entities/src/Entity/Job.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Job.php
@@ -8,6 +8,8 @@ use Drupal\node\Entity\Node;
 use Drupal\reliefweb_entities\BundleEntityInterface;
 use Drupal\reliefweb_entities\DocumentInterface;
 use Drupal\reliefweb_entities\DocumentTrait;
+use Drupal\reliefweb_entities\OpportunityDocumentInterface;
+use Drupal\reliefweb_entities\OpportunityDocumentTrait;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\EntityModeratedTrait;
 use Drupal\reliefweb_revisions\EntityRevisionedInterface;
@@ -16,11 +18,12 @@ use Drupal\reliefweb_revisions\EntityRevisionedTrait;
 /**
  * Bundle class for job nodes.
  */
-class Job extends Node implements BundleEntityInterface, EntityModeratedInterface, EntityRevisionedInterface, DocumentInterface {
+class Job extends Node implements BundleEntityInterface, EntityModeratedInterface, EntityRevisionedInterface, DocumentInterface, OpportunityDocumentInterface {
 
   use DocumentTrait;
   use EntityModeratedTrait;
   use EntityRevisionedTrait;
+  use OpportunityDocumentTrait;
   use StringTranslationTrait;
 
   /**
@@ -127,6 +130,9 @@ class Job extends Node implements BundleEntityInterface, EntityModeratedInterfac
       }
       $this->set('field_theme', $themes);
     }
+
+    // Update the entity status based on the user posting rights.
+    $this->updateModerationStatusFromPostingRights();
 
     parent::preSave($storage);
   }

--- a/html/modules/custom/reliefweb_entities/src/Entity/Report.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Report.php
@@ -216,7 +216,7 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
       $from_ocha = FALSE;
       foreach ($this->field_source as $item) {
         // We don't use a strict equality as tid may be a numeric string...
-        if (!$item->isEmpty() && $item->getValue('target_id') == 1503) {
+        if (!$item->isEmpty() && $item->target_id == 1503) {
           $from_ocha = TRUE;
           break;
         }
@@ -225,6 +225,100 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
         $this->field_ocha_product->setValue([]);
       }
     }
+
+    // Prepare notifications.
+    $this->preparePublicationNotification();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+
+    $this->sendPublicationNotification();
+  }
+
+  /**
+   * Prepare the list of recipients to notify of the publication.
+   */
+  protected function preparePublicationNotification() {
+    // Only send the notifications when the report is published.
+    $status = $this->getModerationStatus();
+    if ($status !== 'to-review' && $status !== 'published') {
+      return;
+    }
+
+    // Extract the emails.
+    $emails = $this->field_notify->value ?? '';
+    $emails = preg_split('/([,;]|\s)+/', trim($emails));
+    $emails = array_filter(filter_var_array($emails, FILTER_VALIDATE_EMAIL));
+    $emails = array_unique($emails);
+
+    // Empty the field.
+    $this->field_notify->setValue([]);
+
+    // Skip if there is no recipients.
+    if (empty($emails)) {
+      return;
+    }
+
+    // Store the emails to notify after the node is saved.
+    $this->_publication_notification_emails = $emails;
+
+    // Update the log message with the list of emails to notify.
+    $log_field = $this->getEntityType()
+      ->getRevisionMetadataKey('revision_log_message');
+
+    // Not using `t()` because this is an internal editorial message.
+    $log = strtr('Publication notification sent to @to', [
+      '@to' => implode(', ', $emails),
+    ]);
+    if (!empty($this->{$log_field}->value)) {
+      $this->{$log_field}->value .= ' - ' . $log;
+    }
+    else {
+      $this->{$log_field}->value = $log;
+    }
+  }
+
+  /**
+   * Notify of the publication.
+   */
+  protected function sendPublicationNotification() {
+    if (empty($this->_publication_notification_emails)) {
+      return;
+    }
+    $emails = $this->_publication_notification_emails;
+    unset($this->_publication_notification_emails);
+
+    // Recipients and sender.
+    $to = implode(', ', $emails);
+    $from = \Drupal::state()->get('reliefweb_submit_email');
+    if (empty($from)) {
+      return;
+    }
+
+    // Subject and content.
+    $parameters = [];
+    $parameters['subject'] = 'ReliefWeb: Your submission has been published';
+    $parameters['content'] = strtr(implode("\n\n", [
+      "Thank you for your submission to ReliefWeb.",
+      "Your submission \"@title\" has been published with the following URL:",
+      "@url",
+      "Please respond to this email in case you have questions or corrections to your submission.",
+      "Best regards,",
+      "ReliefWeb team",
+    ]), [
+      '@title' => $this->label(),
+      '@url' => $this->toUrl('canonical', ['absolute' => TRUE])->toString(FALSE),
+    ]);
+
+    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    // Send the email.
+    \Drupal::service('plugin.manager.mail')
+      ->mail('reliefweb_entities', 'report_publication_notification', $to, $langcode, $parameters, $from, TRUE);
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/Entity/Report.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Report.php
@@ -210,6 +210,21 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
     elseif (isset($this->_original_created)) {
       $this->setCreatedTime($this->_original_created);
     }
+
+    // #KYPCnkXd - No OCHA Product if the source is not OCHA (id: 1503).
+    if (!$this->field_source->isEmpty()) {
+      $from_ocha = FALSE;
+      foreach ($this->field_source as $item) {
+        // We don't use a strict equality as tid may be a numeric string...
+        if (!$item->isEmpty() && $item->getValue('target_id') == 1503) {
+          $from_ocha = TRUE;
+          break;
+        }
+      }
+      if ($from_ocha === FALSE) {
+        $this->field_ocha_product->setValue([]);
+      }
+    }
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/Entity/Training.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Training.php
@@ -2,11 +2,14 @@
 
 namespace Drupal\reliefweb_entities\Entity;
 
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\reliefweb_entities\BundleEntityInterface;
 use Drupal\reliefweb_entities\DocumentInterface;
 use Drupal\reliefweb_entities\DocumentTrait;
+use Drupal\reliefweb_entities\OpportunityDocumentInterface;
+use Drupal\reliefweb_entities\OpportunityDocumentTrait;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\EntityModeratedTrait;
 use Drupal\reliefweb_revisions\EntityRevisionedInterface;
@@ -17,11 +20,12 @@ use Drupal\reliefweb_utility\Helpers\UrlHelper;
 /**
  * Bundle class for training nodes.
  */
-class Training extends Node implements BundleEntityInterface, EntityModeratedInterface, EntityRevisionedInterface, DocumentInterface {
+class Training extends Node implements BundleEntityInterface, EntityModeratedInterface, EntityRevisionedInterface, DocumentInterface, OpportunityDocumentInterface {
 
   use DocumentTrait;
   use EntityModeratedTrait;
   use EntityRevisionedTrait;
+  use OpportunityDocumentTrait;
   use StringTranslationTrait;
 
   /**
@@ -91,6 +95,16 @@ class Training extends Node implements BundleEntityInterface, EntityModeratedInt
       'training_language' => $this->getEntityMetaFromField('training_language', 'TL'),
       'cost' => $cost,
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preSave(EntityStorageInterface $storage) {
+    // Update the entity status based on the user posting rights.
+    $this->updateModerationStatusFromPostingRights();
+
+    parent::preSave($storage);
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/OpportunityDocumentInterface.php
+++ b/html/modules/custom/reliefweb_entities/src/OpportunityDocumentInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\reliefweb_entities;
+
+/**
+ * Interface for the opportunity document entities like jobs and training.
+ */
+interface OpportunityDocumentInterface {
+
+}

--- a/html/modules/custom/reliefweb_entities/src/OpportunityDocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/OpportunityDocumentTrait.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\reliefweb_entities;
+
+use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
+use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
+use Drupal\reliefweb_utility\Helpers\UserHelper;
+
+/**
+ * Trait for "opportunity" documents like jobs and training.
+ *
+ * @see Drupal\reliefweb_entities\DocuemntInterface
+ */
+trait OpportunityDocumentTrait {
+
+  /**
+   * Update the status for the entity based on the user posting rights.
+   */
+  protected function updateModerationStatusFromPostingRights() {
+    $user = $this->getRevisionUser();
+    $status = $this->getModerationStatus();
+
+    // For non editors, we determine the real status based on the user
+    // posting rights for the selected sources.
+    if (!UserHelper::userHasRoles(['editor']) && $status === 'pending') {
+      // Retrieve the list of sources and check the user rights.
+      if (!$this->field_source->isEmpty()) {
+        // Extract source ids.
+        $sources = [];
+        foreach ($this->field_source as $item) {
+          if (!empty($item->target_id)) {
+            $sources[] = $item->target_id;
+          }
+        }
+
+        // Get the user's posting right for the document.
+        $right = UserPostingRightsHelper::getUserConsolidatedPostingRight($user, $this->bundle(), $sources);
+
+        // Update the status based on the user's right.
+        // Note: we don't use `t()` because those are log messages for editors.
+        switch ($right['name']) {
+          // Unverified for some sources => pending + flag.
+          case 'unverified':
+            $status = 'pending';
+            $message = strtr('Unverified user for @sources.', [
+              '@sources' => implode(', ', TaxonomyHelper::getSourceShortnames($right['sources'])),
+            ]);
+            break;
+
+          // Blocked for some sources => refused + flag.
+          case 'blocked':
+            $status = 'refused';
+            $message = strtr('Blocked user for @sources.', [
+              '@sources' => implode(', ', TaxonomyHelper::getSourceShortnames($right['sources'])),
+            ]);
+            break;
+
+          // Allowed for all sources => pending.
+          case 'allowed':
+            $status = 'pending';
+            break;
+
+          // Trusted for all the sources => published.
+          case 'trusted':
+            $status = 'published';
+            break;
+        }
+
+        $this->setModerationStatus($status);
+
+        // Update the log message.
+        if (!empty($message)) {
+          $revision_log_field = $this->getEntityType()
+            ->getRevisionMetadataKey('revision_log_message');
+
+          if (!empty($revision_log_field)) {
+            $log = trim($this->{$revision_log_field}->value ?? '');
+            $log = $message . (!empty($log) ? ' ' . $log : '');
+            $this->{$revision_log_field}->value = $log;
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/html/modules/custom/reliefweb_entities/src/Services/CountryFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/CountryFormAlter.php
@@ -16,9 +16,6 @@ class CountryFormAlter extends EntityFormAlterServiceBase {
   protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
     // Hide term relations as they are not used.
     $form['relations']['#access'] = FALSE;
-
-    // Redirect to term page.
-    $form['#submit'][] = [$this, 'redirectToEntityPage'];
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/Services/DisasterFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/DisasterFormAlter.php
@@ -19,8 +19,6 @@ class DisasterFormAlter extends EntityFormAlterServiceBase {
    * {@inheritdoc}
    */
   protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
-    $entity = $form_state->getFormObject()->getEntity();
-
     // Hide term relations as they are not used.
     $form['relations']['#access'] = FALSE;
 
@@ -42,12 +40,7 @@ class DisasterFormAlter extends EntityFormAlterServiceBase {
     $form['field_primary_disaster_type']['#attributes']['data-with-autocomplete'] = 'primary';
 
     // Add a checkbox to disable the notifications.
-    $status = $entity->getModerationStatus();
-    $form['notifications_content_disable'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Disable notifications'),
-      '#default_value' => !empty($status) && $status !== 'draft',
-    ];
+    $this->addDisableNotifications($form, $form_state);
 
     // Limit form for External disaster managers who are not Editors.
     if (UserHelper::userHasRoles(['external_disaster_manager'])) {
@@ -64,9 +57,6 @@ class DisasterFormAlter extends EntityFormAlterServiceBase {
     // Validate the disaster GLIDE number and check for duplicates.
     $form['#validate'][] = [$this, 'validateGlidePattern'];
     $form['#validate'][] = [$this, 'validateGlideUniqueness'];
-
-    // Redirect to term page.
-    $form['#submit'][] = [$this, 'redirectToEntityPage'];
   }
 
   /**

--- a/html/modules/custom/reliefweb_entities/src/Services/JobFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/JobFormAlter.php
@@ -72,6 +72,9 @@ class JobFormAlter extends EntityFormAlterServiceBase {
 
     // Add the terms and conditions block.
     $this->addTermsAndConditions($form, $form_state);
+
+    // Prevent saving from a blocked source.
+    $form['#validate'][] = [$this, 'validateBlockedSource'];
   }
 
   /**

--- a/html/modules/custom/reliefweb_entities/src/Services/SourceFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/SourceFormAlter.php
@@ -32,9 +32,6 @@ class SourceFormAlter extends EntityFormAlterServiceBase {
 
     // Validate social media links.
     $form['#validate'][] = [$this, 'validateSourceSocialMediaLinks'];
-
-    // Redirect to term page.
-    $form['#submit'][] = [$this, 'redirectToEntityPage'];
   }
 
   /**

--- a/html/modules/custom/reliefweb_entities/src/Services/TrainingFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/TrainingFormAlter.php
@@ -83,6 +83,9 @@ class TrainingFormAlter extends EntityFormAlterServiceBase {
 
     // Add a validation callback to handle the altered fields above.
     $form['#validate'][] = [$this, 'validateTrainingEventUrl'];
+
+    // Prevent saving from a blocked source.
+    $form['#validate'][] = [$this, 'validateBlockedSource'];
   }
 
   /**

--- a/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineModeration.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineModeration.php
@@ -164,6 +164,12 @@ class GuidelineModeration extends ModerationServiceBase {
         $access = $account->hasPermission('delete guideline entities');
         break;
 
+      case 'view_moderation_information':
+        if ($account->hasPermission('view moderation information')) {
+          $access = $account->hasPermission('edit guideline entities');
+        }
+        break;
+
       default:
         return AccessResult::neutral();
     }

--- a/html/modules/custom/reliefweb_moderation/reliefweb_moderation.module
+++ b/html/modules/custom/reliefweb_moderation/reliefweb_moderation.module
@@ -15,6 +15,7 @@ use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\ModeratedNodeStorageSchema;
 use Drupal\reliefweb_moderation\ModeratedTermStorageSchema;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
+use Drupal\reliefweb_utility\Helpers\EntityHelper;
 
 /**
  * Implements hook_theme().
@@ -196,50 +197,60 @@ function reliefweb_moderation_entity_presave(EntityInterface $entity) {
  * Add the moderation information block to entity pages and forms.
  */
 function reliefweb_moderation_preprocess_page(&$variables) {
-  if (!\Drupal::currentUser()->hasPermission('access content moderation features')) {
-    return;
-  }
-
-  $route_match = \Drupal::routeMatch();
-  $entity = $route_match->getParameter('node') ?? $route_match->getParameter('taxonomy_term');
+  $user = \Drupal::currentUser();
 
   // For existing revisionable and moderated entities, add the moderation
   // information at the top of the entity page/form.
-  if (
-      !empty($entity) &&
-      $entity instanceof EntityModeratedInterface &&
-      !$entity->isNew()
-  ) {
-    // Note: when comming back from the preview, the original revision log will
-    // not be available...
+  $entity = EntityHelper::getEntityFromRoute();
+  if (empty($entity) || $entity->isNew() || !($entity instanceof EntityModeratedInterface)) {
+    return;
+  }
+
+  $element = [
+    '#theme' => 'reliefweb_moderation_information',
+    // Display the moderation information before the page title and local
+    // tasks.
+    '#weight' => -100,
+    '#cache' => [
+      '#contexts' => [
+        'user.permissions',
+      ],
+      '#tags' => [
+        $entity->getEntityTypeId() . ':' . $entity->id(),
+      ],
+    ],
+    '#access' => $entity->access('view_moderation_information'),
+  ];
+
+  // Get the moderation status.
+  if ($user->hasPermission('view moderation information status')) {
+    $element['#status'] = [
+      'value' => $entity->getModerationStatus(),
+      'label' => $entity->getModerationStatusLabel(),
+    ];
+  }
+
+  // Get the moderation revision message.
+  //
+  // Note: when comming back from the preview, the original revision log will
+  // not be available...
+  if ($user->hasPermission('view moderation information revision message')) {
     $message = $entity->getOriginalRevisionLogMessage();
     if (!empty($message)) {
-      // Convert the message to markdown to generated links notably.
+      // Convert the message to markdown to generate the links notably.
       // Wrap in a Markup so that the HTML is not escaped when rendered.
       $message = Markup::create(strip_tags(check_markup($message, 'markdown'), '<a><em><strong><br>'));
-    }
 
-    $element = [
-      '#theme' => 'reliefweb_moderation_information',
-      '#status' => [
-        'value' => $entity->getModerationStatus(),
-        'label' => $entity->getModerationStatusLabel(),
-      ],
-      '#message' => [
+      $element['#message'] = [
         'type' => $entity->getOriginalRevisionLogMessageType(),
         'content' => $message,
-        'author' => $entity->getOriginalRevisionUser(),
-      ],
-      // Display the moderation information before the page title and local
-      // tasks.
-      '#weight' => -100,
-      '#cache' => [
-        '#tags' => [
-          $entity->getEntityTypeId() . ':' . $entity->id(),
-        ],
-      ],
-    ];
+      ];
 
-    $variables['page']['content']['moderation-information'] = $element;
+      if ($user->hasPermission('view moderation information revision message author')) {
+        $element['#message']['author'] = $entity->getOriginalRevisionUser();
+      }
+    }
   }
+
+  $variables['page']['content']['moderation-information'] = $element;
 }

--- a/html/modules/custom/reliefweb_moderation/reliefweb_moderation.permissions.yml
+++ b/html/modules/custom/reliefweb_moderation/reliefweb_moderation.permissions.yml
@@ -13,3 +13,19 @@ archive content:
 view any content:
   title: 'View any content'
   description: 'Allow users to view any content.'
+
+view moderation information:
+  title: 'View moderation information'
+  description: 'Allow users to view the moderation status and revision message.'
+
+view moderation information status:
+  title: 'View moderation information status'
+  description: 'Allow users to view the moderation status.'
+
+view moderation information revision message:
+  title: 'View moderation information revision message'
+  description: 'Allow users to view the moderation revision message.'
+
+view moderation information revision message author:
+  title: 'View moderation information revision message author'
+  description: 'Allow users to view the moderation revision message author.'

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -243,7 +243,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
       $this->disableNotifications($entity, $status);
 
       // Disable notifications for buried entities.
-      if ($entity->hasField('field_bury') && !$entity->field_bury->isEmpty()) {
+      if ($entity->hasField('field_bury') && !empty($entity->field_bury->value)) {
         $entity->notifications_content_disable = TRUE;
       }
     }
@@ -403,7 +403,6 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
 
     // Disable the moderation status widget and the default submit buttons.
     $form['actions']['submit']['#access'] = FALSE;
-    $form['actions']['overview']['#access'] = FALSE;
 
     // Move the preview button at the beginning if it exists.
     if (isset($form['actions']['preview'])) {
@@ -419,9 +418,8 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
       $submit_handlers = array_merge($submit_handlers, $form['actions']['submit']['#submit']);
     }
 
-    // Add submit handler at the end to finalize the selection of the status
-    // based on the rest of the submitted data.
-    $submit_handlers[] = [$this, 'handleEntitySubmission'];
+    // Try to redirect to the entity page after submitting the form.
+    $submit_handlers[] = [$this, 'redirectToEntityPage'];
 
     // Add the buttons.
     foreach ($this->getEntityFormSubmitButtons($status, $entity) as $status => $info) {
@@ -445,19 +443,12 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
   public function validateEntityStatus(array $element, FormStateInterface $form_state) {
     $triggering_element = $form_state->getTriggeringElement();
     if (isset($triggering_element['#entity_status']) && $triggering_element['#entity_status'] === $element['#entity_status']) {
-      $form_state->setValue(['moderation_status', 0, 'value'], $element['#entity_status']);
+      // Alter the status from the button. This is useful notably for disasters
+      // because we use a single 'archive' button and the status is derived
+      // from the previous status of the disaster.
+      $status = $this->alterSubmittedEntityStatus($element['#entity_status'], $form_state);
+      $form_state->setValue(['moderation_status', 0, 'value'], $status);
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function handleEntitySubmission(array $form, FormStateInterface $form_state) {
-    // Alter the status based on the rest of the submitted form.
-    // @todo review if that should not be done in the entity presave instead.
-    $status = $form_state->getValue(['moderation_status', 0, 'value']);
-    $status = $this->alterSubmittedEntityStatus($status, $form_state);
-    $form_state->setValue(['moderation_status', 0, 'value'], $status);
   }
 
   /**
@@ -465,6 +456,21 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
    */
   public function alterSubmittedEntityStatus($status, FormStateInterface $form_state) {
     return $status;
+  }
+
+  /**
+   * Redirect to the entity page.
+   *
+   * @param array $form
+   *   Form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   */
+  public function redirectToEntityPage(array $form, FormStateInterface $form_state) {
+    $entity = $form_state->getFormObject()?->getEntity();
+    if (!empty($entity) && empty($entity->in_preview) && $entity->id() !== NULL) {
+      $form_state->setRedirectUrl($entity->toUrl());
+    }
   }
 
   /**

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -326,6 +326,17 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
               }
               break;
 
+            case 'view_moderation_information':
+              if ($account->hasPermission('view moderation information')) {
+                if ($account->hasPermission('edit any ' . $bundle . ' content')) {
+                  $access = TRUE;
+                }
+                elseif ($account->hasPermission('edit own ' . $bundle . ' content')) {
+                  $access = UserPostingRightsHelper::userHasPostingRights($account, $entity, $status);
+                }
+              }
+              break;
+
             default:
               return AccessResult::neutral();
           }
@@ -355,6 +366,12 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
 
             case 'delete':
               $access = $account->hasPermission('delete terms in ' . $bundle);
+              break;
+
+            case 'view_moderation_information':
+              if ($account->hasPermission('view moderation information')) {
+                $access = $account->hasPermission('edit terms in ' . $bundle);
+              }
               break;
 
             default:

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceInterface.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceInterface.php
@@ -183,16 +183,6 @@ interface ModerationServiceInterface {
   public function validateEntityStatus(array $element, FormStateInterface $form_state);
 
   /**
-   * Submit handler to alter the moderation status.
-   *
-   * @param array $form
-   *   Entity form.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   Form state.
-   */
-  public function handleEntitySubmission(array $form, FormStateInterface $form_state);
-
-  /**
    * Get the final entity status based on the rest of the form.
    *
    * @param string $status

--- a/html/modules/custom/reliefweb_moderation/src/Services/DisasterModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/DisasterModeration.php
@@ -284,8 +284,10 @@ class DisasterModeration extends ModerationServiceBase {
    * {@inheritdoc}
    */
   public function disableNotifications(EntityModeratedInterface $entity, $status) {
-    $allowed_statuses = ['alert', 'current', 'ongoing'];
-    $entity->notifications_content_disable = !in_array($status, $allowed_statuses);
+    if (empty($entity->notifications_content_disable)) {
+      $allowed_statuses = ['alert', 'current', 'ongoing'];
+      $entity->notifications_content_disable = !in_array($status, $allowed_statuses);
+    }
   }
 
   /**

--- a/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
@@ -3,13 +3,11 @@
 namespace Drupal\reliefweb_moderation\Services;
 
 use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
-use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\UserHelper;
 
 /**
@@ -268,73 +266,6 @@ class JobModeration extends ModerationServiceBase {
     }
 
     return $buttons;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function alterSubmittedEntityStatus($status, FormStateInterface $form_state) {
-    // For non editors, we determine the real status based on the user
-    // posting rights for the selected sources.
-    if (!UserHelper::userHasRoles(['editor']) && $status === 'pending') {
-      // Retrieve the list of sources and check the user rights.
-      if (!$form_state->isValueEmpty('field_source')) {
-        // Extract source ids.
-        $sources = array_filter(array_map(function ($source) {
-          return $source['target_id'];
-        }, $form_state->getValue('field_source')));
-
-        // Get the user's posting right for the document.
-        $right = UserPostingRightsHelper::getUserConsolidatedPostingRight($user, 'job', $sources);
-
-        // Update the status based on the user's right.
-        // Note: we don't use `t()` because those are log messages for editors.
-        switch ($right['name']) {
-          // Unverified for some sources => pending + flag.
-          case 'unverified':
-            $status = 'pending';
-            $message = strtr('Unverified user for @sources.', [
-              '@sources' => implode(', ', TaxonomyHelper::getSourceShortnames($right['sources'])),
-            ]);
-            break;
-
-          // Blocked for some sources => refused + flag.
-          case 'blocked':
-            $status = 'refused';
-            $message = strtr('Blocked user for @sources.', [
-              '@sources' => implode(', ', TaxonomyHelper::getSourceShortnames($right['sources'])),
-            ]);
-            break;
-
-          // Allowed for all sources => pending.
-          case 'allowed':
-            $status = 'pending';
-            break;
-
-          // Trusted for all the sources => published.
-          case 'trusted':
-            $status = 'published';
-            break;
-        }
-
-        // Update the log message.
-        if (!empty($message)) {
-          $revision_log_field = $form_state
-            ?->getFormObject()
-            ?->getEntity()
-            ?->getEntityType()
-            ?->getRevisionMetadataKey('revision_log_message');
-
-          if (!empty($revision_log_field)) {
-            $log = $form_state->getValue([$revision_log_field, 0, 'value'], '');
-            $log = $message . (!empty($log) ? ' ' . $log : '');
-            $form_state->setValue([$revision_log_field, 0, 'value'], $log);
-          }
-        }
-      }
-    }
-
-    return $status;
   }
 
   /**

--- a/html/modules/custom/reliefweb_moderation/src/Services/TrainingModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/TrainingModeration.php
@@ -3,13 +3,11 @@
 namespace Drupal\reliefweb_moderation\Services;
 
 use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
-use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\UserHelper;
 
 /**
@@ -293,73 +291,6 @@ class TrainingModeration extends ModerationServiceBase {
     }
 
     return $buttons;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function alterSubmittedEntityStatus($status, FormStateInterface $form_state) {
-    // For non editors, we determine the real status based on the user
-    // posting rights for the selected sources.
-    if (!UserHelper::userHasRoles(['editor']) && $status === 'pending') {
-      // Retrieve the list of sources and check the user rights.
-      if (!$form_state->isValueEmpty('field_source')) {
-        // Extract source ids.
-        $sources = array_filter(array_map(function ($source) {
-          return $source['target_id'];
-        }, $form_state->getValue('field_source')));
-
-        // Get the user's posting right for the document.
-        $right = UserPostingRightsHelper::getUserConsolidatedPostingRight($user, 'training', $sources);
-
-        // Update the status based on the user's right.
-        // Note: we don't use `t()` because those are log messages for editors.
-        switch ($right['name']) {
-          // Unverified for some sources => pending + flag.
-          case 'unverified':
-            $status = 'pending';
-            $message = strtr('Unverified user for @sources.', [
-              '@sources' => implode(', ', TaxonomyHelper::getSourceShortnames($right['sources'])),
-            ]);
-            break;
-
-          // Blocked for some sources => refused + flag.
-          case 'blocked':
-            $status = 'refused';
-            $message = strtr('Blocked user for @sources.', [
-              '@sources' => implode(', ', TaxonomyHelper::getSourceShortnames($right['sources'])),
-            ]);
-            break;
-
-          // Allowed for all sources => pending.
-          case 'allowed':
-            $status = 'pending';
-            break;
-
-          // Trusted for all the sources => published.
-          case 'trusted':
-            $status = 'published';
-            break;
-        }
-
-        // Update the log message.
-        if (!empty($message)) {
-          $revision_log_field = $form_state
-            ?->getFormObject()
-            ?->getEntity()
-            ?->getEntityType()
-            ?->getRevisionMetadataKey('revision_log_message');
-
-          if (!empty($revision_log_field)) {
-            $log = $form_state->getValue([$revision_log_field, 0, 'value'], '');
-            $log = $message . (!empty($log) ? ' ' . $log : '');
-            $form_state->setValue([$revision_log_field, 0, 'value'], $log);
-          }
-        }
-      }
-    }
-
-    return $status;
   }
 
   /**

--- a/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.module
+++ b/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\reliefweb_utility\Helpers\MailHelper;
 
 /**
  * Get the list of subscriptions.
@@ -349,6 +350,7 @@ function reliefweb_subscriptions_mail($key, &$message, $params) {
 
   $message['subject'] = $params['subject'];
   $message['body'] = $params['body'];
+  $message['params']['plaintext'] = MailHelper::getPlainText($message['body']);
 }
 
 /**

--- a/html/modules/custom/reliefweb_subscriptions/src/Form/SubscriptionForm.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/Form/SubscriptionForm.php
@@ -131,6 +131,9 @@ class SubscriptionForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $subscriptions = $form_state->getValue('global');
     foreach ($subscriptions as $sid => $value) {
+      if ($sid === '_none') {
+        continue;
+      }
       if (!$value) {
         $this->unsubscribe($form_state->getValue('uid'), $sid);
       }
@@ -141,6 +144,9 @@ class SubscriptionForm extends FormBase {
 
     $subscriptions = $form_state->getValue('country_updates');
     foreach ($subscriptions as $sid => $value) {
+      if ($sid === '_none') {
+        continue;
+      }
       if (!$value) {
         $this->unsubscribe($form_state->getValue('uid'), $sid);
       }

--- a/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content--disaster.html.twig
+++ b/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content--disaster.html.twig
@@ -4,6 +4,10 @@
  * @file
  * Template for the disaster notifications.
  *
+ * Important note: the formmatting of this template and the use of the twig
+ * spaceless indicator `-` are on purpose to ensure a clean conversion to
+ * plain text without excessive line breaks and indentation.
+ *
  * Available variables are:
  * - preheader: string for preheader.
  * - title: disaster name.
@@ -15,18 +19,19 @@
 ?>
 
 #}
-{% embed '@reliefweb_subscriptions/reliefweb-subscriptions-content.html.twig' %}
+{%- embed '@reliefweb_subscriptions/reliefweb-subscriptions-content.html.twig' -%}
 
-{% block content %}
-  <h1 class="email-title">New Disaster - {{ title }} / <span class="email-title-date">{{ date }}</span></h1>
+{%- block content -%}
+<h1 class="email-title">New Disaster - {{ title }} / <span class="email-title-date">{{ date }}</span></h1>
 
-  <div class="email-resource">
-    <h2>Overview</h2>
-    <div class="email-resource-teaser">
-      {{ overview|raw }}
-      <a class="email-resource-read-more" href="{{ url }}">View on ReliefWeb</a>
-    </div>
-  </div>
-{% endblock %}
+<div class="email-resource">
+<h2>Overview</h2>
 
-{% endembed %}
+<div class="email-resource-teaser">
+{{- overview|raw }}
+<a class="email-resource-read-more" href="{{ url }}">View on ReliefWeb</a>
+</div>
+</div>
+{%- endblock -%}
+
+{%- endembed -%}

--- a/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content--ocha-sitrep.html.twig
+++ b/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content--ocha-sitrep.html.twig
@@ -13,19 +13,19 @@
  */
 
 #}
-{% embed '@reliefweb_subscriptions/reliefweb-subscriptions-content.html.twig' %}
+{%- embed '@reliefweb_subscriptions/reliefweb-subscriptions-content.html.twig' -%}
 
-{% block content %}
-  <h1 class="email-title">New OCHA Situation Report - {{ title }}</h1>
+{%- block content -%}
+<h1 class="email-title">New OCHA Situation Report - {{ title }}</h1>
 
-  <div class="email-resource">
-    <div class="email-resource-info">{{ info|raw }}</div>
+<div class="email-resource">
+<div class="email-resource-info">{{ info|raw }}</div>
 
-    <div class="email-resource-teaser">
-      {{ summary|raw }}
-      <a class="email-resource-read-more" href="{{ url }}">Read more</a>
-    </div>
-  </div>
-{% endblock %}
+<div class="email-resource-teaser">
+{{- summary|raw }}
+<a class="email-resource-read-more" href="{{ url }}">Read more</a>
+</div>
+</div>
+{%- endblock -%}
 
-{% endembed %}
+{%- endembed -%}

--- a/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content.html.twig
+++ b/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content.html.twig
@@ -4,6 +4,10 @@
  * @file
  * Default template for notifications.
  *
+ * Important note: the formmatting of this template and the use of the twig
+ * spaceless indicator `-` are on purpose to ensure a clean conversion to
+ * plain text without excessive line breaks and indentation.
+ *
  * Available variables are:
  * - preheader: string for preheader.
  * - title: notification title.
@@ -18,39 +22,39 @@
  */
 
 #}
-{% block header %}
-  {{ render_var({
+{%- block header -%}
+  {{- render_var({
     '#theme': 'reliefweb_subscriptions_header',
     '#preheader': preheader,
-  }) }}
-{% endblock %}
+  }) -}}
+{%- endblock -%}
 
-{% block content %}
-  <h1 class="email-title">{{ title }} / <span class="email-title-date">{{ 'now'|date('j M Y') }}</span></h1>
+{%- block content -%}
+<h1 class="email-title">{{ title }} / <span class="email-title-date">{{ 'now'|date('j M Y') }}</span></h1>
 
-  {% for item in items %}
-    <div class="email-resource">
-      <h2 class="email-resource-title"><a class="email-resource-title-link" href="{{ item.url }}">{{ item.title }}</a></h2>
-      <div class="email-resource-info">{{ item.info|raw }}</div>
+{%- for item in items -%}
+<div class="email-resource">
+<h2 class="email-resource-title"><a class="email-resource-title-link" href="{{ item.url }}">{{ item.title }}</a></h2>
+<div class="email-resource-info">{{ item.info|raw }}</div>
 
-      {% if item.image %}
-        <div class="email-resource-image">
-          <img src="{{ item.image.url }}" alt="{{ item.image.description }}">
-        </div>
-      {% endif %}
+{% if item.image -%}
+<div class="email-resource-image">
+<img src="{{ item.image.url }}" alt="{{ item.image.description }}">
+</div>
+{%- endif -%}
 
-      <div class="email-resource-teaser">
-        {{ item.summary|raw }}
-        <a class="email-resource-read-more" href="{{ item.url }}">{{ read_more_label }}</a>
-      </div>
-    </div>
-  {% endfor %}
-{% endblock %}
+<div class="email-resource-teaser">
+{{- item.summary|raw }}
+<a class="email-resource-read-more" href="{{ item.url }}">{{ read_more_label }}</a>
+</div>
+</div>
+{%- endfor -%}
+{%- endblock -%}
 
-{% block footer %}
-  {{ render_var({
+{%- block footer -%}
+  {{- render_var({
     '#theme': 'reliefweb_subscriptions_footer',
     '#prefooter': prefooter,
-  }) }}
-{% endblock %}
+  }) -}}
+{%- endblock -%}
 

--- a/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-footer.html.twig
+++ b/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-footer.html.twig
@@ -4,19 +4,22 @@
  * @file
  * Footer template for the notifications.
  *
+ * Important note: the formmatting of this template and the use of the twig
+ * spaceless indicator `-` are on purpose to ensure a clean conversion to
+ * plain text without excessive line breaks and indentation.
+ *
  * Available variables are:
  * - prefooter: string for prefooter.
  */
 
 #}
-{% if prefooter %}
+{% if prefooter -%}
 <div class="prefooter">
-  {{ prefooter|raw }}
+  {{- prefooter|raw -}}
 </div>
 {% endif %}
-
 <div class="footer">
-  <a class="footer-link" href="{{ url('<front>') }}contact">Feedback</a> | <a class="footer-link" href="@unsubscribe">Unsubscribe</a>
+<a class="footer-link" href="{{ url('<front>') }}contact">Feedback</a> | <a class="footer-link" href="@unsubscribe">Unsubscribe</a>
 
-  <div class="footer-copyright">&copy; {{ 'now'|date('Y') }} ReliefWeb</div>
+<div class="footer-copyright">&copy; {{ 'now'|date('Y') }} ReliefWeb</div>
 </div>

--- a/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-header.html.twig
+++ b/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-header.html.twig
@@ -4,6 +4,10 @@
  * @file
  * Header template for the notifications.
  *
+ * Important note: the formmatting of this template and the use of the twig
+ * spaceless indicator `-` are on purpose to ensure a clean conversion to
+ * plain text without excessive line breaks and indentation.
+ *
  * Available variables are:
  * - logo: url of the ReliefWeb logo.
  * - preheader: string for preheader.

--- a/html/modules/custom/reliefweb_utility/src/Helpers/EntityHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/EntityHelper.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\reliefweb_utility\Helpers;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Helper to information about entities.
+ */
+class EntityHelper {
+
+  /**
+   * Attempt to get the entity for the current route.
+   *
+   * Note: this only works for routes using the "standard" way to declare
+   * entity parameters: `entity:entity_type_id`.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The entity for the route or NULL if none.
+   */
+  public static function getEntityFromRoute() {
+    $route_match = \Drupal::routeMatch();
+
+    $route = $route_match->getRouteObject();
+    if (empty($route)) {
+      return NULL;
+    }
+
+    $parameters = $route->getOption('parameters');
+    if (empty($parameters)) {
+      return NULL;
+    }
+
+    foreach ($parameters as $name => $options) {
+      if (isset($options['type']) && strpos($options['type'], 'entity:') === 0) {
+        $entity = $route_match->getParameter($name);
+        if (!empty($entity) && $entity instanceof EntityInterface) {
+          return $entity;
+        }
+        else {
+          return NULL;
+        }
+      }
+    }
+  }
+
+}

--- a/html/modules/custom/reliefweb_utility/src/Helpers/MailHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/MailHelper.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\reliefweb_utility\Helpers;
+
+use Drupal\Core\Mail\MailFormatHelper;
+use Drupal\Core\Site\Settings;
+
+/**
+ * Helper to manipulate emails.
+ */
+class MailHelper {
+
+
+  /**
+   * Allowed tags in the HTML body part of the email.
+   *
+   * @var array
+   */
+  protected static $allowedTags = [
+    'html',
+    'head',
+    'meta',
+    'body',
+    'div',
+    'span',
+    'br',
+    'a',
+    'em',
+    'i',
+    'strong',
+    'b',
+    'cite',
+    'code',
+    'strike',
+    'ul',
+    'ol',
+    'li',
+    'dl',
+    'dt',
+    'dd',
+    'blockquote',
+    'p',
+    'pre',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'table',
+    'caption',
+    'thead',
+    'tbody',
+    'th',
+    'td',
+    'tr',
+    'sup',
+    'sub',
+    'img',
+  ];
+
+  /**
+   * Get the plain text version of an email's body.
+   *
+   * @param array|string $body
+   *   The mail body.
+   *
+   * @return string
+   *   The plain text body.
+   */
+  public static function getPlainText($body) {
+    if (empty($body)) {
+      return '';
+    }
+
+    // Get the line ending characters.
+    $eol = Settings::get('mail_line_endings', PHP_EOL);
+
+    // Join the body array into one string if necessary.
+    if (is_array($body)) {
+      $body = implode($eol . $eol, $body);
+    }
+
+    // Skip if there is nothing to convert.
+    $body = trim($body);
+    if (empty($body)) {
+      return '';
+    }
+
+    // If there is no apparent HTML elements we assume it's already plain text.
+    if (preg_match('#</[^>]+>#', $body) !== 1) {
+      $body_text = $body;
+    }
+    else {
+      // Remove the preheader for plain text mail.
+      $body = preg_replace('#<[^ ]+ id="preheader"[^<]*</[^>]+>#', '', $body);
+
+      // Convert any HTML to plain-text.
+      $body_text = MailFormatHelper::htmlToText($body, self::$allowedTags);
+    }
+
+    // Remove unnecessary consecutive line breaks.
+    $body_text = preg_replace('#(' . $eol . '){3,}#', $eol . $eol, $body_text);
+
+    // Ensure there is a blank line before second level titles.
+    $body_text = preg_replace('/([^\n\r])(' . $eol . '--------)/', '$1' . $eol . '$2', $body_text);
+
+    return $body_text;
+  }
+
+}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -63,4 +63,7 @@ ckeditor_stylesheets:
 libraries-override:
   guidelines/guidelines-json:
     js:
-      components/guidelines-json/guidelines-json.js: components/rw-guidelines/guidelines-json.js
+      components/guidelines-json/guidelines-json.js: false
+    css:
+      component:
+        components/guidelines-json/guidelines-json.css: false

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -138,7 +138,7 @@ rw-guidelines:
     theme:
       components/rw-guidelines/rw-guidelines.css: {}
   js:
-    components/rw-guidelines/guidelines-json.js: {}
+    components/rw-guidelines/rw-guidelines.js: {}
   dependencies:
     - common_design_subtheme/rw-icons
 

--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
@@ -484,7 +484,7 @@ form button[data-formatter="pdf"] {
   /* Display the format PDf button in the top right corner above the textarea.
    * The editorial team is used to this position. */
   position: absolute;
-  top: -11px;
+  top: -8px;
   right: 0;
 }
 /* Show/Hide row weight button */

--- a/html/themes/custom/common_design_subtheme/components/rw-guidelines/rw-guidelines.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-guidelines/rw-guidelines.css
@@ -1,18 +1,17 @@
-form[data-with-guidelines] .form-item label,
-form[data-with-guidelines] .form-wrapper label {
-  float: left;
+form[data-with-guidelines] .rw-guideline__label {
+  display: inline-flex;
+  margin-right: 12px;
 }
-form[data-with-guidelines] .fieldset-wrapper label,
-form[data-with-guidelines] label.option {
-  float: none;
+form[data-with-guidelines] .rw-guideline__label.form-required {
+  margin-right: 8px;
 }
-form[data-with-guidelines] button[data-guideline] {
+form[data-with-guidelines] .rw-guideline__open-button {
   position: relative;
   display: inline-block;
   overflow: hidden;
   width: 20px;
   height: 20px;
-  margin: -0.75rem 0 0 0.5rem;
+  margin: -4px 0 0 0;
   padding: 0 0 0 12px;
   vertical-align: middle;
   border: 4px solid var(--cd-reliefweb-brand-grey--light);
@@ -20,28 +19,7 @@ form[data-with-guidelines] button[data-guideline] {
   background: var(--rw-icons--common--help--12--dark-blue);
   background-color: var(--cd-reliefweb-brand-grey--light);
 }
-/* Legend with child button */
-form[data-with-guidelines] legend button[data-guideline] {
-  margin: -0.75rem 0 0 0.5rem;
-}
-form[data-with-guidelines] .form-required button[data-guideline] {
-  margin: 0 0 0 0.5rem;
-}
-form[data-with-guidelines] legend .form-required button[data-guideline] {
-  order: 1;
-}
-/* Label followed by button */
-form[data-with-guidelines] label + button[data-guideline],
-form[data-with-guidelines] .form-required + button[data-guideline] {
-  margin: -0.75rem 0 0;
-}
-form[data-with-guidelines] label.option + button[data-guideline] {
-  margin: -0.5rem 0 0;
-}
-form[data-with-guidelines] .visually-hidden + button[data-guideline] {
-  margin: -0.75rem 0 0 0.5rem;
-}
-form[data-with-guidelines] button[data-guideline]:hover {
+form[data-with-guidelines] .rw-guideline__open-button:hover {
   background: var(--rw-icons--common--help--12--dark-red);
   background-color: var(--cd-reliefweb-brand-grey--light);
 }
@@ -59,7 +37,7 @@ form[data-with-guidelines] .rw-guideline:before {
 }
 form[data-with-guidelines] .rw-guideline {
   position: fixed;
-  z-index: 1;
+  z-index: 10000;
   top: 10vh;
   left: 25vw;
   width: 50vw;
@@ -68,7 +46,7 @@ form[data-with-guidelines] .rw-guideline {
   border: 10px solid rgba(0, 0, 0, 0.1);
 }
 
-form[data-with-guidelines] .rw-guideline > button[value="close"] {
+form[data-with-guidelines] .rw-guideline .rw-guideline__close-button {
   position: absolute;
   z-index: 10002;
   top: -16px;
@@ -81,7 +59,7 @@ form[data-with-guidelines] .rw-guideline > button[value="close"] {
   border-radius: 50%;
   background: white;
 }
-form[data-with-guidelines] .rw-guideline > button[value="close"]:after {
+form[data-with-guidelines] .rw-guideline .rw-guideline__close-button:after {
   position: absolute;
   top: 6px;
   left: 6px;
@@ -91,13 +69,13 @@ form[data-with-guidelines] .rw-guideline > button[value="close"]:after {
   content: "";
   background: var(--rw-icons--common--close--12--dark-blue);
 }
-form[data-with-guidelines] .rw-guideline > button[value="close"]:hover {
+form[data-with-guidelines] .rw-guideline .rw-guideline__close-button:hover {
   border-color: var(--cd-reliefweb-brand-red--dark);
 }
-form[data-with-guidelines] .rw-guideline > button[value="close"]:hover:after {
+form[data-with-guidelines] .rw-guideline .rw-guideline__close-button:hover:after {
   background: var(--rw-icons--common--close--12--dark-red);
 }
-form[data-with-guidelines] .rw-guideline > div {
+form[data-with-guidelines] .rw-guideline__container {
   position: relative;
   z-index: 10001;
   overflow-x: hidden;
@@ -107,20 +85,12 @@ form[data-with-guidelines] .rw-guideline > div {
   padding: 16px;
   background-color: white;
 }
-form[data-with-guidelines] .rw-guideline > div > h3 {
+form[data-with-guidelines] .rw-guideline__heading {
   text-align: center;
 }
-form[data-with-guidelines] .rw-guideline > div > .content {
+form[data-with-guidelines] .rw-guideline__content {
   padding-top: 0;
 }
-form[data-with-guidelines] .rw-guideline > div > .rw-guideline__content img {
+form[data-with-guidelines] .rw-guideline__content img {
   border: 4px solid var(--cd-reliefweb-brand-grey--light);
-}
-
-/* Clear the float on preceding label
-/* to prevent extra height on the autocomplete div */
-form[data-with-guidelines] .rw-autocomplete--with-show-all,
-/* to ensure the WYSIWYG clears float */
-form[data-with-guidelines] button[data-guideline] + div {
-  clear: both;
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-report/rw-report.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-report/rw-report.css
@@ -106,3 +106,14 @@
 .node--report--full li {
   margin: 8px 0 0;
 }
+
+/* Special rules for The Conversation counter images... */
+.node--report--full img[src*="counter.theconversation.com"] {
+  position: absolute;
+  visibility: hidden;
+  width: 1px;
+  height: 1px;
+}
+.node--report--full img[src*="counter.theconversation.com"] + p {
+  margin-top: 0;
+}


### PR DESCRIPTION
- RW-227: add logic for report publication notification
- RW-311: hide outline tab
- RW-367: fix access to moderation information displayed on top entity pages
- RW-368: add missing table elements to text formats
- RW-361: allow alt attribute in image elements in text formats and add special css rule for The Conversation counter images
- RW-372: ensure OCHA product terms are removed when saving a report without OCHA as source
- RW-116: adjust plain text version of notification emails to match D7's
- RW-327, RW-343: simplify guidelines css rules, preventing them from affecting forms without guidelines
- RW-373: fix redirection to term page when creating a new term
- RW-374: fix status when saving a disaster as archived
- Move logic to set a job/training's moderation status based on the user posting rights to `presave` instead of form submit