### PR TITLE
Various fixes - part 21

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b57488f9c9996bbacf6a54bce6dacd43",
+    "content-hash": "b33c52f95904d69a6d064a667c727d0c",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -3,6 +3,9 @@
         "drupal/core" : {
             "https://www.drupal.org/project/drupal/issues/3047110": "patches/core--drupal--3047110-taxonomy-term-moderation-class.patch"
         },
+        "drupal/inline_entity_form": {
+            "https://www.drupal.org/project/inline_entity_form/issues/3226253": "https://git.drupalcode.org/project/inline_entity_form/-/merge_requests/33.diff"
+        },
         "drupal/migrate_tools" : {
             "https://www.drupal.org/project/migrate_tools/issues/3256236": "https://www.drupal.org/files/issues/2021-12-28/invalid_placeholder-3256236-3.patch"
         },

--- a/config/field.field.guideline.field_guideline.field_links.yml
+++ b/config/field.field.guideline.field_guideline.field_links.yml
@@ -11,7 +11,7 @@ id: guideline.field_guideline.field_links
 field_name: field_links
 entity_type: guideline
 bundle: field_guideline
-label: Links
+label: References
 description: ''
 required: false
 translatable: false

--- a/html/modules/custom/reliefweb_docstore/src/Plugin/Field/FieldType/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_docstore/src/Plugin/Field/FieldType/ReliefWebFile.php
@@ -529,7 +529,7 @@ class ReliefWebFile extends FieldItemBase {
 
     // @todo store the dimensions or use something faster to get
     // the width and height?
-    $info = getimagesize($uri);
+    $info = @getimagesize($uri);
     if ($info === FALSE) {
       return [];
     }

--- a/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
+++ b/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
@@ -221,9 +221,11 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
       $form['revision']['#access'] = FALSE;
     }
 
-    // Update the title of the revision log message field.
+    // Update the title of the revision log message field and make sure it's not
+    // populated with the previous message.
     if (isset($form[$revision_field]['widget'][0]['value'])) {
       $form[$revision_field]['widget'][0]['value']['#title'] = $this->t('New comment');
+      $form[$revision_field]['widget'][0]['value']['#default_value'] = '';
       $form[$revision_field]['#group'] = 'revision_information';
     }
   }

--- a/html/modules/custom/reliefweb_fields/components/reliefweb-links/reliefweb-links.js
+++ b/html/modules/custom/reliefweb_fields/components/reliefweb-links/reliefweb-links.js
@@ -399,7 +399,8 @@
       // Remove existing error messages in this container.
       var messages = field.querySelectorAll('[data-error-message]');
       for (var i = 0, l = messages.length; i < l; i++) {
-        field.removeChild(messages[i]);
+        var message = messages[i];
+        message.parentNode.removeChild(message);
       }
 
       // Remove existing highligted errors.
@@ -425,7 +426,9 @@
 
         // Add the message at the top of the fieldset.
         var sibling = field.querySelector('div[data-link-form]');
-        field.insertBefore(message, sibling);
+        if (sibling) {
+          sibling.parentNode.insertBefore(message, sibling);
+        }
 
         // Mark the element as erroneous.
         element.setAttribute('data-error', '');

--- a/html/modules/custom/reliefweb_fields/components/reliefweb-section-links/reliefweb-section-links.js
+++ b/html/modules/custom/reliefweb_fields/components/reliefweb-section-links/reliefweb-section-links.js
@@ -356,7 +356,9 @@
 
         // Add the message at the top of the fieldset.
         var sibling = this.form.querySelector('div[data-link-form]');
-        this.form.insertBefore(message, sibling);
+        if (sibling) {
+          this.form.insertBefore(message, sibling);
+        }
 
         // Mark the element as erroneous.
         element.setAttribute('data-error', '');

--- a/html/modules/custom/reliefweb_fields/components/reliefweb-user-posting-rights/reliefweb-user-posting-rights.js
+++ b/html/modules/custom/reliefweb_fields/components/reliefweb-user-posting-rights/reliefweb-user-posting-rights.js
@@ -267,7 +267,8 @@
       // Remove existing error messages in this container.
       var messages = field.querySelectorAll('[data-error-message]');
       for (var i = 0, l = messages.length; i < l; i++) {
-        field.removeChild(messages[i]);
+        var message = messages[i];
+        message.parentNode.removeChild(message);
       }
 
       // Remove existing highligted errors.
@@ -293,7 +294,9 @@
 
         // Add the message at the top of the fieldset.
         var sibling = field.querySelector('div[data-new-form]');
-        field.insertBefore(message, sibling);
+        if (sibling) {
+          sibling.parentNode.insertBefore(message, sibling);
+        }
 
         // Mark the element as erroneous.
         element.setAttribute('data-error', '');

--- a/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebLinks.php
+++ b/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebLinks.php
@@ -266,7 +266,12 @@ class ReliefWebLinks extends WidgetBase implements ContainerFactoryPluginInterfa
 
       // Only nodes are supported as internal links.
       if (empty($path)) {
-        $invalid = t('Invalid internal URL: it must be in the form "/node/123456" or "/reports/xxx" (it can start with https://reliefweb.int).');
+        if (preg_match('#^(https?://[^/]+)?/(node/\d+|report/[^/]+)#', $item['url']) === 1) {
+          $invalid = t('Invalid internal URL: the document was not found.');
+        }
+        else {
+          $invalid = t('Invalid internal URL: it must be in the form "/node/123456" or "/reports/xxx" (it can start with https://reliefweb.int).');
+        }
       }
       elseif (strpos($path, '/node/') === 0 && strlen($path) > 6) {
         $nid = intval(substr($path, 6), 10);

--- a/html/modules/custom/reliefweb_guidelines/components/reliefweb-guidelines/reliefweb-guidelines.css
+++ b/html/modules/custom/reliefweb_guidelines/components/reliefweb-guidelines/reliefweb-guidelines.css
@@ -311,8 +311,10 @@ aside nav a.active + a {
 }
 
 .rw-guidelines-list article img {
+  display: block;
   box-sizing: border-box;
-  max-width: 100%;
+  max-width: 1000px;
+  margin: 10px 0;
   padding: 10px;
   border: 0;
   background-color: #fff;

--- a/html/modules/custom/reliefweb_guidelines/components/reliefweb-guidelines/reliefweb-guidelines.js
+++ b/html/modules/custom/reliefweb_guidelines/components/reliefweb-guidelines/reliefweb-guidelines.js
@@ -53,6 +53,12 @@
     // Set the active link when the page is loaded.
     setActiveLink(window.location.href);
 
+    // Change the exit link to go to the referrer.
+    var exitLink = document.querySelector('.rw-guidelines-exit-link');
+    if (exitLink && document.referrer) {
+      exitLink.setAttribute('href', document.referrer);
+    }
+
     // Ensure external links open in a new tab/window.
     var links = main.getElementsByTagName('a');
     for (var i = 0, l = links.length; i < l; i++) {

--- a/html/modules/custom/reliefweb_guidelines/src/Controller/GuidelineSinglePageController.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Controller/GuidelineSinglePageController.php
@@ -98,6 +98,7 @@ class GuidelineSinglePageController extends ControllerBase {
         return !empty($item['title']) && !empty($item['children']);
       }),
       '#cache' => [
+        'tags' => ['guideline_list'],
         'contexts' => ['user.permissions'],
       ],
       '#attached' => [

--- a/html/modules/custom/reliefweb_guidelines/src/Controller/GuidelineSinglePageController.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Controller/GuidelineSinglePageController.php
@@ -67,7 +67,22 @@ class GuidelineSinglePageController extends ControllerBase {
       elseif (!empty($guideline->getParentIds())) {
         $parent = $guideline->getParentIds()[0];
         $id = $guideline->field_short_link->value;
-        $description = check_markup($guideline->field_description->value, $guideline->field_description->format);
+        $description = $guideline->field_description->value;
+
+        // Add the references if any at the bottom of the description. This
+        // will be converted to an HTML list when rendering the description.
+        // This notably enables replacing internal reference links.
+        $references = [];
+        foreach ($guideline->field_links as $link) {
+          if (!empty($link->uri)) {
+            $references[] = $link->uri;
+          }
+        }
+        if (!empty($references)) {
+          $description .= "\n## References\n" . implode("\n- ", $references);
+        }
+
+        $description = check_markup($description, $guideline->field_description->format);
 
         $list[$parent]['children'][$id] = [
           'title' => $guideline->label(),

--- a/html/modules/custom/reliefweb_guidelines/src/Entity/Guideline.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Entity/Guideline.php
@@ -108,4 +108,14 @@ class Guideline extends GuidelineBase implements EntityModeratedInterface, Entit
     return !empty($parents) ? reset($parents) : NULL;
   }
 
+  /**
+   * Get the list, this guideline belongs to.
+   *
+   * @return \Drupal\Core\GeneratedLink|null
+   *   Link to the guideline list.
+   */
+  public function getGuidelineListLink() {
+    return $this->getGuidelineList()?->toLink()?->toString();
+  }
+
 }

--- a/html/modules/custom/reliefweb_guidelines/src/Entity/Guideline.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Entity/Guideline.php
@@ -3,6 +3,9 @@
 namespace Drupal\reliefweb_guidelines\Entity;
 
 use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Link;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
 use Drupal\guidelines\Entity\Guideline as GuidelineBase;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\EntityModeratedTrait;
@@ -45,6 +48,26 @@ class Guideline extends GuidelineBase implements EntityModeratedInterface, Entit
       return $this->field_short_link->value;
     }
     return $this->id();
+  }
+
+  /**
+   * Get the link to the guidelines page.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|string $title
+   *   Link title.
+   *
+   * @return \Drupal\Core\GeneratedLink|null
+   *   Link to the guidelines page.
+   */
+  public function getLinkToGuidelines($title = '') {
+    $title = $title ?: new TranslatableMarkup('View on guidelines page');
+    return Link::fromTextAndUrl($title, Url::fromUserInput('/guidelines', [
+      'fragment' => $this->getShortId(),
+      'attributes' => [
+        'target' => '_blank',
+        'rel' => 'noopener',
+      ],
+    ]))?->toString();
   }
 
   /**

--- a/html/modules/custom/reliefweb_guidelines/src/Entity/GuidelineList.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Entity/GuidelineList.php
@@ -51,4 +51,31 @@ class GuidelineList extends GuidelineBase implements EntityModeratedInterface, E
     parent::postDelete($storage, $entities);
   }
 
+  /**
+   * Get the list of guidelines under this list.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function getGuidelineLinks() {
+    $children = $this->getChildren();
+    if (!empty($children)) {
+      $links = [];
+      foreach ($children as $child) {
+        $links[] = [
+          'title' => $child->label(),
+          'url' => $child->toUrl(),
+        ];
+      }
+      return [
+        '#theme' => 'links',
+        '#links' => $links,
+        '#cache' => [
+          'tags' => ['guideline_list'],
+        ],
+      ];
+    }
+    return [];
+  }
+
 }

--- a/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineModeration.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Services/GuidelineModeration.php
@@ -3,9 +3,7 @@
 namespace Drupal\reliefweb_guidelines\Services;
 
 use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
 use Drupal\reliefweb_guidelines\Plugin\Field\FieldWidget\GuidelineFieldTargetSelectWidget;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
@@ -82,9 +80,7 @@ class GuidelineModeration extends ModerationServiceBase {
       $data = [];
 
       // Title.
-      $data['title'] = Link::fromTextAndUrl($entity->label(), Url::fromUserInput('/guidelines', [
-        'fragment' => $entity->getShortId(),
-      ]));
+      $data['title'] = $entity->toLink()?->toString();
 
       // Information.
       $info = [];
@@ -92,6 +88,7 @@ class GuidelineModeration extends ModerationServiceBase {
       if (!empty($list)) {
         $info['list'] = $list->toLink()->toString();
       }
+      $info['link'] = $entity->getLinkToGuidelines($this->t('<em>guidelines</em>'));
       $data['info'] = array_filter($info);
 
       $details = [];

--- a/html/themes/custom/common_design_subtheme/templates/content/taxonomy-term--country--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/taxonomy-term--country--full.html.twig
@@ -68,3 +68,5 @@
   {{ term.getPageContent() }}
 
 </article>
+
+{{ term.getHistory() }}

--- a/html/themes/custom/common_design_subtheme/templates/content/taxonomy-term--disaster--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/taxonomy-term--disaster--full.html.twig
@@ -78,3 +78,5 @@
   {% endif %}
 
 </article>
+
+{{ term.getHistory() }}

--- a/html/themes/custom/common_design_subtheme/templates/content/taxonomy-term--source--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/taxonomy-term--source--full.html.twig
@@ -48,3 +48,5 @@
   {{ term.getPageContent() }}
 
 </article>
+
+{{ term.getHistory() }}

--- a/html/themes/custom/common_design_subtheme/templates/field/field--guideline--field-links.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/field/field--guideline--field-links.html.twig
@@ -1,0 +1,84 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    label_display == 'inline' ? 'clearfix',
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+    'cd-block-title',
+  ]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes.addClass(classes, 'field__items') }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes.addClass(classes) }}>
+    <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
+    {% if multiple %}
+      <ul class="field__items">
+      {% for item in items %}
+        <li{{ item.attributes.addClass('field__item') }}>{{ item.content }}</li>
+      {% endfor %}
+      </ul>
+    {% else %}
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    {% endif %}
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/navigation/menu--help.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/navigation/menu--help.html.twig
@@ -60,20 +60,23 @@
           be replaced with a button to show the child menu.
         #}
         {% spaceless %}
-        <a href="{{ item.url }}" id="{{ id }}">
-          {# Add the user icon for the first menu item of the root element. #}
-          {% if menu_level == 0 and item.url|render == '/help' %}
+        {% if menu_level == 0 and item.url|render == '/help' %}
+          <a href="{{ item.url }}" id="{{ id }}">
             <svg class="cd-icon cd-icon--help" aria-hidden="true" focusable="false" width="16" height="16">
               <use xlink:href="#cd-icon--help"></use>
             </svg>
-          {% endif %}
-          {% if menu_level == 0 and item.url|render == '/guidelines' %}
+            <span>{{ title }}</span>
+          </a>
+        {% elseif menu_level == 0 and item.url|render == '/guidelines' %}
+          <a href="{{ item.url }}" id="{{ id }}" target="_blank">
             <svg class="cd-icon cd-icon--education" aria-hidden="true" focusable="false" width="16" height="16">
               <use xlink:href="#cd-icon--education"></use>
             </svg>
-          {% endif %}
-          <span>{{ title }}</span>
-        </a>
+            <span>{{ title }}</span>
+          </a>
+        {% else %}
+          <a href="{{ item.url }}" id="{{ id }}"><span>{{ title }}</span></a>
+        {% endif %}
         {% endspaceless %}
 
         {# If the menu item has children then we mark it as toggable and we'll

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--field-guideline--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--field-guideline--full.html.twig
@@ -17,6 +17,11 @@
 #}
 <div class="rw-page-content">
 {% if content %}
-  {{- content -}}
+  {% set parent_link = elements['#guideline'].getGuidelineListLink() %}
+  {% if parent_link %}
+  <p>{% trans %}<strong>Guideline list:</strong> {{ parent_link }}{% endtrans %}</p>
+  {% endif %}
+  {{- content.field_description.0|render|sanitize_html(false, 1) -}}
+  {{- content|without(['field_description']) -}}
 {% endif %}
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--field-guideline--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--field-guideline--full.html.twig
@@ -17,10 +17,12 @@
 #}
 <div class="rw-page-content">
 {% if content %}
+  {{- elements['#guideline'].getLinkToGuidelines() -}}
   {% set parent_link = elements['#guideline'].getGuidelineListLink() %}
   {% if parent_link %}
   <p>{% trans %}<strong>Guideline list:</strong> {{ parent_link }}{% endtrans %}</p>
   {% endif %}
+  <hr>
   {{- content.field_description.0|render|sanitize_html(false, 1) -}}
   {{- content|without(['field_description']) -}}
 {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--guideline-list--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/guideline/guideline--guideline-list--full.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file guideline.html.twig
+ * Default theme implementation to present Guideline data.
+ *
+ * This template is used when viewing Guideline pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_guideline()
+ *
+ * @ingroup themeable
+ */
+#}
+<div class="rw-page-content">
+{% if content %}
+  {{- content -}}
+  {{- elements['#guideline'].getGuidelineLinks() -}}
+{% endif %}
+</div>


### PR DESCRIPTION
- RW-443: Fix caching of guidelines page
- RW-444: Ensure the revision log message field is empty when editing content
- RW-445: Make exit link redirect to referrer on guidelines page
- RW-446: Change links on guideline moderation page
- RW-447: Add link to guideline list on guideline page 
- RW-448: Open guidelines in new tab
- RW-452: Show reference links at bottom of guidelines
- RW-472: Set date of datepicker when opening it
- RW-476: Add revision information at bottom of country, disaster and source pages
- RW-477: Fix issue with display of error message on country/disaster profile form
- RW-478: Prevent PHP warning when image file is missing
- RW-479: Restore inline_entity_form patch
- RW-480: Show guidelines on guideline list page
- RW-481: Limit width of images on guidelines page