### PR TITLE
[RW-23] Most read adjustments

### DIFF
--- a/html/modules/custom/reliefweb_analytics/reliefweb_analytics.module
+++ b/html/modules/custom/reliefweb_analytics/reliefweb_analytics.module
@@ -298,7 +298,7 @@ function reliefweb_analytics_get_terms(FieldableEntityInterface $entity, $field,
  * @return string
  *   Comma separated list of term Ids.
  */
-function reliefweb_analytics_get_terms_id(FieldableEntityInterface $entity, $field, CacheableMetadata $cache_metadata) {
+function reliefweb_analytics_get_term_ids(FieldableEntityInterface $entity, $field, CacheableMetadata $cache_metadata) {
   $terms = [];
   if ($entity->hasField($field) && !$entity->get($field)->isEmpty()) {
     foreach ($entity->get($field)->referencedEntities() as $term) {

--- a/html/modules/custom/reliefweb_entities/src/SectionedContentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/SectionedContentTrait.php
@@ -301,13 +301,18 @@ trait SectionedContentTrait {
     if (!empty($ids)) {
       // We reverse the ids to add the boost (higher boost = higher view count).
       foreach (array_reverse($ids) as $index => $id) {
-        $ids[] = $id . '^' . ($index * 10);
+        if (is_numeric($id)) {
+          $ids[$index] = 'id:' . $id . '^' . ($index * 10);
+        }
+        else {
+          $ids[$index] = 'url_alias:"' . $id . '"^' . ($index * 10);
+        }
       }
 
       $payload = RiverServiceBase::getRiverApiPayload('report');
       $payload['fields']['exclude'][] = 'file';
       $payload['fields']['exclude'][] = 'body-html';
-      $payload['query']['value'] = 'id:' . implode(' OR id:', $ids);
+      $payload['query']['value'] = implode(' OR ', $ids);
       $payload['limit'] = $limit;
       $payload['sort'] = ['score:desc', 'date.created:desc'];
 

--- a/html/modules/custom/reliefweb_homepage/src/Controller/Homepage.php
+++ b/html/modules/custom/reliefweb_homepage/src/Controller/Homepage.php
@@ -267,25 +267,25 @@ class Homepage extends ControllerBase {
    *   API Payload.
    */
   public function getMostReadApiPayload($limit = 2) {
+    $ids = [];
+
     // Load the most-read data. This file is generated via a drush command,
     // usually every day as the query to get the 5 most read reports is very
     // heavy.
     $handle = @fopen('public://most-read/most-read.csv', 'r');
-    if ($handle === FALSE) {
-      return [];
-    }
-
-    // Find the line corresponding to the entity id.
-    while (($row = fgetcsv($handle, 100)) !== FALSE) {
-      if (count($row) === 2 && $row[0] == 'front') {
-        $ids = array_slice(explode(',', $row[1]), 0, $limit);
-        break;
+    if ($handle !== FALSE) {
+      // Find the line corresponding to the entity id.
+      while (($row = fgetcsv($handle, 100)) !== FALSE) {
+        if (count($row) === 2 && $row[0] == 'front') {
+          $ids = array_slice(explode(',', $row[1]), 0, $limit);
+          break;
+        }
       }
-    }
 
-    // Close the file.
-    if (is_resource($handle)) {
-      @fclose($handle);
+      // Close the file.
+      if (is_resource($handle)) {
+        @fclose($handle);
+      }
     }
 
     $payload = RiverServiceBase::getRiverApiPayload('report');


### PR DESCRIPTION
Refs: RW-23

Follow-up of https://github.com/UN-OCHA/rwint9-site/pull/376 that adjusts and fixes a few things.

The 2 main changes are:

The addition of the the "contains" match type to the disaster/country filters so that reports tagged with multiple terms are included. This was the reason why the results were different from the single request command.

With that match type, the results from the individual requests and the single large requests are the same so there is actually no need for the individual ones which makes things dramatically faster.

The second main change is the use of the `url_alias` property for the RW API query so that we don't have to do path alias lookups. This, notably makes testing locally much simpler (see below).

The `property id` is retrieved via `Settings:get` instead of a state variable so that it can be set via Ansible and the crendentials file path is set via the GOOGLE_APPLICATION_CREDENTIALS env variable so it can be injected when running the command.

Otherwise, it's mostly fixes (disaster statuses, last id not incremented in some cases, removed ids not removed, title for homepage etc.) and prefixing of the variables with `reliefweb_analytics_most_read_`.

**Local dev changes**

Credentials: the path to the `crendentials.json` is set via the GOOGLE_APPLICATION_CREDENTIALS env variable (ex: `putenv('GOOGLE_APPLICATION_CREDENTIALS=/var/www/credentials.json');` in local.settings.php.

The propery id is set via a setting: `$settings['reliefweb_analytics_property_id'] = XXX;` in local.settings.php.

To test the display of the blocks locally, set `$config['reliefweb_api.settings']['api_url'] = 'https://api.reliefweb.int/v1';` in local.settings.php to use the prod API and clear the cache.

If using the local API instead of the prod one, set `reliefweb_analytics_most_read_base_url` to the local site (ex: `https://rw9.test`) and regenerate the `most-read.csv` file.