### PR TITLE
[OPS-8377] legacy redirection symlinks

### DIFF
--- a/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
@@ -1,17 +1,35 @@
 local attachment_file = ngx.var.attachment_file
 
--- The generation of the UUID from the legacy URL is similar to what is done
--- in \Drupal\reliefeb_utility\Helpers\LegacyHelper::getAttachmentUuid().
+-- Try to get the attachment from a potential symlink.
+-- This handles the redirection for some location maps so that they all have
+-- the same pattern for example to compensate for some inconsistencies between
+-- the URL, URI in DB and file on disk in D7.
+-- This can also be used to handle aliases for some specific files.
+local symlink = ngx.var.document_root .. '/sites/default/files/legacy-attachments/' .. attachment_file;
+local handle = io.popen('readlink "' .. symlink .. '"')
+local target = handle:read()
+handle:close()
 
--- Strip the % characters.
-attachment_file = string.gsub(attachment_file, "%%", '')
+-- If there was no symlink then we generated the target based on the filename.
+if target == nil or target == '' then
+  -- The generation of the UUID from the legacy URL is similar to what is done
+  -- in \Drupal\reliefeb_utility\Helpers\LegacyHelper::getAttachmentUuid().
 
--- Consolidate the URL.
-local legacy_url = 'https://reliefweb.int/sites/reliefweb.int/files/resources/' .. attachment_file
+  -- Strip the % characters.
+  attachment_file = string.gsub(attachment_file, "%%", '')
 
--- Generate the UUID corresponding to the URL.
-local jit_uuid = require 'resty.jit-uuid'
-local uuid = jit_uuid.generate_v3('6ba7b811-9dad-11d1-80b4-00c04fd430c8', legacy_url)
+  -- Consolidate the URL.
+  local legacy_url = 'https://reliefweb.int/sites/reliefweb.int/files/resources/' .. attachment_file
+
+  -- Generate the UUID corresponding to the URL.
+  local jit_uuid = require 'resty.jit-uuid'
+  local uuid = jit_uuid.generate_v3('6ba7b811-9dad-11d1-80b4-00c04fd430c8', legacy_url)
+
+  target = uuid .. '/' .. attachment_file
+else
+  local uuid = string.gsub(target, '../attachments/[^/]+/[^/]+/([^.]+).+', '%1')
+  target = uuid .. '/' .. attachment_file
+end
 
 -- Redirect to the new URL.
-return ngx.redirect('/attachments/' .. uuid .. '/' .. attachment_file, 301)
+return ngx.redirect('/attachments/' .. target, 301)

--- a/html/modules/custom/reliefweb_files/drush.services.yml
+++ b/html/modules/custom/reliefweb_files/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   reliefweb_files.commands:
     class: \Drupal\reliefweb_files\Commands\ReliefWebFilesCommands
-    arguments: ['@config.factory', '@database', '@entity_field.manager', '@entity_type.manager', '@reliefweb_files.client']
+    arguments: ['@config.factory', '@database', '@entity_field.manager', '@entity_type.manager', '@file_system', '@reliefweb_files.client']
     tags:
       - { name: drush.command }

--- a/html/modules/custom/reliefweb_files/src/Commands/ReliefWebFilesCommands.php
+++ b/html/modules/custom/reliefweb_files/src/Commands/ReliefWebFilesCommands.php
@@ -8,12 +8,14 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\reliefweb_files\Plugin\Field\FieldType\ReliefWebFile;
 use Drupal\reliefweb_files\Services\DocstoreClient;
 use Drupal\reliefweb_utility\Helpers\LegacyHelper;
 use Drupal\reliefweb_utility\Helpers\UrlHelper;
 use Drupal\reliefweb_utility\Traits\EntityDatabaseInfoTrait;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * ReliefWeb migration Drush commandfile.
@@ -53,6 +55,13 @@ class ReliefWebFilesCommands extends DrushCommands {
   protected $entityTypeManager;
 
   /**
+   * The file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
    * The docstore client service.
    *
    * @var \Drupal\reliefweb_files\Services\DocstoreClient
@@ -67,12 +76,14 @@ class ReliefWebFilesCommands extends DrushCommands {
     Connection $database,
     EntityFieldManagerInterface $entity_field_manager,
     EntityTypeManagerInterface $entity_type_manager,
+    FileSystemInterface $file_system,
     DocstoreClient $docstore_client,
   ) {
     $this->configFactory = $config_factory;
     $this->database = $database;
     $this->entityFieldManager = $entity_field_manager;
     $this->entityTypeManager = $entity_type_manager;
+    $this->fileSystem = $file_system;
     $this->docstoreClient = $docstore_client;
   }
 
@@ -894,6 +905,140 @@ class ReliefWebFilesCommands extends DrushCommands {
       '@existing' => $count_existing,
       '@total' => count($records),
     ]));
+  }
+
+  /**
+   * Generate a symlink of a legacy URL.
+   *
+   * This generates a symlink to handle a file whose filename differs from
+   * its URI basename because the nginx redirection logic cannot work in that
+   * case as the UUID from the URL will not match the actual UUID of the file.
+   * So we generate a symlink using the relevant part from the URL to the
+   * given preview or attachment with the given UUID.
+   *
+   * Ex: public://file1.pdf with filename file1_compressed.pdf.
+   *
+   * @param string $url
+   *   Legacy attachment or preview URL.
+   * @param string $uuid
+   *   UUID of the file in the new system.
+   *
+   * @command rw-files:generate-redirection-symlink
+   *
+   * @usage rw-files:generate-redirection-symlink URL UUID
+   *   Generate the symlink for the URL to the file with the given UUID.
+   *
+   * @validate-module-enabled reliefweb_files
+   */
+  public function generateRedirectionSymlink($url, $uuid) {
+    if (!Uuid::isValid($uuid)) {
+      $this->logger()->error(dt('Invalid UUID: @uuid', [
+        '@uuid' => $uuid,
+      ]));
+      return FALSE;
+    }
+
+    $base_directory = rtrim($this->fileSystem->realpath('public://'), '/');
+
+    // Preview.
+    if (preg_match('#^https?://[^/]+/sites/[^/]+/files/resource-previews/(\d+)-[^/]+$#', $url, $match) === 1) {
+      $extension = 'png';
+      $directory = $base_directory . '/legacy-previews';
+      $target = '../previews/' . substr($uuid, 0, 2) . '/' . substr($uuid, 2, 2) . '/' . $uuid . '.' . $extension;
+      $link = $directory . '/' . $match[1] . '.' . $extension;
+    }
+    // Attachment.
+    elseif (preg_match('#^https?://[^/]+/sites/[^/]+/files/resources/([^/]+)$#', $url, $match) === 1) {
+      $extension = ReliefWebFile::extractFileExtension($match[1]);
+      $directory = $base_directory . '/legacy-attachments';
+      $target = '../attachments/' . substr($uuid, 0, 2) . '/' . substr($uuid, 2, 2) . '/' . $uuid . '.' . $extension;
+      $link = $directory . '/' . $match[1];
+    }
+    else {
+      $this->logger()->error(dt('Invalid attachment or preview URL: @url', [
+        '@url' => $url,
+      ]));
+      return FALSE;
+    }
+
+    // Create the legacy directory.
+    if (!$this->fileSystem->prepareDirectory($directory, $this->fileSystem::CREATE_DIRECTORY)) {
+      $this->logger()->error(dt('Unable to create @directory', [
+        '@directory' => $directory,
+      ]));
+      return FALSE;
+    }
+
+    // Remove any previous link.
+    if (is_link($link)) {
+      @unlink($link);
+    }
+
+    // Create the symlink.
+    if (!@symlink($target, $link)) {
+      $this->logger()->error(dt('Unable to create symlink: @link => @target', [
+        '@link' => $link,
+        '@target' => $target,
+      ]));
+      return FALSE;
+    }
+
+    $this->logger()->success(dt('Successfully created symlink: @link => @target', [
+      '@link' => $link,
+      '@target' => $target,
+    ]));
+    return TRUE;
+  }
+
+  /**
+   * Remove a symlink of a legacy URL.
+   *
+   * @param string $url
+   *   Legacy attachment or preview URL.
+   *
+   * @command rw-files:remove-redirection-symlink
+   *
+   * @usage rw-files:remove-redirection-symlink
+   *   Remove a legacy symlink.
+   *
+   * @validate-module-enabled reliefweb_files
+   */
+  public function removeRedirectionSymlink($url) {
+    $base_directory = rtrim($this->fileSystem->realpath('public://'), '/');
+
+    // Preview.
+    if (preg_match('#^https?://[^/]+/sites/[^/]+/files/resource-previews/(\d+)-[^/]+$#', $url, $match) === 1) {
+      $extension = '.png';
+      $directory = $base_directory . '/legacy-previews';
+      $link = $directory . '/' . $match[1] . $extension;
+    }
+    // Attachment.
+    elseif (preg_match('#^https?://[^/]+/sites/[^/]+/files/resources/([^/]+)$#', $url, $match) === 1) {
+      $extension = ReliefWebFile::extractFileExtension($match[1]);
+      $directory = $base_directory . '/legacy-attachments';
+      $link = $directory . '/' . $match[1];
+    }
+    else {
+      $this->logger()->error(dt('Invalid attachment or preview URL: @url', [
+        '@url' => $url,
+      ]));
+      return FALSE;
+    }
+
+    // Remove any previous link.
+    if (is_link($link)) {
+      @unlink($link);
+
+      $this->logger()->success(dt('Successfully removed symlink @link', [
+        '@link' => $link,
+      ]));
+    }
+    else {
+      $this->logger()->notice(dt('Symlink @link didn\'t exist', [
+        '@link' => $link,
+      ]));
+    }
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
Refs: OPS-8377

This contains 2 parts:

1. An update of the legacy attachment redirection lua script to check for symlinks similar to what is done for some previews
2. A drush command that can be used to generate redirection symlinks