### PR TITLE
[RW-608] Optional mark

### DIFF
--- a/html/modules/custom/reliefweb_form/js/drupal.states.js
+++ b/html/modules/custom/reliefweb_form/js/drupal.states.js
@@ -43,9 +43,16 @@
     // Extend the behavior for the required state to remove any optional marker.
     $(document).on('state:required', function (event) {
       if (event.trigger) {
+        var target = event.target;
+        var type = target.nodeName;
+        if ((type === 'BUTTON' || type === 'INPUT' || type === 'SELECT' || type === 'TEXTAREA') && target.id) {
+          target = document.querySelector('label[for="' + target.id + '"]');
+        }
+
         if (!event.value) {
+          var $elements = target.hasAttribute('data-optional') ? $(target) : $(target).find('[data-optional]');
           // Add the optional mark if not already there.
-          $(event.target).find('[data-optional]').each(function () {
+          $elements.each(function () {
             var $label = $(this);
             if (!$label.find('.form-optional').length) {
               $label.append('<span class="form-optional">' + $label.attr('data-optional') + '</span>');
@@ -55,7 +62,7 @@
         else {
           // Store the text of the optional marker to preseve the translated
           // string so that it can be re-used if the marker is added back.
-          $(event.target).find('.form-optional').each(function () {
+          $(target).find('.form-optional').each(function () {
             var $element = $(this);
             $element.parent().attr('data-optional', $element.text());
             $element.remove();


### PR DESCRIPTION
Refs: RW-608

This fixes an issue where the "optional" mark is not removed for fields that become required via drupal.states.

Ex: the headline title and summary fields on the report form when the headline checkbox is checked.

**Test**

1. Go to the `/node/add/report` form
2. Check the `headline` checkbox -> this should remove the "optional" mark on the headline title and summary fields and add it back when unchecking

