### PR TITLE
[RW-615] Fix moderation backend date filter

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -852,6 +852,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
           'shortcut' => 'cd',
           'form' => 'omnibox',
           'widget' => 'datepicker',
+          'condition_callback' => 'addDateFilterCondition',
         ],
         'registration_deadline' => [
           'type' => 'field',
@@ -861,6 +862,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
           'shortcut' => 'rd',
           'form' => 'omnibox',
           'widget' => 'datepicker',
+          'condition_callback' => 'addDateFilterCondition',
         ],
         'disaster_date' => [
           'type' => 'field',
@@ -870,6 +872,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
           'shortcut' => 'cd',
           'form' => 'omnibox',
           'widget' => 'datepicker',
+          'condition_callback' => 'addDateFilterCondition',
         ],
         'author' => [
           'type' => 'property',
@@ -1625,6 +1628,49 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
       else {
         $base->condition($fields, $value, $operator);
       }
+    }
+  }
+
+  /**
+   * Add a date filter condition with the given values to the base condition.
+   *
+   * The date fields store the date in `Y-m-d` format so we need to convert
+   * them to timestamp for comparison with the start and/or end dates which are
+   * timestamps.
+   *
+   * @param array $definition
+   *   Field definition.
+   * @param \Drupal\Core\Database\Query\Condition $base
+   *   Base condition to add the field conditions to.
+   * @param string|array $fields
+   *   Field(s) on which to add the condtion.
+   * @param mixed $value
+   *   Value for the condition.
+   * @param string|null $operator
+   *   Operator for the condition.
+   */
+  protected function addDateFilterCondition(array $definition, Condition $base, $fields, $value, $operator = NULL) {
+    // Skip.
+    if (empty($fields)) {
+      return;
+    }
+
+    if (is_array($fields)) {
+      if (count($fields) > 1) {
+        $condition = new Condition('OR');
+        foreach ($fields as $field) {
+          $condition->where("UNIX_TIMESTAMP(${field}) ${operator} ${value}");
+        }
+        $base->condition($condition);
+      }
+      else {
+        $field = reset($field);
+        $base->where("UNIX_TIMESTAMP(${field}) ${operator} ${value}");
+      }
+    }
+    else {
+      $field = $fields;
+      $base->where("UNIX_TIMESTAMP(${field}) ${operator} ${value}");
     }
   }
 


### PR DESCRIPTION
Refs: RW-615

Date fields store the value in the `Y-m-d` format so we need to convert them to timestamps to compare with the filter values.

Affected fields:
- field_job_closing_date
- field_registration_deadline
- field_disaster_date

The `field_training_date` would be affected to but there is no filter on it (not requested).