### PR TITLE
CD-356 Datetime field preprocess function in base theme, removed from sub theme

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12483,12 +12483,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "1d101edc8e39ad4cdc35e3d9a55eb7d5feb77850"
+                "reference": "8e7dd6d96fbfbe83b63ef4a65dbe12588534245a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/1d101edc8e39ad4cdc35e3d9a55eb7d5feb77850",
-                "reference": "1d101edc8e39ad4cdc35e3d9a55eb7d5feb77850",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/8e7dd6d96fbfbe83b63ef4a65dbe12588534245a",
+                "reference": "8e7dd6d96fbfbe83b63ef4a65dbe12588534245a",
                 "shasum": ""
             },
             "require": {
@@ -12503,7 +12503,7 @@
                 "source": "https://github.com/UN-OCHA/common_design/tree/cd-304-forms",
                 "issues": "https://github.com/UN-OCHA/common_design/issues"
             },
-            "time": "2022-02-01T20:19:59+00:00"
+            "time": "2022-02-24T11:23:19+00:00"
         },
         {
             "name": "webflo/drupal-finder",

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -283,19 +283,6 @@ function common_design_subtheme_preprocess_inline_entity_form_entity_table(array
 }
 
 /**
- * Implements hook_preprocess_datetime_wrapper().
- *
- * Ensure the title is not displayed when instructed to be hidden.
- *
- * @todo remove when https://humanitarian.atlassian.net/browse/CD-356 is merged.
- */
-function common_design_subtheme_preprocess_datetime_wrapper(&$variables) {
-  if (isset($variables['element']['#title_display']) && $variables['element']['#title_display'] === 'invisible') {
-    $variables['title_attributes']['class'][] = 'visually-hidden';
-  }
-}
-
-/**
  * Implements hook_reliefweb_form_mark_optional_alter().
  *
  * Mark form elements as optional.


### PR DESCRIPTION
As per https://github.com/UN-OCHA/rwint9-site/pull/254/commits/76580fd241033ca5d104e4880c869d5986a6fb65 and fix in base theme https://github.com/UN-OCHA/common_design/pull/303,
this remove the fix from the sub theme and updates the base theme to latest which includes fix