### PR TITLE
feat: queue filtered re-indexing for processing later

### DIFF
--- a/html/modules/custom/reliefweb_api/drush.services.yml
+++ b/html/modules/custom/reliefweb_api/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   reliefweb_api.commands:
     class: \Drupal\reliefweb_api\Commands\ReliefWebApiCommands
-    arguments: ['@config.factory', '@module_handler', '@state']
+    arguments: ['@config.factory', '@entity_field.manager', '@entity_type.manager', '@module_handler', '@state']
     tags:
       - { name: drush.command }

--- a/html/modules/custom/reliefweb_api/reliefweb_api.module
+++ b/html/modules/custom/reliefweb_api/reliefweb_api.module
@@ -12,19 +12,12 @@ use RWAPIIndexer\Bundles;
 use RWAPIIndexer\Manager;
 
 /**
- * Implements hook_entity_before_save().
- *
- * @see \Drupal\reliefweb_entities\BundleEntityStorageInterface
+ * Implements hook_ENTITY_TYPE_update().
  */
-function reliefweb_api_entity_before_save(EntityInterface $entity) {
-  // Check if we need re-indexing.
-  if (!$entity->isNew() && $entity->getEntityTypeId() == 'taxonomy_term') {
-    $bundle = $entity->bundle();
-    // Only these types get checked for automatic re-indexing.
-    $taxonomy_types = ['country', 'disaster', 'source'];
-    if (in_array($bundle, $taxonomy_types)) {
-      reliefweb_api_check_reindexing($entity, $bundle);
-    }
+function reliefweb_api_taxonomy_term_update(EntityInterface $entity) {
+  // Check if term needs re-indexing.
+  if (!$entity->isNew()) {
+    reliefweb_api_check_reindexing($entity);
   }
 }
 
@@ -37,6 +30,13 @@ function reliefweb_api_entity_after_save(EntityInterface $entity) {
   // @todo remove when removing `reliefweb_migrate`.
   if (!empty($entity->_is_migrating)) {
     return;
+  }
+
+  if (!empty($entity->needs_reindex)) {
+    $reindex_queue = \Drupal::state()->get('reliefweb_api.reindex_queue');
+    $reindex_queue[$entity->bundle()][$entity->id()] = $entity->id();
+    \Drupal::state()->set('reliefweb_api.reindex_queue', $reindex_queue);
+    unset($entity->needs_reindex);
   }
 
   reliefweb_api_handle_entity($entity);
@@ -170,19 +170,24 @@ function reliefweb_api_execute(array $options, $entity_type_id) {
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   Entity that might require re-indexing.
- * @param string $bundle
- *   Taxonomy type of entity.
  */
-function reliefweb_api_check_reindexing(EntityInterface $entity, $bundle) {
-  $needs_reindex = FALSE;
-  // Get unchanged entity for comparison.
-  // Tried loadUnchanged() via hooks _entity_update() and _entity_after_save()
-  // but neither gave the original values.
-  $unchanged_entity = \Drupal::entityTypeManager()
-    ->getStorage($entity->getEntityTypeId())
-    ->loadUnchanged($entity->id());
+function reliefweb_api_check_reindexing(EntityInterface &$entity) {
 
-  switch ($bundle) {
+  if (!isset($entity->original)) {
+    return;
+  }
+  $original_entity = $entity->original;
+
+  switch ($entity->bundle()) {
+    case 'country':
+      $fields = [
+        'name',
+        'field_shortname',
+        'field_iso3',
+        'field_location',
+      ];
+      break;
+
     case 'disaster':
       $fields = [
         'name',
@@ -192,11 +197,17 @@ function reliefweb_api_check_reindexing(EntityInterface $entity, $bundle) {
       ];
       break;
 
-    case 'country':
+    case 'disaster_type':
       $fields = [
         'name',
-        'field_shortname',
-        'field_iso3',
+        'field_disaster_type_code',
+      ];
+      break;
+
+    case 'language':
+      $fields = [
+        'name',
+        'field_language_code',
       ];
       break;
 
@@ -211,20 +222,20 @@ function reliefweb_api_check_reindexing(EntityInterface $entity, $bundle) {
         'field_organization_type',
       ];
       break;
+
+    default:
+      $fields = [
+        'name',
+      ];
   }
 
   foreach ($fields as $field) {
-    if ($entity->get($field)->getValue() != $unchanged_entity->get($field)->getValue()) {
-      $needs_reindex = TRUE;
+    if ($entity->get($field)->getValue() != $original_entity->get($field)->getValue()) {
+      $entity->needs_reindex = TRUE;
       break;
     }
   }
 
-  if ($needs_reindex) {
-    $reindex_queue = json_decode(\Drupal::state()->get('reliefweb_api.reindex_queue'));
-    $reindex_queue[$bundle][] = $entity->id();
-    \Drupal::state()->set('reliefweb_api.reindex_queue', json_encode($reindex_queue));
-  }
 }
 
 /**

--- a/html/modules/custom/reliefweb_api/reliefweb_api.module
+++ b/html/modules/custom/reliefweb_api/reliefweb_api.module
@@ -12,6 +12,23 @@ use RWAPIIndexer\Bundles;
 use RWAPIIndexer\Manager;
 
 /**
+ * Implements hook_entity_before_save().
+ *
+ * @see \Drupal\reliefweb_entities\BundleEntityStorageInterface
+ */
+function reliefweb_api_entity_before_save(EntityInterface $entity) {
+  // Check if we need re-indexing.
+  if (!$entity->isNew() && $entity->getEntityTypeId() == 'taxonomy_term') {
+    $bundle = $entity->bundle();
+    // Only these types get checked for automatic re-indexing.
+    $taxonomy_types = ['country', 'disaster', 'source'];
+    if (in_array($bundle, $taxonomy_types)) {
+      reliefweb_api_check_reindexing($entity, $bundle);
+    }
+  }
+}
+
+/**
  * Implements hook_entity_after_save().
  *
  * @see \Drupal\reliefweb_entities\BundleEntityStorageInterface
@@ -21,6 +38,7 @@ function reliefweb_api_entity_after_save(EntityInterface $entity) {
   if (!empty($entity->_is_migrating)) {
     return;
   }
+
   reliefweb_api_handle_entity($entity);
 }
 
@@ -142,6 +160,70 @@ function reliefweb_api_execute(array $options, $entity_type_id) {
     ]);
   }
   catch (\Exception $exception) {
+  }
+}
+
+/**
+ * Check if taxonomy terms require re-indexing of tagged content.
+ *
+ * Store terms for re-indexing so we can process them later in batches.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity that might require re-indexing.
+ * @param string $bundle
+ *   Taxonomy type of entity.
+ */
+function reliefweb_api_check_reindexing(EntityInterface $entity, $bundle) {
+  $needs_reindex = FALSE;
+  // Get unchanged entity for comparison.
+  // Tried loadUnchanged() via hooks _entity_update() and _entity_after_save()
+  // but neither gave the original values.
+  $unchanged_entity = \Drupal::entityTypeManager()
+    ->getStorage($entity->getEntityTypeId())
+    ->loadUnchanged($entity->id());
+
+  switch ($bundle) {
+    case 'disaster':
+      $fields = [
+        'name',
+        'field_glide',
+        'field_disaster_type',
+        'moderation_status',
+      ];
+      break;
+
+    case 'country':
+      $fields = [
+        'name',
+        'field_shortname',
+        'field_iso3',
+      ];
+      break;
+
+    case 'source':
+      $fields = [
+        'name',
+        'field_shortname',
+        'field_longname',
+        'field_spanish_name',
+        'field_homepage',
+        'field_disclaimer',
+        'field_organization_type',
+      ];
+      break;
+  }
+
+  foreach ($fields as $field) {
+    if ($entity->get($field)->getValue() != $unchanged_entity->get($field)->getValue()) {
+      $needs_reindex = TRUE;
+      break;
+    }
+  }
+
+  if ($needs_reindex) {
+    $reindex_queue = json_decode(\Drupal::state()->get('reliefweb_api.reindex_queue'));
+    $reindex_queue[$bundle][] = $entity->id();
+    \Drupal::state()->set('reliefweb_api.reindex_queue', json_encode($reindex_queue));
   }
 }
 

--- a/html/modules/custom/reliefweb_api/reliefweb_api.module
+++ b/html/modules/custom/reliefweb_api/reliefweb_api.module
@@ -171,7 +171,7 @@ function reliefweb_api_execute(array $options, $entity_type_id) {
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   Entity that might require re-indexing.
  */
-function reliefweb_api_check_reindexing(EntityInterface &$entity) {
+function reliefweb_api_check_reindexing(EntityInterface $entity) {
 
   if (!isset($entity->original)) {
     return;

--- a/html/modules/custom/reliefweb_api/reliefweb_api.module
+++ b/html/modules/custom/reliefweb_api/reliefweb_api.module
@@ -230,7 +230,7 @@ function reliefweb_api_check_reindexing(EntityInterface $entity) {
   }
 
   foreach ($fields as $field) {
-    if ($entity->get($field)->getValue() != $original_entity->get($field)->getValue()) {
+    if (!$entity->get($field)->equals($original_entity->get($field))) {
       $entity->needs_reindex = TRUE;
       break;
     }

--- a/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
+++ b/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
@@ -4,8 +4,8 @@ namespace Drupal\reliefweb_api\Commands;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Database;
-use Drupal\Core\Entity\EntityFieldManager;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\State\StateInterface;
 use Drush\Commands\DrushCommands;
@@ -27,14 +27,14 @@ class ReliefWebApiCommands extends DrushCommands {
   /**
    * Entity Field manager.
    *
-   * @var \Drupal\Core\Entity\EntityFieldManager
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
   protected $entityFieldManager;
 
   /**
    * Entity Type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -57,8 +57,8 @@ class ReliefWebApiCommands extends DrushCommands {
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
-    EntityFieldManager $entity_field_manager,
-    EntityTypeManager $entity_type_manager,
+    EntityFieldManagerInterface $entity_field_manager,
+    EntityTypeManagerInterface $entity_type_manager,
     ModuleHandlerInterface $module_handler,
     StateInterface $state
   ) {

--- a/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
+++ b/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
@@ -4,6 +4,8 @@ namespace Drupal\reliefweb_api\Commands;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Database;
+use Drupal\Core\Entity\EntityFieldManager;
+use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\State\StateInterface;
 use Drush\Commands\DrushCommands;
@@ -21,6 +23,20 @@ class ReliefWebApiCommands extends DrushCommands {
    * @var \Drupal\Core\Config\ImmutableConfig
    */
   protected $apiConfig;
+
+  /**
+   * Entity Field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManager
+   */
+  protected $entityFieldManager;
+
+  /**
+   * Entity Type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
 
   /**
    * Module handler.
@@ -41,10 +57,14 @@ class ReliefWebApiCommands extends DrushCommands {
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
+    EntityFieldManager $entity_field_manager,
+    EntityTypeManager $entity_type_manager,
     ModuleHandlerInterface $module_handler,
     StateInterface $state
   ) {
     $this->apiConfig = $config_factory->get('reliefweb_api.settings');
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityTypeManager = $entity_type_manager;
     $this->moduleHandler = $module_handler;
     $this->state = $state;
   }
@@ -312,54 +332,89 @@ class ReliefWebApiCommands extends DrushCommands {
    */
   public function reIndexQueue() {
 
-    $reindex_queue = json_decode($this->state->get('reliefweb_api.reindex_queue'));
+    $reindex_queue = $this->state->get('reliefweb_api.reindex_queue');
+    // Empty the queue now so it can be repopulated during re-indexing.
+    $this->state->set('reliefweb_api.reindex_queue', []);
 
     if (empty($reindex_queue)) {
       return;
     }
 
-    // Use default values from $this->index().
-    $options = [
-      'elasticsearch' => '',
-      'base-index-name' => '',
-      'website' => '',
-      'limit' => 0,
-      'offset' => 0,
-      'filter' => '',
-      'chunk-size' => 500,
-      'tag' => '',
-      'id' => 0,
-      'remove' => FALSE,
-      'replace' => FALSE,
-      'alias' => FALSE,
-      'alias-only' => FALSE,
-      'log' => 'echo',
-      'count-only' => FALSE,
-      'memory-limit' => '512M',
-      'replicas' => NULL,
-      'shards' => NULL,
-    ];
-    foreach (array_keys($reindex_queue) as $bundle) {
-      if (empty($reindex_queue[$bundle])) {
-        continue;
+    // Get default options for indexing.
+    $reflection = new \ReflectionMethod(get_called_class(), 'index');
+    foreach ($reflection->getParameters() as $parameter) {
+      if ($parameter->getName() === 'options') {
+        $options = $parameter->getDefaultValue();
+        break;
       }
-      // Launch the re-indexing.
-      try {
-        $options['filter'] = $bundle . ':' . implode(',', $reindex_queue[$bundle]);
-        if ($bundle == 'country' || $bundle == 'source') {
-          $this->index('training', $options);
-          $this->index('job', $options);
-        }
-        $this->index('report', $options);
-      }
-      catch (\Exception $exception) {
-        $this->logger->error('(' . $exception->getCode() . ') ' . $exception->getMessage());
-      }
-      $reindex_queue[$bundle] = [];
+    }
+    if (!isset($options)) {
+      return;
     }
 
-    $this->state->set('reliefweb_api.reindex_queue', json_encode($reindex_queue));
+    foreach ($reindex_queue as $bundle => $ids) {
+      if (empty($ids)) {
+        continue;
+      }
 
+      $bundles_to_reindex = $this->getBundlesToReindex($bundle);
+      if (empty($bundles_to_reindex)) {
+        continue;
+      }
+
+      $options['filter'] = $bundle . ':' . implode(',', array_unique($ids));
+      foreach ($bundles_to_reindex as $bundle_to_reindex) {
+        $this->index($bundle_to_reindex, $options);
+      }
+    }
+  }
+
+  /**
+   * Get list of bundles to re-index for given taxonomy vocabulary.
+   *
+   * @param string $vocabulary
+   *   Vocabulary.
+   *
+   * @return array
+   *   List of bundles to re-index.
+   */
+  protected function getBundlesToReindex($vocabulary) {
+    // Gather a list of entity reference fields.
+    $entity_reference_fields = $this->entityFieldManager
+      ->getFieldMapByFieldType('entity_reference');
+
+    // Generate list of field config ids for the reference fields.
+    $ids = [];
+    foreach ($entity_reference_fields as $entity_type_id => $fields) {
+      foreach ($fields as $field_name => $info) {
+        foreach ($info['bundles'] as $entity_bundle) {
+          $ids[] = "$entity_type_id.$entity_bundle.$field_name";
+        }
+      }
+    }
+
+    // Load the configuration of the entity reference fields.
+    $field_configs = $this->entityTypeManager
+      ->getStorage('field_config')
+      ->loadMultiple($ids);
+
+    // Check if the fields reference the vocabulary. If so, get list of bundles
+    // that use those fields.
+    $bundles = [];
+    foreach ($field_configs as $field_config) {
+      $field_name = $field_config->getName();
+      $entity_type_id = $field_config->getTargetEntityTypeId();
+
+      if ($field_config->getSetting('target_type') === 'taxonomy_term') {
+        $handler_settings = $field_config->getSetting('handler_settings');
+        if (isset($handler_settings['target_bundles'][$vocabulary])) {
+          $bundles += $entity_reference_fields[$entity_type_id][$field_name]['bundles'];
+        }
+      }
+    }
+
+    // Exclude bundles that are not indexed in the API.
+    return array_keys(array_intersect_key(Bundles::$bundles, $bundles));
   }
 
 }

--- a/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
+++ b/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
@@ -217,7 +217,12 @@ class ReliefWebApiCommands extends DrushCommands {
       }
     }
     catch (\Exception $exception) {
-      $this->logger->error('(' . $exception->getCode() . ') ' . $exception->getMessage());
+      if ($exception->getMessage() !== 'No entity to index.') {
+        $this->logger->error('(' . $exception->getCode() . ') ' . $exception->getMessage());
+      }
+      else {
+        $this->logger->notice($exception->getMessage());
+      }
     }
   }
 

--- a/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
+++ b/html/modules/custom/reliefweb_api/src/Commands/ReliefWebApiCommands.php
@@ -342,6 +342,7 @@ class ReliefWebApiCommands extends DrushCommands {
     $this->state->set('reliefweb_api.reindex_queue', []);
 
     if (empty($reindex_queue)) {
+      $this->logger->info('No terms queued for re-indexing');
       return;
     }
 
@@ -369,6 +370,7 @@ class ReliefWebApiCommands extends DrushCommands {
 
       $options['filter'] = $bundle . ':' . implode(',', array_unique($ids));
       foreach ($bundles_to_reindex as $bundle_to_reindex) {
+        $this->logger->info('Re-indexing ' . $bundle_to_reindex . ' resources');
         $this->index($bundle_to_reindex, $options);
       }
     }

--- a/html/modules/custom/reliefweb_entities/src/BundleTaxonomyTermStorage.php
+++ b/html/modules/custom/reliefweb_entities/src/BundleTaxonomyTermStorage.php
@@ -14,9 +14,6 @@ class BundleTaxonomyTermStorage extends TermStorage implements BundleEntityStora
    * {@inheritdoc}
    */
   public function save(EntityInterface $entity) {
-
-    $this->invokeHook('before_save', $entity);
-
     parent::save($entity);
 
     $this->invokeHook('after_save', $entity);

--- a/html/modules/custom/reliefweb_entities/src/BundleTaxonomyTermStorage.php
+++ b/html/modules/custom/reliefweb_entities/src/BundleTaxonomyTermStorage.php
@@ -14,6 +14,9 @@ class BundleTaxonomyTermStorage extends TermStorage implements BundleEntityStora
    * {@inheritdoc}
    */
   public function save(EntityInterface $entity) {
+
+    $this->invokeHook('before_save', $entity);
+
     parent::save($entity);
 
     $this->invokeHook('after_save', $entity);


### PR DESCRIPTION
Refs: RW-588

Includes a new entity_before_save hook, which was added reluctantly. I had
trouble getting the unchanged content of the entity in hook_entity_update or
hook_entity_after_save.