### PR TITLE
[RW-594] Bump api indexer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "league/html-to-markdown": "^5.0",
         "lolli42/finediff": "^1.0",
         "pelago/emogrifier": "^6.0",
-        "reliefweb/api-indexer": "^v2.2",
+        "reliefweb/api-indexer": "^v2.3",
         "reliefweb/simple-autocomplete": "^v1.3",
         "reliefweb/simple-datepicker": "^v1.3",
         "symfony/flex": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -8910,16 +8910,16 @@
         },
         {
             "name": "reliefweb/api-indexer",
-            "version": "v2.2.5",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/rwint-api-indexer.git",
-                "reference": "0a281b9bde0f0bc39c690457bda309074aee7ee5"
+                "reference": "016639dfcc68129c733da3aaff3d3064bb4c3bb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/rwint-api-indexer/zipball/0a281b9bde0f0bc39c690457bda309074aee7ee5",
-                "reference": "0a281b9bde0f0bc39c690457bda309074aee7ee5",
+                "url": "https://api.github.com/repos/UN-OCHA/rwint-api-indexer/zipball/016639dfcc68129c733da3aaff3d3064bb4c3bb7",
+                "reference": "016639dfcc68129c733da3aaff3d3064bb4c3bb7",
                 "shasum": ""
             },
             "require": {
@@ -8945,9 +8945,9 @@
             ],
             "support": {
                 "issues": "https://github.com/UN-OCHA/rwint-api-indexer/issues",
-                "source": "https://github.com/UN-OCHA/rwint-api-indexer/tree/v2.2.5"
+                "source": "https://github.com/UN-OCHA/rwint-api-indexer/tree/v2.3.0"
             },
-            "time": "2022-07-05T23:21:00+00:00"
+            "time": "2022-07-12T00:04:50+00:00"
         },
         {
             "name": "reliefweb/simple-autocomplete",


### PR DESCRIPTION
Refs: RW-594

Follow up of https://github.com/UN-OCHA/rwint9-site/pull/406 to bump the api-indexer to the version that index the date fields for countries, disasters and sources.