### PR TITLE
RW-573 Unsubscribe form styles in global library

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
@@ -541,3 +541,17 @@ legend.form-required::after {
 form:not(.rw-entity-form-altered) .form-actions.form-item {
   margin-top: var(--cd-flow-space, 2.5rem);
 }
+
+/**
+ * Unsubscribe form.
+ *
+ * These rules are place here because this CSS is loaded globally.
+ */
+.unsubscribe-form .form-checkboxes .form-type-checkbox {
+  display: block;
+}
+
+/* Cancel button on unsubscribe form */
+.unsubscribe-form > .button + a {
+  margin-left: 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-user/rw-user.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-user/rw-user.css
@@ -4,8 +4,7 @@
  * Style the form in the page where users can subscribe to ReliefWeb
  * notifications.
  */
-.subscription-form .form-checkboxes .form-type-checkbox,
-.unsubscribe-form .form-checkboxes .form-type-checkbox {
+.subscription-form .form-checkboxes .form-type-checkbox {
   display: block;
 }
 
@@ -33,10 +32,6 @@
 }
 .subscription-form .form-actions.form-item {
   margin-top: 24px;
-}
-/* Cancel button on unsubscribe form */
-.unsubscribe-form > .button + a {
-  margin-left: 1rem;
 }
 
 /**


### PR DESCRIPTION
I moved the unsubscribe form rules from `rw-user` component and added them to `rw-form` which is part of the global library. The first attempt #353 didn't work because the library isn't loaded onto that page and since I cannot view this page locally, using the global library seems like the most straight-forward.