### PR TITLE
[RW-594] Add a created field to taxonomy terms

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.install
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Install file for reliefweb_entities.
+ */
+
+/**
+ * Implements hook_update_N().
+ *
+ * Add the created field to the taxonomy terms.
+ */
+function reliefweb_entities_update_9001() {
+  $definition = reliefweb_entities_get_taxonomy_term_created_field_definition();
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('created', 'taxonomy_term', 'taxonomy', $definition);
+}

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\reliefweb_entities\BundleEntityInterface;
@@ -21,6 +22,39 @@ use Drupal\reliefweb_utility\Helpers\MailHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\taxonomy\TermInterface;
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Add a created field to taxonomy terms as Drupal Core is not yet doing that.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/2869432
+ */
+function reliefweb_entities_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+
+  switch ($entity_type->id()) {
+    case 'taxonomy_term':
+      $fields['created'] = reliefweb_entities_get_taxonomy_term_created_field_definition();
+      break;
+  }
+
+  return $fields;
+}
+
+/**
+ * Get the taxonomy term "created" field definition.
+ *
+ * @return \Drupal\Core\Field\BaseFieldDefinition
+ *   Field definition.
+ */
+function reliefweb_entities_get_taxonomy_term_created_field_definition() {
+  return BaseFieldDefinition::create('created')
+    ->setLabel(t('Created'))
+    ->setDescription(t('The time that the term was created.'))
+    ->setReadOnly(TRUE)
+    ->setTranslatable(TRUE);
+}
 
 /**
  * Implements hook_entity_bundle_field_info_alter().

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.post_update.php
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.post_update.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Post update file for reliefweb_entities.
+ */
+
+/**
+ * Implements hook_post_update_NAME().
+ *
+ * Populate the created field of taxonomy terms.
+ */
+function reliefweb_entities_post_update_populate_created_value() {
+  $database = \Drupal::database();
+  $timestamp = time();
+
+  // Set the created value to the oldest revision timestamp if it exists or
+  // the current time otherwise.
+  $database->query('
+    UPDATE {taxonomy_term_field_data} AS td
+    LEFT JOIN (
+      SELECT tr.tid AS tid, MIN(tr.revision_created) AS timestamp
+      FROM {taxonomy_term_revision} AS tr
+      GROUP BY tr.tid
+    ) AS subquery
+    ON subquery.tid = td.tid
+    SET td.created = COALESCE(subquery.timestamp, :timestamp)
+  ', [
+    'timestamp' => $timestamp,
+  ]);
+
+  // For disasters with an event date, override the created date with it.
+  $database->query('
+    UPDATE {taxonomy_term_field_data} AS td
+    INNER JOIN {taxonomy_term__field_disaster_date} AS fd
+    ON fd.entity_id = td.tid AND fd.bundle = :bundle
+    SET td.created = UNIX_TIMESTAMP(fd.field_disaster_date_value)
+  ', [
+    ':bundle' => 'disaster',
+  ]);
+
+  // Invalidate the taxonomy term cache.
+  \Drupal::service('cache_tags.invalidator')
+    ->invalidateTags(['taxonomy_term_list']);
+
+  return t('Taxonomy term created value populated.');
+}


### PR DESCRIPTION
Refs: RW-594

Sister PR of: https://github.com/UN-OCHA/rwint-api-indexer/pull/39 and https://github.com/UN-OCHA/rwint-api/pull/96

Taxonomy terms don't have a "created" field: https://www.drupal.org/project/drupal/issues/2869432

So this adds a "created" field to taxonomy terms and populate it with the oldest revision timestamp or the event date for disasters for compatibility with what is currently returned by the RW API.

**Note 1**: once https://github.com/UN-OCHA/rwint-api-indexer/pull/39 is merged and a new release created, we'll have to update the version in the rwint9-site repo.

**Note 2**: once deployed, we'll need to do a full re-indexing of the countries, disasters and sources with a new index tag to take into account the updated ES schemas.
