### PR TITLE
RW-438 update base theme and SVG sprite icon partial

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "reliefweb/simple-datepicker": "^v1.3.1",
         "symfony/flex": "^2.0",
         "symfony/uid": "^6.0",
-        "unocha/common_design": "^6.0.0",
+        "unocha/common_design": "^7.0.0",
         "webflo/drupal-finder": "^1.2.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b33c52f95904d69a6d064a667c727d0c",
+    "content-hash": "882169504e343e1546a04196cb4ab975",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -13459,16 +13459,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v6.0.0",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "6d8222a5d87bfb6effbd22f41676512a021a6c53"
+                "reference": "c52fd2c5302fc0a832272a70e9062372ce8946a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/6d8222a5d87bfb6effbd22f41676512a021a6c53",
-                "reference": "6d8222a5d87bfb6effbd22f41676512a021a6c53",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/c52fd2c5302fc0a832272a70e9062372ce8946a2",
+                "reference": "c52fd2c5302fc0a832272a70e9062372ce8946a2",
                 "shasum": ""
             },
             "require": {
@@ -13482,9 +13482,9 @@
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v6.0.0"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v7.0.0"
             },
-            "time": "2022-03-09T10:50:04+00:00"
+            "time": "2022-04-21T13:23:47+00:00"
         },
         {
             "name": "webflo/drupal-finder",
@@ -15153,5 +15153,5 @@
         "php": ">=8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -426,19 +426,3 @@ function common_design_subtheme_add_optional_mark_to_title($title) {
     '@title' => $title,
   ]);
 }
-
-/**
- * Implements hook_preprocess_html().
- */
-function common_design_subtheme_preprocess_html(&$vars) {
-  // SVG sprite
-  // Get the contents of the SVG sprite.
-  $icons = file_get_contents(\Drupal::service('extension.list.theme')->getPath('common_design_subtheme') . '/img/icons/cd-icons-sprite.svg');
-
-  // Add a new render array to page_bottom so the icons
-  // get added to the page.
-  $vars['page_bottom']['icons'] = [
-    '#type' => 'inline_template',
-    '#template' => '<span class="hidden">' . $icons . '</span>',
-  ];
-}

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-icons/cd-icons.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-icons/cd-icons.html.twig
@@ -1,0 +1,11 @@
+{#
+
+/**
+ * @file
+ * Template to include SVG sprites used for the icons across the site.
+ */
+
+#}
+<div class="hidden">
+  {% include '@common_design_subtheme/../img/icons/cd-icons-sprite.svg' %}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/layout/html.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/html.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Theme override for the basic structure of a single Drupal page.
+ *
+ * Variables:
+ * - logged_in: A flag indicating if user is logged in.
+ * - root_path: The root path of the current page (e.g., node, admin, user).
+ * - node_type: The content type for the current node, if the page is a node.
+ * - head_title: List of text elements that make up the head_title variable.
+ *   May contain one or more of the following:
+ *   - title: The title of the page.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site.
+ * - page_top: Initial rendered markup. This should be printed before 'page'.
+ * - page: The rendered page markup.
+ * - page_bottom: Closing rendered markup. This variable should be printed after
+ *   'page'.
+ * - db_offline: A flag indicating if the database is offline.
+ * - placeholder_token: The token for generating head, css, js and js-bottom
+ *   placeholders.
+ *
+ * @see template_preprocess_html()
+ */
+#}
+{%
+  set body_classes = [
+    logged_in ? 'user-logged-in',
+    not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+    node_type ? 'page-node-type-' ~ node_type|clean_class,
+    db_offline ? 'db-offline',
+  ]
+%}
+<!DOCTYPE html>
+<html{{ html_attributes.addClass('no-js') }}>
+  <head>
+    <head-placeholder token="{{ placeholder_token }}">
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token }}">
+    <js-placeholder token="{{ placeholder_token }}">
+  </head>
+  <body{{ attributes.addClass(body_classes) }}>
+    {#
+      Keyboard navigation/accessibility link to main content section in
+      page.html.twig.
+    #}
+    <a href="#main-content" class="visually-hidden focusable skip-link">
+      {{ 'Skip to main content'|t }}
+    </a>
+    {{ page_top }}
+    {{ page }}
+    {{ page_bottom }}
+
+    {% block icons %}
+    {% include '@common_design_subtheme/cd/cd-icons/cd-icons.html.twig' %}
+    {% endblock %}
+
+    <js-bottom-placeholder token="{{ placeholder_token }}">
+  </body>
+</html>

--- a/html/themes/custom/common_design_subtheme/templates/layout/html.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/html.html.twig
@@ -1,60 +1,7 @@
-{#
-/**
- * @file
- * Theme override for the basic structure of a single Drupal page.
- *
- * Variables:
- * - logged_in: A flag indicating if user is logged in.
- * - root_path: The root path of the current page (e.g., node, admin, user).
- * - node_type: The content type for the current node, if the page is a node.
- * - head_title: List of text elements that make up the head_title variable.
- *   May contain one or more of the following:
- *   - title: The title of the page.
- *   - name: The name of the site.
- *   - slogan: The slogan of the site.
- * - page_top: Initial rendered markup. This should be printed before 'page'.
- * - page: The rendered page markup.
- * - page_bottom: Closing rendered markup. This variable should be printed after
- *   'page'.
- * - db_offline: A flag indicating if the database is offline.
- * - placeholder_token: The token for generating head, css, js and js-bottom
- *   placeholders.
- *
- * @see template_preprocess_html()
- */
-#}
-{%
-  set body_classes = [
-    logged_in ? 'user-logged-in',
-    not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
-    node_type ? 'page-node-type-' ~ node_type|clean_class,
-    db_offline ? 'db-offline',
-  ]
-%}
-<!DOCTYPE html>
-<html{{ html_attributes.addClass('no-js') }}>
-  <head>
-    <head-placeholder token="{{ placeholder_token }}">
-    <title>{{ head_title|safe_join(' | ') }}</title>
-    <css-placeholder token="{{ placeholder_token }}">
-    <js-placeholder token="{{ placeholder_token }}">
-  </head>
-  <body{{ attributes.addClass(body_classes) }}>
-    {#
-      Keyboard navigation/accessibility link to main content section in
-      page.html.twig.
-    #}
-    <a href="#main-content" class="visually-hidden focusable skip-link">
-      {{ 'Skip to main content'|t }}
-    </a>
-    {{ page_top }}
-    {{ page }}
-    {{ page_bottom }}
+{% embed '@common_design/layout/html.html.twig' %}
 
-    {% block icons %}
+  {% block icons %}
     {% include '@common_design_subtheme/cd/cd-icons/cd-icons.html.twig' %}
-    {% endblock %}
+  {% endblock %}
 
-    <js-bottom-placeholder token="{{ placeholder_token }}">
-  </body>
-</html>
+{% endembed %}


### PR DESCRIPTION
- Upgrade base theme to v7 https://github.com/UN-OCHA/common_design/releases/tag/v7.0.0
- Removes the SVG icon sprite from being attached in the sub theme preprocess, and instead uses a template override
There should be visual changes, and the social media icons should continue to display in the footer.