### PR TITLE
Various fixes - part 4

### DIFF
--- a/config/core.entity_form_display.node.announcement.default.yml
+++ b/config/core.entity_form_display.node.announcement.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.announcement.field_link
     - node.type.announcement
   module:
+    - allowed_formats
     - link
     - media_library
     - text
@@ -21,11 +22,14 @@ content:
     weight: 3
     region: content
     settings:
-      rows: 9
+      rows: 5
       summary_rows: 3
       placeholder: ''
       show_summary: false
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
   field_image:
     type: media_library_widget
     weight: 2

--- a/config/core.entity_form_display.node.blog_post.default.yml
+++ b/config/core.entity_form_display.node.blog_post.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.blog_post.field_tags
     - node.type.blog_post
   module:
+    - allowed_formats
     - media_library
     - path
     - text
@@ -23,11 +24,14 @@ content:
     weight: 4
     region: content
     settings:
-      rows: 9
+      rows: 20
       summary_rows: 3
       placeholder: ''
       show_summary: false
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '1'
   field_attached_images:
     type: media_library_widget
     weight: 6

--- a/config/core.entity_form_display.node.book.default.yml
+++ b/config/core.entity_form_display.node.book.default.yml
@@ -23,13 +23,13 @@ content:
     weight: 1
     region: content
     settings:
-      rows: 9
+      rows: 20
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_attached_images:
     type: media_library_widget

--- a/config/core.entity_form_display.node.report.default.yml
+++ b/config/core.entity_form_display.node.report.default.yml
@@ -29,6 +29,7 @@ dependencies:
     - field.field.node.report.field_vulnerable_groups
     - node.type.report
   module:
+    - allowed_formats
     - datetime
     - media_library
     - path
@@ -45,11 +46,14 @@ content:
     weight: 2
     region: content
     settings:
-      rows: 9
+      rows: 20
       summary_rows: 3
       placeholder: ''
       show_summary: false
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '1'
   field_bury:
     type: boolean_checkbox
     weight: 22

--- a/config/core.entity_form_display.node.topic.default.yml
+++ b/config/core.entity_form_display.node.topic.default.yml
@@ -37,7 +37,7 @@ content:
       show_summary: false
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_bury:
     type: boolean_checkbox
@@ -77,11 +77,11 @@ content:
     weight: 3
     region: content
     settings:
-      rows: 5
+      rows: 9
       placeholder: ''
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_reports_search:
     type: reliefweb_section_links
@@ -94,11 +94,11 @@ content:
     weight: 4
     region: content
     settings:
-      rows: 5
+      rows: 9
       placeholder: ''
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_sections:
     type: reliefweb_section_links

--- a/config/core.entity_form_display.taxonomy_term.country.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.country.default.yml
@@ -33,7 +33,7 @@ content:
       placeholder: ''
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_aliases:
     type: string_textarea

--- a/config/core.entity_form_display.taxonomy_term.country.profile.yml
+++ b/config/core.entity_form_display.taxonomy_term.country.profile.yml
@@ -33,7 +33,7 @@ content:
       placeholder: ''
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_appeals_response_plans:
     type: reliefweb_links

--- a/config/core.entity_form_display.taxonomy_term.disaster.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.disaster.default.yml
@@ -36,7 +36,7 @@ content:
       placeholder: ''
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_country:
     type: reliefweb_entity_reference_select

--- a/config/core.entity_form_display.taxonomy_term.disaster.profile.yml
+++ b/config/core.entity_form_display.taxonomy_term.disaster.profile.yml
@@ -35,7 +35,7 @@ content:
       placeholder: ''
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_appeals_response_plans:
     type: reliefweb_links

--- a/config/core.entity_form_display.taxonomy_term.source.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.source.default.yml
@@ -44,7 +44,7 @@ content:
       placeholder: ''
     third_party_settings:
       allowed_formats:
-        hide_help: '1'
+        hide_help: '0'
         hide_guidelines: '1'
   field_aliases:
     type: string_textarea

--- a/config/field.field.node.announcement.field_link.yml
+++ b/config/field.field.node.announcement.field_link.yml
@@ -19,5 +19,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   title: 0
-  link_type: 17
+  link_type: 16
 field_type: link

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -38,6 +38,7 @@ dependencies:
     - reliefweb_revisions
     - reliefweb_topics
     - reliefweb_user_posts
+    - reliefweb_users
     - taxonomy
     - taxonomy_term_revision
 id: editor
@@ -181,6 +182,7 @@ permissions:
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view published guideline entities'
+  - 'view reliefweb admin menu'
   - 'view report revisions'
   - 'view term revision data'
   - 'view term revision list'

--- a/config/user.role.user_manager.yml
+++ b/config/user.role.user_manager.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - reliefweb_subscriptions
+    - reliefweb_users
 id: user_manager
 label: 'User manager'
 weight: 3
@@ -13,4 +14,5 @@ permissions:
   - 'administer subscriptions'
   - 'administer users'
   - 'change own username'
+  - 'view reliefweb admin menu'
   - 'view user email addresses'

--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -26,6 +26,7 @@ dependencies:
     - filter
     - google_tag
     - guidelines
+    - reliefweb_users
     - taxonomy
     - taxonomy_term_revision
 id: webmaster
@@ -114,6 +115,7 @@ permissions:
   - 'use text format guideline'
   - 'view all guideline revisions'
   - 'view published guideline entities'
+  - 'view reliefweb admin menu'
   - 'view term revision data'
   - 'view term revision list'
   - 'view unpublished guideline entities'

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -372,6 +372,13 @@ function reliefweb_entities_form_node_form_alter(array &$form, FormStateInterfac
  */
 function reliefweb_entities_form_taxonomy_term_form_alter(array &$form, FormStateInterface $form_state) {
   EntityFormAlterServiceBase::alterEntityForm($form, $form_state);
+
+  // Empty the revision log message as we always create new revisions.
+  //
+  // @see reliefweb_entities_set_taxonomy_term_revision()
+  if (!empty($form['revision_log_message']['widget'][0]['value']['#default_value'])) {
+    $form['revision_log_message']['widget'][0]['value']['#default_value'] = '';
+  }
 }
 
 /**
@@ -392,11 +399,63 @@ function reliefweb_entities_form_alter(array &$form, FormStateInterface $form_st
 }
 
 /**
+ * Implements hook_module_implements_alter().
+ */
+function reliefweb_entities_module_implements_alter(&$implementation, $hook) {
+  // Remove the hook_entity_presave() implementation from the
+  // taxonomy_term_revision module because it doesn't allow us to speify the
+  // revision user or timestamp. This is replaced by
+  // reliefweb_entities_set_taxonomy_term_revision().
+  //
+  // @see taxonomy_term_revision_entity_presave()
+  // @see reliefweb_entities_set_taxonomy_term_revision()
+  if ($hook === 'entity_presave') {
+    unset($implementation['taxonomy_term_revision']);
+  }
+}
+
+/**
  * Implements hook_entity_presave().
- *
- * Remove control characters from text fields.
  */
 function reliefweb_entities_entity_presave(EntityInterface $entity) {
+  // Remove control characters from an entity's text fields.
+  reliefweb_entities_clean_text_fields($entity);
+
+  // Set the taxonomy term revision.
+  reliefweb_entities_set_taxonomy_term_revision($entity);
+}
+
+/**
+ * Set a taxonomy term's revision information.
+ *
+ * Note: this replaces the taxonomy_term_revision_entity_presave() which
+ * is not flexible and forces the revision user ID and creation time.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity.
+ *
+ * @see taxonomy_term_revision_entity_presave()
+ */
+function reliefweb_entities_set_taxonomy_term_revision(EntityInterface $entity) {
+  // Saving new revision of term on each save.
+  if ($entity instanceof TermInterface) {
+    $entity->setNewRevision(TRUE);
+    if (is_null($entity->getRevisionUserId())) {
+      $entity->setRevisionUserId(\Drupal::currentUser()->id());
+    }
+    if (empty($entity->getRevisionCreationTime())) {
+      $entity->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+    }
+  }
+}
+
+/**
+ * Remove control characters from an entity's text fields.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity.
+ */
+function reliefweb_entities_clean_text_fields(EntityInterface $entity) {
   $entity_type_id = $entity->getEntityTypeId();
   if ($entity_type_id === 'node' || $entity_type_id === 'taxonomy_term') {
     $field_definitions = \Drupal::service('entity_field.manager')

--- a/html/modules/custom/reliefweb_entities/src/Entity/BlogPost.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/BlogPost.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\reliefweb_entities\Entity;
 
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\reliefweb_entities\BundleEntityInterface;
@@ -105,6 +106,20 @@ class BlogPost extends Node implements BundleEntityInterface, EntityModeratedInt
         'label' => $this->t('View all blog posts'),
       ],
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preSave(EntityStorageInterface $storage) {
+    // Set the creation date to the changed date when publishing the blog
+    // post from an unpublished state.
+    if (isset($this->original) &&
+      $this->getModerationStatus() === 'published' &&
+      $this->original->getModerationStatus() !== 'published'
+    ) {
+      $this->setCreatedTime($this->getChangedTime());
+    }
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/Entity/Job.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Job.php
@@ -134,6 +134,9 @@ class Job extends Node implements BundleEntityInterface, EntityModeratedInterfac
     // Update the entity status based on the user posting rights.
     $this->updateModerationStatusFromPostingRights();
 
+    // Update the entity statys based on the source(s) moderation status.
+    $this->updateModerationStatusFromSourceStatus();
+
     parent::preSave($storage);
   }
 

--- a/html/modules/custom/reliefweb_entities/src/Entity/Job.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Job.php
@@ -138,6 +138,16 @@ class Job extends Node implements BundleEntityInterface, EntityModeratedInterfac
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+
+    // Make the sources active.
+    $this->updateSourceModerationStatus();
+  }
+
+  /**
    * Get the list of job categories for which themes are irrelevant.
    *
    * @return array

--- a/html/modules/custom/reliefweb_entities/src/Entity/Job.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Job.php
@@ -137,6 +137,10 @@ class Job extends Node implements BundleEntityInterface, EntityModeratedInterfac
     // Update the entity statys based on the source(s) moderation status.
     $this->updateModerationStatusFromSourceStatus();
 
+    // Update the creation date when published for the first time so that
+    // the opportunity can appear at the top of the opportunity river.
+    $this->updateDateWhenPublished();
+
     parent::preSave($storage);
   }
 

--- a/html/modules/custom/reliefweb_entities/src/Entity/Training.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Training.php
@@ -104,6 +104,9 @@ class Training extends Node implements BundleEntityInterface, EntityModeratedInt
     // Update the entity status based on the user posting rights.
     $this->updateModerationStatusFromPostingRights();
 
+    // Update the entity statys based on the source(s) moderation status.
+    $this->updateModerationStatusFromSourceStatus();
+
     parent::preSave($storage);
   }
 

--- a/html/modules/custom/reliefweb_entities/src/Entity/Training.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Training.php
@@ -107,6 +107,10 @@ class Training extends Node implements BundleEntityInterface, EntityModeratedInt
     // Update the entity statys based on the source(s) moderation status.
     $this->updateModerationStatusFromSourceStatus();
 
+    // Update the creation date when published for the first time so that
+    // the opportunity can appear at the top of the opportunity river.
+    $this->updateDateWhenPublished();
+
     parent::preSave($storage);
   }
 

--- a/html/modules/custom/reliefweb_entities/src/Entity/Training.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Training.php
@@ -107,4 +107,14 @@ class Training extends Node implements BundleEntityInterface, EntityModeratedInt
     parent::preSave($storage);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+
+    // Make the sources active.
+    $this->updateSourceModerationStatus();
+  }
+
 }

--- a/html/modules/custom/reliefweb_entities/src/OpportunityDocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/OpportunityDocumentTrait.php
@@ -125,6 +125,33 @@ trait OpportunityDocumentTrait {
   }
 
   /**
+   * Update creation date when the opportunity is published for the first time.
+   */
+  protected function updateDateWhenPublished() {
+    if ($this->id() === NULL || $this->getModerationStatus() !== 'published') {
+      return;
+    }
+
+    $entity_type = $this->getEntityType();
+    $table = $entity_type->getRevisionDataTable();
+    $id_field = $entity_type->getKey('id');
+
+    $previously_published = \Drupal::database()
+      ->select($table, $table)
+      ->fields($table, [$entity_type->getKey('revision')])
+      ->condition($table . '.' . $id_field, $this->id(), '=')
+      ->condition($table . '.moderation_status', 'published', '=')
+      ->range(0, 1)
+      ->execute()
+      ?->fetchField();
+
+    // Update publication date if published for the first time.
+    if (empty($previously_published)) {
+      $this->setCreatedTime($this->getChangedTime());
+    }
+  }
+
+  /**
    * Update the status of the sources when publishing an opportunity.
    */
   protected function updateSourceModerationStatus() {

--- a/html/modules/custom/reliefweb_entities/src/Services/AnnouncementFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/AnnouncementFormAlter.php
@@ -14,7 +14,7 @@ class AnnouncementFormAlter extends EntityFormAlterServiceBase {
    * {@inheritdoc}
    */
   protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
-    // No customizations.
+    $form['title']['widget'][0]['value']['#description'] = $this->t('Title will show up in tooltip when you hover over the banner.');
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/Services/CountryFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/CountryFormAlter.php
@@ -13,9 +13,23 @@ class CountryFormAlter extends EntityFormAlterServiceBase {
   /**
    * {@inheritdoc}
    */
-  protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
+  public function alterForm(array &$form, FormStateInterface $form_state) {
+    parent::alterForm($form, $form_state);
+
+    // Restrict the description to the markdown format.
+    $form['description']['widget'][0]['#allowed_formats'] = [
+      'markdown' => 'markdown',
+    ];
+
     // Hide term relations as they are not used.
     $form['relations']['#access'] = FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
+    // No customizations.
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/Services/DisasterFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/DisasterFormAlter.php
@@ -18,10 +18,22 @@ class DisasterFormAlter extends EntityFormAlterServiceBase {
   /**
    * {@inheritdoc}
    */
-  protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
+  public function alterForm(array &$form, FormStateInterface $form_state) {
+    parent::alterForm($form, $form_state);
+
+    // Restrict the description to the markdown format.
+    $form['description']['widget'][0]['#allowed_formats'] = [
+      'markdown' => 'markdown',
+    ];
+
     // Hide term relations as they are not used.
     $form['relations']['#access'] = FALSE;
+  }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
     // Alter the primary country field, ensuring it's using a value among
     // the selected country values.
     $this->alterPrimaryField('field_primary_country', $form, $form_state);

--- a/html/modules/custom/reliefweb_entities/src/Services/SourceFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/SourceFormAlter.php
@@ -17,10 +17,22 @@ class SourceFormAlter extends EntityFormAlterServiceBase {
   /**
    * {@inheritdoc}
    */
-  protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
+  public function alterForm(array &$form, FormStateInterface $form_state) {
+    parent::alterForm($form, $form_state);
+
+    // Restrict the description to the markdown format.
+    $form['description']['widget'][0]['#allowed_formats'] = [
+      'markdown' => 'markdown',
+    ];
+
     // Hide term relations as they are not used.
     $form['relations']['#access'] = FALSE;
+  }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
     // Use an autocomplete widget for the country and source fields.
     $form['field_country']['#attributes']['data-with-autocomplete'] = '';
 

--- a/html/modules/custom/reliefweb_form/reliefweb_form.module
+++ b/html/modules/custom/reliefweb_form/reliefweb_form.module
@@ -273,3 +273,52 @@ function reliefweb_form_module_implements_alter(&$implementations, $hook) {
     $implementations['reliefweb_form'] = $group;
   }
 }
+
+/**
+ * Implements hook_field_widget_form_alter().
+ */
+function reliefweb_form_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+  if (!empty($element['#after_build'])) {
+    foreach ($element['#after_build'] as $key => $callback) {
+      if ($callback === '_allowed_formats_remove_textarea_help') {
+        $element['#after_build'][$key] = 'reliefweb_form_hide_format_help';
+      }
+    }
+  }
+}
+
+/**
+ * After build callback to hide the text format help.
+ */
+function reliefweb_form_hide_format_help($form_element, FormStateInterface $form_state) {
+  if (isset($form_element['format'])) {
+    $hide_help = !empty($form_element['#allowed_format_hide_settings']['hide_help']);
+    $hide_guidelines = !empty($form_element['#allowed_format_hide_settings']['hide_guidelines']);
+
+    if ($hide_help) {
+      $form_element['format']['help']['#access'] = FALSE;
+    }
+    if ($hide_guidelines) {
+      $form_element['format']['guidelines']['#access'] = FALSE;
+    }
+
+    // Ensure the format is displayed even it's only one, except for plain text.
+    if (isset($form_element['#allowed_formats']) && count($form_element['#allowed_formats']) === 1) {
+      if (($hide_help && $hide_guidelines) || $form_element['format']['format']['#default_value'] === 'plain_text') {
+        // We need to keep the format (we cannot use #access = FALSE) otherwise
+        // the editor for the text format, if any, will not be displayed...
+        // @see \Drupal\editor\Element::preRenderTextFormat()
+        unset($form_element['format']['#type']);
+        unset($form_element['format']['#theme_wrappers']);
+      }
+      else {
+        // We need to set the #access to TRUE otherwiwse it's hidden...
+        // @see \Drupal\editor\Element::preRenderTextFormat()
+        $form_element['format']['format']['#access'] = TRUE;
+        $form_element['format']['format']['#attributes']['disabled'] = TRUE;
+      }
+    }
+  }
+
+  return $form_element;
+}

--- a/html/modules/custom/reliefweb_users/reliefweb_users.permissions.yml
+++ b/html/modules/custom/reliefweb_users/reliefweb_users.permissions.yml
@@ -1,0 +1,3 @@
+view reliefweb admin menu:
+  title: 'View reliefweb admin menu'
+  description: 'Allow users to view the reliefwebadmin menu.'

--- a/html/modules/custom/reliefweb_utility/src/Plugin/Filter/Markdown.php
+++ b/html/modules/custom/reliefweb_utility/src/Plugin/Filter/Markdown.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\reliefweb_utility\Plugin\Filter;
 
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\Core\Render\Markup;
 use Drupal\filter\FilterProcessResult;
 use Drupal\filter\Plugin\FilterBase;
 use League\CommonMark\Environment;
@@ -67,6 +70,164 @@ class Markdown extends FilterBase {
     $html = $converter->convertToHtml($text);
 
     return new FilterProcessResult($html);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tips($long = FALSE) {
+    $help = '<h4>Markdown reference</h4>
+    <table class="markdown-reference">
+        <thead>
+            <tr>
+                <th>Type</th>
+                <th>… to Get</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>*Italic*</td>
+                <td><em>Italic</em></td>
+            </tr>
+            <tr>
+                <td>**Bold**</td>
+                <td><strong>Bold</strong></td>
+            </tr>
+            <tr>
+                <td>
+                    # Heading 1
+                </td>
+                <td>
+                    <h1>Heading 1</h1>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    ## Heading 2
+                </td>
+                <td>
+                    <h2>Heading 2</h2>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    ### Heading 3
+                </td>
+                <td>
+                    <h3>Heading 3</h3>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    #### Heading 4
+                </td>
+                <td>
+                    <h4>Heading 4</h4>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    ##### Heading 5
+                </td>
+                <td>
+                    <h5>Heading 5</h5>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    ###### Heading 6
+                </td>
+                <td>
+                    <h6>Heading 6</h6>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    [Link](http://a.com)
+                </td>
+                <td><a href="https://commonmark.org/help">Link</a></td>
+            </tr>
+            <tr>
+                <td>
+                    ![Image](http://url/reliefweb.png)
+                </td>
+                <td>
+                    <img src="/themes/custom/common_design_subtheme/img/logos/rw-logo-desktop.svg" width="140" height="60" alt="">
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    &gt; Blockquote
+                </td>
+                <td>
+                    <blockquote>Blockquote</blockquote>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p>
+                        - List<br>
+                        - List<br>
+                        - List
+                    </p>
+                </td>
+                <td>
+                    <ul>
+                        <li>List</li>
+                        <li>List</li>
+                        <li>List</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p>
+                        1. One<br>
+                        2. Two<br>
+                        3. Three
+                    </p>
+                </td>
+                <td>
+                    <ol>
+                        <li>One</li>
+                        <li>Two</li>
+                        <li>Three</li>
+                    </ol>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Horizontal rule:
+                    <br>
+                    ---
+                </td>
+                <td>
+                    Horizontal rule:
+                    <hr>
+                </td>
+            </tr>
+        </tbody>
+    </table>';
+
+    $tips = [
+      '#type' => 'container',
+    ];
+
+    $tips[] = [
+      '#markup' => Markup::create($help),
+    ];
+
+    // Documentation link.
+    $url = Url::fromUri('https://commonmark.org/help', [
+      'attributes' => ['target' => '_blank', 'rel' => 'noopener noreferrer'],
+    ]);
+    $tips[] = [
+      '#markup' => $this->t('For complete details on the Markdown syntax, see the @link', [
+        '@link' => Link::fromTextAndUrl($this->t('Markdown documentation'), $url)->toString(),
+      ]),
+    ];
+
+    return \Drupal::service('renderer')->render($tips);
   }
 
 }

--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
@@ -444,7 +444,7 @@ form > #actions legend + .form-type-checkbox.form-item-notifications-content-dis
 .filter-wrapper .filter-help a:after {
   top: 2px;
 }
-.filter-wrapper select[disabled] {
+.filter-wrapper select {
   padding: 0 4px;
 }
 .filter-wrapper ul {

--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
@@ -426,9 +426,11 @@ form > #actions legend + .form-type-checkbox.form-item-notifications-content-dis
   margin-top: 0;
 }
 .filter-wrapper {
-  border: 1px solid var(--cd-reliefweb-brand-grey--light);
+  border: 2px solid var(--cd-reliefweb-brand-grey--light);
+  border-top: none;
+  background: var(--cd-reliefweb-brand-grey--light);
 }
-.filter-wrapper .filter-help {
+.filter-wrapper * {
   font-size: 14px;
 }
 .filter-wrapper ul {

--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
@@ -238,8 +238,7 @@ form .form-disabled [data-irrelevant] > div {
   display: none;
 }
 form input[disabled],
-form textarea[disabled],
-form select[disabled] {
+form textarea[disabled] {
   background: var(--cd-reliefweb-brand-grey--light);
   background: var(--cd-reliefweb-grey--disable);
 }
@@ -426,6 +425,8 @@ form > #actions legend + .form-type-checkbox.form-item-notifications-content-dis
   margin-top: 0;
 }
 .filter-wrapper {
+  display: flex;
+  align-items: center;
   border: 2px solid var(--cd-reliefweb-brand-grey--light);
   border-top: none;
   background: var(--cd-reliefweb-brand-grey--light);
@@ -433,7 +434,21 @@ form > #actions legend + .form-type-checkbox.form-item-notifications-content-dis
 .filter-wrapper * {
   font-size: 14px;
 }
+.filter-wrapper .filter-help {
+  display: flex;
+  float: none;
+  flex-grow: 1;
+  justify-content: flex-end;
+  order: 1;
+}
+.filter-wrapper .filter-help a:after {
+  top: 2px;
+}
+.filter-wrapper select[disabled] {
+  padding: 0 4px;
+}
 .filter-wrapper ul {
+  width: 100%;
   margin: 0;
   padding: 0;
   list-style-type: none;

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-footer.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-footer.html.twig
@@ -18,7 +18,7 @@
       {% include '@common_design_subtheme/cd/cd-footer/cd-copyright.html.twig' %}
     {% endblock %}
 
-    {% if ('editor' in user.getroles) or ('webmaster' in user.getroles) or ('administrator' in user.getroles) or (user.id == '1')%}
+    {% if user.hasPermission('view reliefweb admin menu') %}
       {% include '@common_design_subtheme/user/admin-menu.html.twig' %}
     {% endif %}
 


### PR DESCRIPTION
- RW-123: Add permission to view the reliefweb admin menu
- RW-369: Add entity label validation for cloned entities
- RW-223: Adjust the announcement field descriptions and settings
- RW-224: Consolidate text format help, styling and add markdown reference to the help page
- RW-379: Update the source(s) moderation status to `active` when publishing a job/training
- RW-380: Update block post date when published
- RW-382: Update job/training status to `refused` when publishing if one of the source(s) is blocked.
- RW-383: Update job/training date when published for the first time