### PR TITLE
[RW-467] Only add optional mark before rendering form elements

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -5,13 +5,12 @@
  * Preprocess functions for the Common Design subtheme.
  */
 
-use Drupal\Component\Render\FormattableMarkup;
-use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\common_design_subtheme\FormElementOptional;
 use Drupal\media\MediaInterface;
 
 /**
@@ -293,138 +292,7 @@ function common_design_subtheme_preprocess_inline_entity_form_entity_table(array
  * we use '#not_required' to flag optional elements.
  */
 function common_design_subtheme_reliefweb_form_mark_optional_alter(array &$element, array &$context) {
-  $types_to_skip = [
-    'button',
-    'hidden',
-    'link',
-    'submit',
-    'text_format',
-    'token',
-    'vertical_tabs',
-    'weight',
-  ];
-
-  $container_types = [
-    'container',
-    'details',
-    'fieldset',
-    'checkboxes',
-    'radios',
-  ];
-
-  // Skip if the field is not of a type we want to mark as optional.
-  if (!isset($element['#type']) || in_array($element['#type'], $types_to_skip)) {
-    return;
-  }
-
-  // Skip if the field is required.
-  if (!empty($element['#required']) || !empty($elment['widget']['#required'])) {
-    return;
-  }
-
-  // Skipped if already processed.
-  if (isset($element['#not_required'])) {
-    return;
-  }
-
-  // Process container elements.
-  if (in_array($element['#type'], $container_types)) {
-    common_design_subtheme_mark_children_as_optional($element);
-  }
-  // Process other elements.
-  else {
-    // Flag the element as optional.
-    $element['#not_required'] = TRUE;
-
-    $form = $context['form'];
-    $type = $element['#type'];
-
-    // Special handling of checkbox and radio elements. We need to check if
-    // they are part of a group of checkboxes or radios in which case we'll
-    // mark the grouping element as optional when processed by
-    // common_design_subtheme_mark_children_as_optional().
-    if ($type === 'checkbox' || $type === 'radio') {
-      if (isset($element['#array_parents'])) {
-        $parents = array_slice($element['#array_parents'], 0, -1);
-
-        while (!empty($parents)) {
-          $parent = NestedArray::getValue($form, $parents);
-
-          switch ($parent['#type'] ?? NULL) {
-            case 'checkboxes':
-            case 'radios':
-              return;
-          }
-
-          array_pop($parents);
-        }
-      }
-    }
-
-    if (isset($element['#title'])) {
-      $element['#title'] = common_design_subtheme_add_optional_mark_to_title($element['#title']);
-    }
-  }
-}
-
-/**
- * Mark an element and its children as optional.
- *
- * @param mixed $element
- *   Form element.
- */
-function common_design_subtheme_mark_children_as_optional(&$element) {
-  $types_to_skip = [
-    // Grouped checkboxes and radios.
-    'checkbox',
-    'radio',
-    // Same list as common_design_subtheme_reliefweb_form_mark_optional_alter().
-    'button',
-    'hidden',
-    'link',
-    'submit',
-    'text_format',
-    'token',
-    'vertical_tabs',
-    'weight',
-  ];
-
-  // Skip if the element is invalid or already processed or required.
-  if (!is_array($element) || isset($element['#not_required']) || !empty($element['#required'])) {
-    return;
-  }
-
-  // Skip if the field is not of a type we want to mark as optional.
-  if (isset($element['#type']) && in_array($element['#type'], $types_to_skip)) {
-    return;
-  }
-
-  $element['#not_required'] = TRUE;
-  if (!empty($element['#title'])) {
-    $element['#title'] = common_design_subtheme_add_optional_mark_to_title($element['#title']);
-  }
-  if (!empty($element['#field_title'])) {
-    $element['#field_title'] = common_design_subtheme_add_optional_mark_to_title($element['#field_title']);
-  }
-
-  foreach (Element::children($element) as $key) {
-    common_design_subtheme_mark_children_as_optional($element[$key]);
-  }
-}
-
-/**
- * Add the optional mark to a form element title.
- *
- * @param string|\Drupal\Component\Render\MarkupInterface $title
- *   Form element title.
- *
- * @return \Drupal\Component\Render\MarkupInterface
- *   Title with "optional" appended.
- */
-function common_design_subtheme_add_optional_mark_to_title($title) {
-  return new FormattableMarkup('@title <span class="form-optional"> - optional</span>', [
-    '@title' => $title,
-  ]);
+  FormElementOptional::markAsOptional($element, $context['form']);
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/src/FormElementOptional.php
+++ b/html/themes/custom/common_design_subtheme/src/FormElementOptional.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Drupal\common_design_subtheme;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Trusted callback to add the optional mark next to a form element title.
+ */
+class FormElementOptional implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['afterBuild', 'preRenderTitle', 'preRenderFieldTitle'];
+  }
+
+  /**
+   * After build callback: add a pre render callback to add the optional marl.
+   *
+   * @param array $element
+   *   Form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state interface.
+   *
+   * @return array
+   *   Form element.
+   */
+  public static function afterBuild(array $element, FormStateInterface $form_state) {
+    if (!empty($element['#title'])) {
+      $element['#pre_render'][] = [static::class, 'preRenderTitle'];
+    }
+    if (!empty($element['#field_title'])) {
+      $element['#pre_render'][] = [static::class, 'preRenderFieldTitle'];
+    }
+    return $element;
+  }
+
+  /**
+   * Pre-render callback: add the optional mark to the form element title.
+   *
+   * @param array $element
+   *   Form element.
+   *
+   * @return array
+   *   Form element.
+   */
+  public static function preRenderTitle(array $element) {
+    if (!empty($element['#not_required']) && !empty($element['#title'])) {
+      $element['#title'] = static::addOptionalMark($element['#title']);
+    }
+    return $element;
+  }
+
+  /**
+   * Pre-render callback: add the optional mark to the form element field title.
+   *
+   * @param array $element
+   *   Form element.
+   *
+   * @return array
+   *   Form element.
+   */
+  public static function preRenderFieldTitle(array $element) {
+    if (!empty($element['#not_required']) && !empty($element['#field_title'])) {
+      $element['#field_title'] = static::addOptionalMark($element['#field_title']);
+    }
+    return $element;
+  }
+
+  /**
+   * Add the optional mark to a form element title.
+   *
+   * @param string|\Drupal\Component\Render\MarkupInterface $title
+   *   Form element title.
+   *
+   * @return \Drupal\Component\Render\MarkupInterface
+   *   Title with "optional" appended.
+   */
+  public static function addOptionalMark($title) {
+    return new FormattableMarkup('@title <span class="form-optional"> - optional</span>', [
+      '@title' => $title,
+    ]);
+  }
+
+  /**
+   * Mark an element and its children as optional.
+   *
+   * @param mixed $element
+   *   Form element.
+   */
+  public static function markChildrenAsOptional(&$element) {
+    $types_to_skip = [
+      // Grouped checkboxes and radios.
+      'checkbox',
+      'radio',
+      // Same list as ::markAsOptional().
+      'button',
+      'hidden',
+      'link',
+      'submit',
+      'text_format',
+      'token',
+      'vertical_tabs',
+      'weight',
+    ];
+
+    // Skip if the element is invalid or already processed or required.
+    if (!is_array($element) || isset($element['#not_required']) || !empty($element['#required'])) {
+      return;
+    }
+
+    // Skip if the field is not of a type we want to mark as optional.
+    if (isset($element['#type']) && in_array($element['#type'], $types_to_skip)) {
+      return;
+    }
+
+    $element['#not_required'] = TRUE;
+    if (!empty($element['#title']) || !empty($element['#field_title'])) {
+      $element['#after_build'][] = [static::class, 'afterBuild'];
+    }
+
+    foreach (Element::children($element) as $key) {
+      static::markChildrenAsOptional($element[$key]);
+    }
+  }
+
+  /**
+   * Implements hook_reliefweb_form_mark_optional_alter().
+   *
+   * Mark form elements as optional.
+   *
+   * Note: we cannot use '#optional' as it has a different meaning in Drupal 9
+   * so we use '#not_required' to flag optional elements.
+   *
+   * @param array $element
+   *   Form element.
+   * @param array $form
+   *   Full form.
+   */
+  public static function markAsOptional(array &$element, array $form) {
+    $types_to_skip = [
+      'button',
+      'hidden',
+      'link',
+      'submit',
+      'text_format',
+      'token',
+      'vertical_tabs',
+      'weight',
+    ];
+
+    $container_types = [
+      'container',
+      'details',
+      'fieldset',
+      'checkboxes',
+      'radios',
+    ];
+
+    // Skip if the field is not of a type we want to mark as optional.
+    if (!isset($element['#type']) || in_array($element['#type'], $types_to_skip)) {
+      return;
+    }
+
+    // Skip if the field is required.
+    if (!empty($element['#required']) || !empty($elment['widget']['#required'])) {
+      return;
+    }
+
+    // Skipped if already processed.
+    if (isset($element['#not_required'])) {
+      return;
+    }
+
+    // Process container elements.
+    if (in_array($element['#type'], $container_types)) {
+      static::markChildrenAsOptional($element);
+    }
+    // Process other elements.
+    else {
+      // Flag the element as optional.
+      $element['#not_required'] = TRUE;
+      $type = $element['#type'];
+
+      // Special handling of checkbox and radio elements. We need to check if
+      // they are part of a group of checkboxes or radios in which case we'll
+      // mark the grouping element as optional when processed by
+      // ::markChildrenAsOptional().
+      if ($type === 'checkbox' || $type === 'radio') {
+        if (isset($element['#array_parents'])) {
+          $parents = array_slice($element['#array_parents'], 0, -1);
+
+          while (!empty($parents)) {
+            $parent = NestedArray::getValue($form, $parents);
+
+            switch ($parent['#type'] ?? NULL) {
+              case 'checkboxes':
+              case 'radios':
+                return;
+            }
+
+            array_pop($parents);
+          }
+        }
+      }
+
+      if (isset($element['#title'])) {
+        $element['#after_build'][] = [static::class, 'afterBuild'];
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Ticket: RW-467

This PR delays the addition of the "optional" mark so that other places using the form element title (ex: to set an error message) see the original one.

Due to the way drupal builds the form elements we need to pass around the optional information before we can finally alter the title:

1. Process function to add an `after build` callback to the relevant form elements
2. After build callback to add the `pre render` callbacks to add the optional mark
3. Pre render callback to add the "optional" mark

## Testing

Create a training, for example, and leave the "registration deadline" empty. Without this PR, the error message at the top should show "Registration deadline - optional". With the PR, the message should show "Registration deadline" only.

Other optional fields like "Theme" should still display the "- optional" text next to the title.