### PR TITLE
[RE-537] update help text for origin url field

### DIFF
--- a/config/field.field.node.report.field_origin_notes.yml
+++ b/config/field.field.node.report.field_origin_notes.yml
@@ -10,7 +10,7 @@ field_name: field_origin_notes
 entity_type: node
 bundle: report
 label: 'Origin notes'
-description: 'Origin URL of the document starting with http:// or https://; or list of email addresses to notify when origin "submit" is selected.'
+description: 'Origin URL of the document starting with http:// or https://.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
I also updated the link in the [guidelines](https://reliefweb.int/admin/structure/guideline/21/edit) (from `guideline/AS0L5YBd35` to `guidelines#AS0L5YBd` without the 35 at the end). I've now seen [there's already a fix](https://github.com/UN-OCHA/rwint9-site/pull/330) that means I didn't need to change the slash for a #, (or indeed make the change at all) but it's not deployed yet so I can change that back afterwards.

I considered mentioning the notify box here while editors get used to 'the new way', but decided it's better not to.