### PR TITLE
Various fixes - part 12

### DIFF
--- a/config/core.entity_form_display.guideline.field_guideline.default.yml
+++ b/config/core.entity_form_display.guideline.field_guideline.default.yml
@@ -12,8 +12,9 @@ dependencies:
     - guidelines.guideline_type.field_guideline
     - image.style.thumbnail
   module:
-    - guidelines
+    - allowed_formats
     - link
+    - reliefweb_guidelines
     - svg_image
     - text
 id: guideline.field_guideline.default
@@ -26,11 +27,14 @@ content:
     weight: 1
     region: content
     settings:
-      rows: 5
+      rows: 20
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '1'
   field_field:
-    type: guideline_field_target_widget
+    type: guideline_field_target_select_widget
     weight: 4
     region: content
     settings:

--- a/config/core.entity_form_display.node.announcement.default.yml
+++ b/config/core.entity_form_display.node.announcement.default.yml
@@ -52,13 +52,6 @@ content:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 4
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0
@@ -72,6 +65,7 @@ hidden:
   langcode: true
   path: true
   promote: true
+  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.node.blog_post.default.yml
+++ b/config/core.entity_form_display.node.blog_post.default.yml
@@ -21,7 +21,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 4
+    weight: 3
     region: content
     settings:
       rows: 20
@@ -34,7 +34,7 @@ content:
         hide_guidelines: '1'
   field_attached_images:
     type: media_library_widget
-    weight: 6
+    weight: 5
     region: content
     settings:
       media_types: {  }
@@ -49,7 +49,7 @@ content:
     third_party_settings: {  }
   field_image:
     type: media_library_widget
-    weight: 5
+    weight: 4
     region: content
     settings:
       media_types: {  }
@@ -66,16 +66,9 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 9
+    weight: 6
     region: content
     settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 7
-    region: content
-    settings:
-      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -89,6 +82,7 @@ hidden:
   created: true
   langcode: true
   promote: true
+  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.node.book.default.yml
+++ b/config/core.entity_form_display.node.book.default.yml
@@ -40,16 +40,9 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 3
     region: content
     settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 4
-    region: content
-    settings:
-      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -63,6 +56,7 @@ hidden:
   created: true
   langcode: true
   promote: true
+  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.node.job.default.yml
+++ b/config/core.entity_form_display.node.job.default.yml
@@ -170,16 +170,9 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
     weight: 11
     region: content
-    settings:
-      display_label: true
+    settings: {  }
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -194,6 +187,7 @@ hidden:
   field_job_id: true
   langcode: true
   promote: true
+  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.node.report.default.yml
+++ b/config/core.entity_form_display.node.report.default.yml
@@ -57,14 +57,14 @@ content:
         hide_guidelines: '1'
   field_bury:
     type: boolean_checkbox
-    weight: 22
+    weight: 21
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_content_format:
     type: reliefweb_entity_reference_select
-    weight: 15
+    weight: 14
     region: content
     settings:
       sort: label
@@ -72,7 +72,7 @@ content:
     third_party_settings: {  }
   field_country:
     type: reliefweb_entity_reference_select
-    weight: 11
+    weight: 10
     region: content
     settings:
       sort: label
@@ -108,7 +108,7 @@ content:
     third_party_settings: {  }
   field_disaster:
     type: reliefweb_disaster
-    weight: 13
+    weight: 12
     region: content
     settings:
       sort: id
@@ -146,7 +146,7 @@ content:
     third_party_settings: {  }
   field_disaster_type:
     type: reliefweb_entity_reference_select
-    weight: 14
+    weight: 13
     region: content
     settings:
       sort: label
@@ -154,7 +154,7 @@ content:
     third_party_settings: {  }
   field_embargo_date:
     type: datetime_datelist
-    weight: 6
+    weight: 5
     region: content
     settings:
       increment: 1
@@ -163,26 +163,26 @@ content:
     third_party_settings: {  }
   field_feature:
     type: options_buttons
-    weight: 21
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   field_file:
     type: reliefweb_file
-    weight: 101
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   field_headline:
     type: boolean_checkbox
-    weight: 17
+    weight: 16
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_headline_image:
     type: inline_entity_form_complex
-    weight: 19
+    weight: 18
     region: content
     settings:
       form_mode: media_library
@@ -199,7 +199,7 @@ content:
     third_party_settings: {  }
   field_headline_summary:
     type: string_textarea
-    weight: 20
+    weight: 19
     region: content
     settings:
       rows: 5
@@ -207,7 +207,7 @@ content:
     third_party_settings: {  }
   field_headline_title:
     type: string_textfield
-    weight: 18
+    weight: 17
     region: content
     settings:
       size: 60
@@ -215,7 +215,7 @@ content:
     third_party_settings: {  }
   field_image:
     type: inline_entity_form_complex
-    weight: 4
+    weight: 3
     region: content
     settings:
       form_mode: media_library
@@ -238,7 +238,7 @@ content:
     third_party_settings: {  }
   field_notify:
     type: string_textarea
-    weight: 23
+    weight: 22
     region: content
     settings:
       rows: 3
@@ -246,19 +246,19 @@ content:
     third_party_settings: {  }
   field_ocha_product:
     type: options_buttons
-    weight: 8
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_origin:
     type: options_buttons
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_origin_notes:
     type: string_textfield
-    weight: 10
+    weight: 9
     region: content
     settings:
       size: 60
@@ -266,13 +266,13 @@ content:
     third_party_settings: {  }
   field_original_publication_date:
     type: reliefweb_datetime
-    weight: 5
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_primary_country:
     type: reliefweb_entity_reference_select
-    weight: 12
+    weight: 11
     region: content
     settings:
       sort: label
@@ -308,7 +308,7 @@ content:
     third_party_settings: {  }
   field_source:
     type: reliefweb_source
-    weight: 7
+    weight: 6
     region: content
     settings:
       sort: label
@@ -352,7 +352,7 @@ content:
     third_party_settings: {  }
   field_theme:
     type: reliefweb_entity_reference_select
-    weight: 16
+    weight: 15
     region: content
     settings:
       sort: label
@@ -360,16 +360,9 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 25
+    weight: 23
     region: content
     settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 24
-    region: content
-    settings:
-      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -384,6 +377,7 @@ hidden:
   field_vulnerable_groups: true
   langcode: true
   promote: true
+  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.node.topic.default.yml
+++ b/config/core.entity_form_display.node.topic.default.yml
@@ -50,7 +50,7 @@ content:
     third_party_settings: {  }
   field_disaster_type:
     type: reliefweb_entity_reference_select
-    weight: 26
+    weight: 13
     region: content
     settings:
       sort: label
@@ -118,7 +118,7 @@ content:
     third_party_settings: {  }
   field_theme:
     type: reliefweb_entity_reference_select
-    weight: 27
+    weight: 14
     region: content
     settings:
       sort: label
@@ -132,16 +132,9 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
     weight: 12
     region: content
-    settings:
-      display_label: true
+    settings: {  }
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -155,6 +148,7 @@ hidden:
   created: true
   langcode: true
   promote: true
+  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.node.training.default.yml
+++ b/config/core.entity_form_display.node.training.default.yml
@@ -216,16 +216,9 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 19
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
     weight: 17
     region: content
-    settings:
-      display_label: true
+    settings: {  }
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -239,6 +232,7 @@ hidden:
   created: true
   langcode: true
   promote: true
+  status: true
   sticky: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.taxonomy_term.country.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.country.default.yml
@@ -97,19 +97,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
     weight: 9
     region: content
-    settings:
-      display_label: true
+    settings: {  }
     third_party_settings: {  }
 hidden:
   field_appeals_response_plans: true
   field_key_content: true
   field_useful_links: true
   langcode: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.disaster.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.disaster.default.yml
@@ -171,19 +171,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
     weight: 11
     region: content
-    settings:
-      display_label: true
+    settings: {  }
     third_party_settings: {  }
 hidden:
   field_appeals_response_plans: true
   field_key_content: true
   field_useful_links: true
   langcode: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.source.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.source.default.yml
@@ -210,14 +210,8 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 19
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
 hidden:
   field_job_import_feed_url: true
   field_user_posting_rights: true
   langcode: true
+  status: true

--- a/config/field.field.guideline.field_guideline.field_links.yml
+++ b/config/field.field.guideline.field_guideline.field_links.yml
@@ -19,5 +19,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   title: 1
-  link_type: 17
+  link_type: 16
 field_type: link

--- a/config/migrate_plus.migration.reliefweb_menu_link__header.yml
+++ b/config/migrate_plus.migration.reliefweb_menu_link__header.yml
@@ -1,14 +1,21 @@
-id: reliefweb_menu_link__help
-label: Migrate ReliefWeb help menu links.
-migration_group: reliefweb_base
+uuid: 1988fe46-36e3-4c14-88af-0cbb86413b56
+langcode: en
+status: true
 dependencies:
   enforced:
     module:
       - reliefweb_migrate
-audit: true
+_core:
+  default_config_hash: pi8p-ZwjH0M6dxQ1YNfCO4hlMVjQpYFgDDIFZWR2b88
+id: reliefweb_menu_link__header
+class: null
+field_plugin_method: null
+cck_plugin_method: null
 migration_tags:
-  - Drupal 7
+  - 'Drupal 7'
   - Content
+migration_group: reliefweb_base
+label: 'Migrate ReliefWeb header menu links.'
 source:
   plugin: embedded_data
   data_rows:
@@ -16,9 +23,16 @@ source:
       id: 13
       title: Help
       description: Help
-      link_uri: base:/help
+      link_uri: 'base:/help'
       external: 0
       weight: 0
+    -
+      id: 14
+      title: Guidelines
+      description: Guidelines
+      link_uri: 'internal:/guidelines'
+      external: 0
+      weight: -1
   ids:
     id:
       type: integer
@@ -28,9 +42,6 @@ source:
     enabled: 1
     expanded: 0
     parent: null
-destination:
-  plugin: entity:menu_link_content
-  no_stub: true
 process:
   id: id
   bundle: constants/bundle
@@ -43,6 +54,9 @@ process:
   expanded: constants/expanded
   enabled: constants/enabled
   parent: constants/parent
+destination:
+  plugin: 'entity:menu_link_content'
+  no_stub: true
 migration_dependencies:
   required:
-    - rw_menu_link__main
+    - rw_menu_link__footer

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -33,6 +33,7 @@ dependencies:
     - reliefweb_docstore
     - reliefweb_fields
     - reliefweb_form
+    - reliefweb_guidelines
     - reliefweb_homepage
     - reliefweb_moderation
     - reliefweb_revisions
@@ -48,6 +49,7 @@ is_admin: null
 permissions:
   - 'access content moderation backend'
   - 'access content moderation features'
+  - 'access editorial guidelines'
   - 'access media overview'
   - 'access reliefweb links field validation'
   - 'access reliefweb private files'

--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -26,6 +26,7 @@ dependencies:
     - filter
     - google_tag
     - guidelines
+    - reliefweb_guidelines
     - reliefweb_users
     - taxonomy
     - taxonomy_term_revision
@@ -34,6 +35,7 @@ label: Webmaster
 weight: 4
 is_admin: null
 permissions:
+  - 'access editorial guidelines'
   - 'add content to books'
   - 'add guideline entities'
   - 'administer google tag manager'

--- a/html/modules/custom/reliefweb_entities/src/Entity/BlogPost.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/BlogPost.php
@@ -112,6 +112,12 @@ class BlogPost extends Node implements BundleEntityInterface, EntityModeratedInt
    * {@inheritdoc}
    */
   public function preSave(EntityStorageInterface $storage) {
+    // @todo remove when removing `reliefweb_migrate`.
+    if (!empty($this->_is_migrating)) {
+      parent::preSave($storage);
+      return;
+    }
+
     // Set the creation date to the changed date when publishing the blog
     // post from an unpublished state.
     if (isset($this->original) &&

--- a/html/modules/custom/reliefweb_entities/src/Entity/Report.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Report.php
@@ -195,6 +195,12 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
    * {@inheritdoc}
    */
   public function preSave(EntityStorageInterface $storage) {
+    // @todo remove when removing `reliefweb_migrate`.
+    if (!empty($this->_is_migrating)) {
+      parent::preSave($storage);
+      return;
+    }
+
     parent::preSave($storage);
 
     // Change the publication date if bury is selected, to the original
@@ -248,6 +254,11 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
    */
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
+
+    // @todo remove when removing `reliefweb_migrate`.
+    if (!empty($this->_is_migrating)) {
+      return;
+    }
 
     $this->sendPublicationNotification();
   }

--- a/html/modules/custom/reliefweb_entities/src/OpportunityDocumentInterface.php
+++ b/html/modules/custom/reliefweb_entities/src/OpportunityDocumentInterface.php
@@ -7,4 +7,12 @@ namespace Drupal\reliefweb_entities;
  */
 interface OpportunityDocumentInterface {
 
+  /**
+   * Check if the opportunity has expired.
+   *
+   * @return bool
+   *   TRUE if the opportunity has expired.
+   */
+  public function hasExpired();
+
 }

--- a/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebEntityReferenceSelect.php
+++ b/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebEntityReferenceSelect.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsSelectWidget;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\OptGroup;
 use Drupal\reliefweb_utility\Helpers\LocalizationHelper;
 use Drupal\reliefweb_utility\Traits\EntityDatabaseInfoTrait;
 

--- a/html/modules/custom/reliefweb_form/reliefweb_form.module
+++ b/html/modules/custom/reliefweb_form/reliefweb_form.module
@@ -126,6 +126,10 @@ function reliefweb_form_date_element_process(array $element, FormStateInterface 
  *   The modified form element.
  */
 function reliefweb_form_mark_optional(array $element, FormStateInterface $form_state, array $form) {
+  if ($element === $form) {
+    return $element;
+  }
+
   $context = [
     'form_state' => $form_state,
     'form' => $form,

--- a/html/modules/custom/reliefweb_guidelines/reliefweb_guidelines.module
+++ b/html/modules/custom/reliefweb_guidelines/reliefweb_guidelines.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
 use Drupal\reliefweb_guidelines\Controller\GuidelineSinglePageController;
 use Drupal\reliefweb_guidelines\Entity\Guideline;
+use Drupal\reliefweb_guidelines\Form\GuidelineSortForm;
 use Drupal\reliefweb_guidelines\ModeratedGuidelineStorageSchema;
 use Drupal\reliefweb_revisions\Services\EntityHistory;
 
@@ -63,6 +64,9 @@ function reliefweb_guidelines_entity_base_field_info(EntityTypeInterface $entity
 function reliefweb_guidelines_entity_type_alter(array &$entity_types) {
   if (isset($entity_types['guideline'])) {
     $entity_types['guideline']->setHandlerClass('storage_schema', ModeratedGuidelineStorageSchema::class);
+
+    // Replace the sort form handler.
+    $entity_types['guideline']->setFormClass('sort', GuidelineSortForm::class);
   }
 }
 

--- a/html/modules/custom/reliefweb_guidelines/reliefweb_guidelines.permissions.yml
+++ b/html/modules/custom/reliefweb_guidelines/reliefweb_guidelines.permissions.yml
@@ -1,0 +1,3 @@
+access editorial guidelines:
+  title: 'Access editorial guidelines'
+  description: 'Allow users to access the editorial guidelines.'

--- a/html/modules/custom/reliefweb_guidelines/reliefweb_guidelines.routing.yml
+++ b/html/modules/custom/reliefweb_guidelines/reliefweb_guidelines.routing.yml
@@ -4,4 +4,4 @@ reliefweb_guidelines.guidelines:
     _title: 'Guidelines'
     _controller: '\Drupal\reliefweb_guidelines\Controller\GuidelineSinglePageController::getPageContent'
   requirements:
-    _permission: 'access content'
+    _permission: 'access editorial guidelines'

--- a/html/modules/custom/reliefweb_guidelines/src/Entity/Guideline.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Entity/Guideline.php
@@ -97,4 +97,15 @@ class Guideline extends GuidelineBase implements EntityModeratedInterface, Entit
     return 'published';
   }
 
+  /**
+   * Get the list, this guideline belongs to.
+   *
+   * @return \Drupal\reliefweb_guidelines\Entity\GuidelineList|null
+   *   Guideline List.
+   */
+  public function getGuidelineList() {
+    $parents = $this->getParents();
+    return !empty($parents) ? reset($parents) : NULL;
+  }
+
 }

--- a/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineSortForm.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineSortForm.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Drupal\reliefweb_guidelines\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form controller for Guideline edit forms.
+ *
+ * @ingroup guidelines
+ */
+class GuidelineSortForm extends ContentEntityForm {
+
+  /**
+   * The current user account.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $account;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    // Instantiates this form class.
+    $instance = parent::create($container);
+    $instance->account = $container->get('current_user');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'guideline_sort_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\guidelines\Entity\Guideline $guideline */
+    $guideline = $this->entity;
+
+    $form['#title'] = $this->t('Sort guidelines under %list', [
+      '%list' => $guideline->label(),
+    ]);
+
+    $children = $guideline->getChildren();
+    if (empty($children)) {
+      return;
+    }
+
+    // Build table.
+    $group_class = 'group-order-weight';
+    $form['items'] = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Guideline'),
+        $this->t('Weight'),
+      ],
+      '#empty' => $this->t('No items.'),
+      '#tableselect' => FALSE,
+      '#tabledrag' => [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => $group_class,
+          'hidden' => TRUE,
+        ],
+      ],
+    ];
+
+    // Build rows.
+    foreach ($children as $child) {
+      $id = $child->id();
+
+      $form['items'][$id]['#attributes']['class'][] = 'draggable';
+      $form['items'][$id]['#weight'] = $child->getWeight();
+
+      // Label.
+      $form['items'][$id]['label'] = [
+        '#markup' => $child->toLink($child->label(), 'edit-form')->toString(),
+      ];
+
+      // Weight.
+      $form['items'][$id]['weight'] = [
+        '#type' => 'weight',
+        '#title' => $this->t('Weight for @title', [
+          '@title' => $child->label(),
+        ]),
+        '#title_display' => 'invisible',
+        '#default_value' => $child->getWeight(),
+        '#attributes' => [
+          'class' => [
+            $group_class,
+          ],
+        ],
+      ];
+    }
+
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save'),
+      '#button_type' => 'primary',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function extractFormValues(FieldableEntityInterface $entity, array &$form, FormStateInterface $form_state) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function copyFormValuesToEntity(EntityInterface $entity, array $form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    /** @var \Drupal\guidelines\Entity\Guideline $guideline */
+    $guideline = $this->entity;
+
+    $children = $guideline->getChildren();
+    $new_weights = $form_state->getValue('items');
+
+    foreach ($children as $child) {
+      if (isset($new_weights[$child->id()])) {
+        if ($child->getWeight() !== $new_weights[$child->id()]['weight']) {
+          $child->setWeight($new_weights[$child->id()]['weight']);
+          $child->save();
+        }
+      }
+    }
+  }
+
+}

--- a/html/modules/custom/reliefweb_guidelines/src/Plugin/Field/FieldFormatter/GuidelineFieldTargetDefaultFormatter.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Plugin/Field/FieldFormatter/GuidelineFieldTargetDefaultFormatter.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Drupal\reliefweb_guidelines\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Implementation of the 'guideline_field_target_default_formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "guideline_field_target_default_formatter",
+ *   label = @Translation("Guideline field target default formatter"),
+ *   field_types = {
+ *     "guideline_field_target_type"
+ *   }
+ * )
+ */
+class GuidelineFieldTargetDefaultFormatter extends FormatterBase {
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a FormatterBase object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    $label,
+    $view_mode,
+    array $third_party_settings,
+    EntityFieldManagerInterface $entity_field_manager,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct(
+      $plugin_id,
+      $plugin_definition,
+      $field_definition,
+      $settings,
+      $label,
+      $view_mode,
+      $third_party_settings
+    );
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      // Implement default settings.
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    return [
+      // Implement settings form.
+    ] + parent::settingsForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $elements[$delta] = ['#markup' => $this->viewValue($item)];
+    }
+
+    return $elements;
+  }
+
+  /**
+   * Generate the output appropriate for one field item.
+   *
+   * @param \Drupal\Core\Field\FieldItemInterface $item
+   *   One field item.
+   *
+   * @return string
+   *   The textual output generated.
+   */
+  protected function viewValue(FieldItemInterface $item) {
+    if (!$item->isEmpty()) {
+      [$entity_type_id, $bundle, $field_name] = explode('.', $item->value);
+
+      $entity_type = $this->entityTypeManager
+        ->getDefinition($entity_type_id);
+
+      $bundle_info = $this->entityTypeBundleInfo
+        ->getBundleInfo($entity_type_id);
+
+      $field_definitions = $this->entityFieldManager
+        ->getFieldDefinitions($entity_type_id, $bundle);
+
+      $field_label = $field_name;
+      if (isset($field_definitions[$field_name])) {
+        $field_label = $field_definitions[$field_name]->getLabel();
+      }
+
+      return implode(' > ', [
+        isset($entity_type) ? $entity_type->getLabel() : $entity_type_id,
+        $bundle_info[$bundle]['label'] ?? $bundle,
+        $field_label,
+      ]);
+    }
+    return '';
+  }
+
+}

--- a/html/modules/custom/reliefweb_guidelines/src/Plugin/Field/FieldWidget/GuidelineFieldTargetSelectWidget.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Plugin/Field/FieldWidget/GuidelineFieldTargetSelectWidget.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\reliefweb_guidelines\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsSelectWidget;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\OptGroup;
+use Drupal\Core\Entity\ContentEntityTypeInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+
+/**
+ * Plugin implementation of the 'guideline_field_target_select_widget' widget.
+ *
+ * @FieldWidget(
+ *   id = "guideline_field_target_select_widget",
+ *   module = "reliefweb_guidelines",
+ *   label = @Translation("Guideline field target select widget"),
+ *   multiple_values = true,
+ *   field_types = {
+ *     "guideline_field_target_type"
+ *   }
+ * )
+ */
+class GuidelineFieldTargetSelectWidget extends OptionsSelectWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'enabled_entities' => [],
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements = [];
+
+    /** @var \Drupal\Core\Entity\EntityFieldManager $entity_field_manager */
+    $entity_type_manager = \Drupal::service('entity_type.manager');
+
+    /** @var \Drupal\Core\Entity\EntityTypeBundleInfo $entity_type_bundle_info */
+    $entity_type_bundle_info = \Drupal::service('entity_type.bundle.info');
+
+    $entity_types = $entity_type_manager->getDefinitions();
+    $bundle_info = $entity_type_bundle_info->getAllBundleInfo();
+
+    $options = [];
+    foreach ($entity_types as $entity_type_id => $entity_type) {
+      if ($entity_type instanceof ContentEntityTypeInterface && isset($bundle_info[$entity_type_id])) {
+        foreach ($bundle_info[$entity_type_id] as $bundle => $info) {
+          $options[$entity_type_id][$entity_type_id . '.' . $bundle] = $info['label'];
+        }
+      }
+    }
+
+    $elements['enabled_entities'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Enabled entities'),
+      '#default_value' => $this->getSetting('enabled_entities'),
+      '#required' => FALSE,
+      '#multiple' => TRUE,
+      '#options' => $options,
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $summary[] = $this->t('Enabled entities: @enabled_entities', [
+      '@enabled_entities' => implode(', ', array_filter($this->getSetting('enabled_entities'))),
+    ]);
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getOptions(FieldableEntityInterface $entity) {
+    if (!isset($this->options)) {
+      $options = ['_none' => $this->getEmptyLabel()];
+
+      /** @var \Drupal\Core\Entity\EntityFieldManager $entity_field_manager */
+      $entity_field_manager = \Drupal::service('entity_field.manager');
+
+      /** @var \Drupal\Core\Entity\EntityTypeBundleInfo $entity_type_bundle_info */
+      $entity_type_bundle_info = \Drupal::service('entity_type.bundle.info');
+
+      $bundle_info = $entity_type_bundle_info->getAllBundleInfo();
+
+      $enabled_entities = array_filter($this->getSetting('enabled_entities'));
+      foreach ($enabled_entities as $enabled_entity) {
+        [$entity_type_id, $bundle] = explode('.', $enabled_entity);
+        $bundle_label = $bundle_info[$entity_type_id][$bundle]['label'] ?? $bundle;
+
+        // Retrieve the list of fields displayed in the default entity form.
+        // Only those fields can have attached guidelines.
+        $form_fields = \Drupal::entityTypeManager()
+          ->getStorage('entity_form_display')
+          ?->load($entity_type_id . '.' . $bundle . '.default')
+          ?->getComponents();
+
+        $field_definitions = $entity_field_manager->getFieldDefinitions($entity_type_id, $bundle);
+        foreach ($field_definitions as $field_name => $field_definition) {
+          // Skip if the field is not supposed to be editable.
+          if (!isset($form_fields[$field_name])) {
+            continue;
+          }
+
+          // Skip computed, internal and read-only fields.
+          if ($field_definition->isComputed() || $field_definition->isInternal() || $field_definition->isReadOnly()) {
+            continue;
+          }
+
+          $key = $entity_type_id . '.' . $bundle . '.' . $field_name;
+          $options[$key] = $bundle_label . ' > ' . $field_definition->getLabel() . ' (' . $field_name . ')';
+        }
+      }
+
+      // Options might be nested ("optgroups"). If the widget does not support
+      // nested options, flatten the list.
+      if (!$this->supportsGroups()) {
+        $options = OptGroup::flattenOptions($options);
+      }
+
+      $this->options = $options;
+    }
+
+    return $this->options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEmptyLabel() {
+    return !$this->required ? $this->t('- None -') : $this->t('- Select a value -');
+  }
+
+}

--- a/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineFormAlter.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineFormAlter.php
@@ -31,9 +31,8 @@ class GuidelineFormAlter extends EntityFormAlterServiceBase {
     $form['field_images']['widget']['#theme_wrappers'] = ['fieldset'];
 
     // Transform the field selector into a select with autocomplete.
-    $form['field_field']['widget']['#type'] = 'select';
     $form['field_field']['widget']['#attributes']['data-with-autocomplete'] = '';
-    $form['field_field']['widget']['#description'] = $this->t('Select the node or term field this guideline is for.');
+    $form['field_field']['widget']['#description'] = $this->t('Select the node or term field(s) this guideline is for.');
 
     // Url to create a new guideline list.
     $new_list_url = Url::fromRoute('entity.guideline.add_form', [

--- a/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineListModeration.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineListModeration.php
@@ -3,7 +3,9 @@
 namespace Drupal\reliefweb_guidelines\Services;
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
 
@@ -77,6 +79,20 @@ class GuidelineListModeration extends ModerationServiceBase {
 
       // Entity data cell.
       $data = [];
+
+      // Add link to the sort form.
+      $children = $entity->getChildren();
+      if (!empty($children)) {
+        $label = $this->formatPlural(count($children), '1 child guideline', '@count child guidelines');
+        // Sigh... we cannot use `$entity->toLink($label, 'sort-form')` because
+        // that would make Drupal look for a `entity.guideline.sort_form` route
+        // which doesn't exist because the route for the sort form is
+        // defined as `entity.{entity_type_id}.sort`...
+        $url = Url::fromRoute('entity.' . $entity->getEntityTypeId() . '.sort', [
+          'guideline' => $entity->id(),
+        ]);
+        $data['info']['sort'] = Link::fromTextAndUrl($label, $url);
+      }
 
       // Title.
       $data['title'] = $entity->toLink()->toString();

--- a/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_menu_link__header.yml
+++ b/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_menu_link__header.yml
@@ -1,21 +1,14 @@
-uuid: d1a1a842-2f6d-48f6-b49f-9be1ecf61061
-langcode: en
-status: true
+id: reliefweb_menu_link__header
+label: Migrate ReliefWeb header menu links.
+migration_group: reliefweb_base
 dependencies:
   enforced:
     module:
       - reliefweb_migrate
-_core:
-  default_config_hash: oMGwjRYiH0smHUBnxss8xQ1S_QnyNsZRCpVunpTxj8M
-id: reliefweb_menu_link__help
-class: null
-field_plugin_method: null
-cck_plugin_method: null
+audit: true
 migration_tags:
-  - 'Drupal 7'
+  - Drupal 7
   - Content
-migration_group: reliefweb_base
-label: 'Migrate ReliefWeb help menu links.'
 source:
   plugin: embedded_data
   data_rows:
@@ -23,9 +16,16 @@ source:
       id: 13
       title: Help
       description: Help
-      link_uri: 'base:/help'
+      link_uri: base:/help
       external: 0
       weight: 0
+    -
+      id: 14
+      title: Guidelines
+      description: Guidelines
+      link_uri: internal:/guidelines
+      external: 0
+      weight: -1
   ids:
     id:
       type: integer
@@ -35,6 +35,9 @@ source:
     enabled: 1
     expanded: 0
     parent: null
+destination:
+  plugin: entity:menu_link_content
+  no_stub: true
 process:
   id: id
   bundle: constants/bundle
@@ -47,9 +50,6 @@ process:
   expanded: constants/expanded
   enabled: constants/enabled
   parent: constants/parent
-destination:
-  plugin: 'entity:menu_link_content'
-  no_stub: true
 migration_dependencies:
   required:
-    - rw_menu_link__main
+    - rw_menu_link__footer

--- a/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
@@ -7,7 +7,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
-use Drupal\reliefweb_utility\Helpers\DateHelper;
 use Drupal\reliefweb_utility\Helpers\UserHelper;
 
 /**
@@ -162,26 +161,6 @@ class JobModeration extends ModerationServiceBase {
       'published',
       'expired',
     ]);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function entityPresave(EntityModeratedInterface $entity) {
-    // Set the status of the entity as expired if past the deadline.
-    $status = $entity->getModerationStatus();
-
-    if ($status === 'published') {
-      $time = gmmktime(0, 0, 0);
-      $date = DateHelper::getDateTimeStamp($entity->field_job_closing_date->value);
-
-      // Set status to expired if the current date is past the deadline.
-      if (!empty($date) && $date < $time) {
-        $entity->setModerationStatus('expired');
-      }
-    }
-
-    parent::entityPresave($entity);
   }
 
   /**

--- a/html/modules/custom/reliefweb_moderation/src/Services/TrainingModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/TrainingModeration.php
@@ -7,7 +7,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
-use Drupal\reliefweb_utility\Helpers\DateHelper;
 use Drupal\reliefweb_utility\Helpers\UserHelper;
 
 /**
@@ -187,26 +186,6 @@ class TrainingModeration extends ModerationServiceBase {
       'on-hold',
       'published',
     ]);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function entityPresave(EntityModeratedInterface $entity) {
-    // Set the status of the entity as expired if past the deadline.
-    $status = $entity->getModerationStatus();
-
-    if ($status === 'published') {
-      $time = gmmktime(0, 0, 0);
-      $date = DateHelper::getDateTimeStamp($entity->field_registration_deadline->value);
-
-      // Set status to expired if the current date is past the deadline.
-      if (!empty($date) && $date < $time) {
-        $entity->setModerationStatus('expired');
-      }
-    }
-
-    parent::entityPresave($entity);
   }
 
   /**

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -181,10 +181,12 @@ function common_design_subtheme_theme(array $existing, $type, $theme, $path) {
 }
 
 /**
- * Implements hook_form_node_HOOK_alter().
+ * Implements hook_form_guideline_HOOK_alter().
  */
-function common_design_subtheme_form_guideline_form_alter(&$form, FormStateInterface $form_state) {
-  common_design_add_entity_edit_form_theme($form, $form_state);
+function common_design_subtheme_form_guideline_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (!empty($form_state->get('form_display'))) {
+    common_design_add_entity_edit_form_theme($form, $form_state);
+  }
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form--widget.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form--widget.css
@@ -264,3 +264,39 @@ form .ief-form .fieldset-wrapper {
 .rw-file-widget .warning.tabledrag-changed {
   color: red;
 }
+
+/* Table drag. */
+.tabledrag-toggle-weight-wrapper {
+  margin-bottom: 0;
+}
+.messages.tabledrag-changed-warning {
+  color: red;
+}
+.draggable a.tabledrag-handle {
+  display: inline-flex;
+  float: none;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 32px;
+  margin-left: 0;
+}
+.draggable a.tabledrag-handle .handle {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+.draggable .warning.tabledrag-changed {
+  margin-left: 4px;
+  color: red;
+}
+
+.cd-flow > .tabledrag-toggle-weight-wrapper {
+  margin-top: var(--cd-flow-space, 1rem);
+}
+.cd-flow > .tabledrag-toggle-weight-wrapper ~ table,
+.cd-flow > .tabledrag-toggle-weight-wrapper ~ .tableresponsive-toggle-columns,
+.cd-flow > .tabledrag-toggle-weight-wrapper ~ .tabledrag-changed-warning {
+  margin-top: 0;
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-page-title/rw-page-title.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-page-title/rw-page-title.css
@@ -9,3 +9,8 @@
 .rw-404 .rw-page-title {
   margin-bottom: 24px;
 }
+
+/* Avoid having a h1.rw-page-title attached to the page content. */
+.rw-page-title + .rw-page-content {
+  margin-top: 24px;
+}

--- a/html/themes/custom/common_design_subtheme/templates/navigation/menu--help.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/navigation/menu--help.html.twig
@@ -1,0 +1,106 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see https://twig.symfony.com/doc/1.x/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+
+    {%
+      set menu_classes = [
+        'menu',
+        menu_level > 0 ? 'cd-global-header__dropdown',
+        menu_level > 0 ? 'cd-user-menu__dropdown'
+      ]
+    %}
+
+    <ul{{ attributes.addClass(menu_classes) }}>
+
+    {% for item in items %}
+      {%
+        set classes = [
+          'menu-item',
+          item.is_expanded ? 'menu-item--expanded',
+          item.is_collapsed ? 'menu-item--collapsed',
+          item.in_active_trail ? 'menu-item--active-trail',
+        ]
+      %}
+
+      {% set title = item.title %}
+      {% set id = ('cd-help-menu-item-' ~ menu_level ~ '-' ~ loop.index)|clean_id %}
+
+      <li{{ item.attributes.addClass(classes) }}>
+
+        {#
+          Progressive enhancement: make sure there is always a menu entry.
+          If the menu item has children and javascript is enabled then this will
+          be replaced with a button to show the child menu.
+        #}
+        {% spaceless %}
+        <a href="{{ item.url }}" id="{{ id }}">
+          {# Add the user icon for the first menu item of the root element. #}
+          {% if menu_level == 0 and item.url|render == '/help' %}
+            <svg class="cd-icon cd-icon--help" aria-hidden="true" focusable="false" width="16" height="16">
+              <use xlink:href="#cd-icon--help"></use>
+            </svg>
+          {% endif %}
+          <span>{{ title }}</span>
+        </a>
+        {% endspaceless %}
+
+        {# If the menu item has children then we mark it as toggable and we'll
+           let the dropdown javascript handle the rest. #}
+        {% if item.is_expanded and item.below %}
+
+          {%
+            set attributes =  create_attribute({
+              'data-cd-toggable': title,
+              'data-cd-icon': 'arrow-down',
+              'data-cd-component': 'cd-help-menu',
+              'data-cd-replace': id,
+              'id': ('cd-help-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id,
+            })
+          %}
+
+          {# Add the help icon for the first menu item of the root element. #}
+          {% if menu_level == 0 and loop.index == 1 %}
+          {%
+            do attributes
+              .setAttribute('data-cd-logo', 'help')
+              .setAttribute('data-cd-logo-only', '')
+          %}
+          {% endif %}
+
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+
+        {% endif %}
+
+      </li>
+
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--field-guideline--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--field-guideline--full.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file guideline.html.twig
+ * Default theme implementation to present Guideline data.
+ *
+ * This template is used when viewing Guideline pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_guideline()
+ *
+ * @ingroup themeable
+ */
+#}
+<div class="rw-page-content">
+{% if content %}
+  {{- content -}}
+{% endif %}
+</div>


### PR DESCRIPTION
- RW-289: Fix and improve target field widget
- RW-406: Add link to guidelines in top header
- RW-407: Add guideline list and target field filters to guidelines moderation backend
- RW-408: Prevent running some part of the presave code for bundle entities when migrating
- RW-409: Do mark form title as optional
- RW-410: Improve guideline sort form
- RW-412: Improve guideline moderation backend
- RW-413: Fix spacing between title and content on guideline pages
