### PR TITLE
[RW-554] Disable nginx rules related to the docstore

### DIFF
--- a/docker/etc/nginx/custom/01_attachment_redirections.conf
+++ b/docker/etc/nginx/custom/01_attachment_redirections.conf
@@ -12,7 +12,9 @@ location /attachments/ {
     add_header Content-Disposition 'attachment; filename="$file_name$file_ext"';
 
     ## Try the local file first then the remote one.
-    try_files "/sites/default/files/attachments/$1/$2/$1$2$3$file_ext" @docstore-file;
+    # RW-554: Disabled as the docstore is not used.
+    # try_files "/sites/default/files/attachments/$1/$2/$1$2$3$file_ext" @docstore-file;
+    try_files "/sites/default/files/attachments/$1/$2/$1$2$3$file_ext" =404;
   }
 
   return 404;
@@ -39,41 +41,42 @@ location /private/attachments/ {
 }
 
 ## Request to the docstore.
-location @docstore-file {
-  ## Use our custom 404 handler so we can set the content disposition
-  ## to inline to prevent the browser from downloading a file with the
-  ## "404 Not Found" message.
-  error_page 404 @attachment-404;
+# RW-554: Disabled as the docstore is not used.
+# location @docstore-file {
+#   ## Use our custom 404 handler so we can set the content disposition
+#   ## to inline to prevent the browser from downloading a file with the
+#   ## "404 Not Found" message.
+#   error_page 404 @attachment-404;
 
-  ## Return a 404 when the connection to the docstore fails.
-  error_page 502 @attachment-404;
+#   ## Return a 404 when the connection to the docstore fails.
+#   error_page 502 @attachment-404;
 
-  ## Make sure we can catch the 404 error to be able to use our handler.
-  proxy_intercept_errors on;
+#   ## Make sure we can catch the 404 error to be able to use our handler.
+#   proxy_intercept_errors on;
 
-  ## Remove the content disposition header to avoid unwanted encoding of the
-  ## filename (ex: "My%20file.pdf" instead of "My file.pdf"). See DOC-72.
-  proxy_hide_header Content-Disposition;
+#   ## Remove the content disposition header to avoid unwanted encoding of the
+#   ## filename (ex: "My%20file.pdf" instead of "My file.pdf"). See DOC-72.
+#   proxy_hide_header Content-Disposition;
 
-  ## Force download of the file.
-  add_header Content-Disposition 'attachment; filename="$file_name$file_ext"';
+#   ## Force download of the file.
+#   add_header Content-Disposition 'attachment; filename="$file_name$file_ext"';
 
-  ## Set the docstore provider UUID header so that we can get the proper
-  ## version of the file for the provider.
-  set_by_lua $x_docstore_provider_uuid_from_env 'return os.getenv("X_DOCSTORE_PROVIDER_UUID") or "latest"';
-  proxy_set_header X-Docstore-Provider-Uuid "$x_docstore_provider_uuid_from_env";
+#   ## Set the docstore provider UUID header so that we can get the proper
+#   ## version of the file for the provider.
+#   set_by_lua $x_docstore_provider_uuid_from_env 'return os.getenv("X_DOCSTORE_PROVIDER_UUID") or "latest"';
+#   proxy_set_header X-Docstore-Provider-Uuid "$x_docstore_provider_uuid_from_env";
 
-  ## Rewrite the url to what the docstore wants.
-  rewrite /attachments/(.+)$ /files/$1 break;
-  proxy_pass http://docstore.ahconu.org.internal;
+#   ## Rewrite the url to what the docstore wants.
+#   rewrite /attachments/(.+)$ /files/$1 break;
+#   proxy_pass http://docstore.ahconu.org.internal;
 
-  ## Override connection and buffer vars: do not attempt to buffer, just throw
-  ## the data out right away and close the docstore connection when done.
-  proxy_set_header Connection '';
-  proxy_buffering off;
-  tcp_nodelay on;
-  tcp_nopush off;
-}
+#   ## Override connection and buffer vars: do not attempt to buffer, just throw
+#   ## the data out right away and close the docstore connection when done.
+#   proxy_set_header Connection '';
+#   proxy_buffering off;
+#   tcp_nodelay on;
+#   tcp_nopush off;
+# }
 
 ## 404 handler for attachments that prevent browsers from downloading a file
 ## with the attachment file name but containing a "404 Not Found" message.


### PR DESCRIPTION
 Disable nginx rules related to the docstore as it is not used to avoid upstream not found issues when there is no connected docstore instance.