### PR TITLE
[RW-621] Disable form submission during ajax requests

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -59,6 +59,10 @@ libraries-extend:
   reliefweb-guidelines/reliefweb-guidelines:
     - common_design_subtheme/rw-guidelines
 
+  # Core ajax.
+  core/drupal.ajax:
+    - common_design_subtheme/cd-ajax-disable-submit-buttons
+
 # Use the common_design_subtheme styles inside the editor.
 ckeditor_stylesheets:
   - css/styles.css

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -14,6 +14,11 @@ global-styling:
     - common_design_subtheme/rw-site-slogan
     - common_design_subtheme/rw-page-title
 
+# Disable submit buttons during ajax requests.
+cd-ajax-disable-submit-buttons:
+  js:
+    js/cd-ajax-disable-submit-buttons.js: {}
+
 # RW custom components
 rw-admin-menu:
   css:

--- a/html/themes/custom/common_design_subtheme/js/cd-ajax-disable-submit-buttons.js
+++ b/html/themes/custom/common_design_subtheme/js/cd-ajax-disable-submit-buttons.js
@@ -1,0 +1,74 @@
+/**
+ * Handle enabling/disabling submit buttons when an ajax request is performed.
+ *
+ * Note: this can conflict with other things enabling/disabling submit buttons
+ * like form states.
+ *
+ * @todo Possibly refactor to add an event handler that disables the form
+ * submission with a message instead of disabling the form elements but that
+ * may also conflict with other event handlers.
+ *
+ * @see core/misc/ajax.js
+ */
+(function (Drupal) {
+
+  'use strict';
+
+  // Store the Drupal core ajax methods so we can call them in the overrides.
+  var beforeSend = Drupal.Ajax.prototype.beforeSend;
+  var success = Drupal.Ajax.prototype.success;
+  var error = Drupal.Ajax.prototype.error;
+
+  // Disable/Enable form submit buttons when an ajax event is performed.
+  Drupal.Ajax.prototype.disableSubmitButtons = function (disable) {
+    if (this.element && this.element.form) {
+      // Store a counter that is incremented when an ajax request is performed
+      // and decremented when the request is finished (success or error).
+      // We only re-enable the submit buttons when there are no ajax request
+      // being performed anymore. This prevents premature re-enabling when there
+      // are several concurrent ajax requests.
+      var counter = 0;
+      if (this.element.form.hasAttribute('data-ajax-disable-submit-buttons-counter')) {
+        counter = parseInt(this.element.form.getAttribute('data-ajax-disable-submit-buttons-counter'), 10);
+      }
+      if (disable === true) {
+        counter++;
+      }
+      else if (counter > 0) {
+        counter--;
+      }
+      this.element.form.setAttribute('data-ajax-disable-submit-buttons-counter', counter);
+
+      // Disable/enable the buttons.
+      if (disable === true || counter === 0) {
+        // We only disable the form submit buttons so that it's still possible
+        // to perform parallel requests like uploading files in different
+        // fields.
+        var selector = '.form-actions .form-submit';
+        var elements = this.element.form.querySelectorAll(selector);
+        for (var i = 0, l = elements.length; i < l; i++) {
+          elements[i].disabled = disable;
+        }
+      }
+    }
+  };
+
+  // Disable form submit buttons before sending the ajax request.
+  Drupal.Ajax.prototype.beforeSend = function (xmlhttprequest, options) {
+    this.disableSubmitButtons(true);
+    beforeSend.call(this, xmlhttprequest, options);
+  };
+
+  // Enable form submit buttons before handling the response's success.
+  Drupal.Ajax.prototype.success = function (xmlhttprequest, options) {
+    this.disableSubmitButtons(false);
+    success.call(this, xmlhttprequest, options);
+  };
+
+  // Enable form submit buttons before handling the response's error.
+  Drupal.Ajax.prototype.error = function (xmlhttprequest, options) {
+    this.disableSubmitButtons(false);
+    error.call(this, xmlhttprequest, options);
+  };
+
+})(Drupal);


### PR DESCRIPTION
Refs: RW-621

This adds a script added when `ajax.js` is added to a form for example, that disables the form submit buttons while an ajax request is being performed (ex: file/image upload) to prevent mistakes.

Note: this could be added to the CD's subtheme with the following commented out in the `common_design_subtheme.info.yml`

```yaml
  # Core ajax.
  core/drupal.ajax:
    - common_design_subtheme/cd-ajax-disable-submit-buttons
```

so that devs could enable this behavior if interested.

## Test

1. In your browser of choice, if the option is available, set some throttling so that you can see the effect (ex: Firefox dev tools > Network tab > Throttling -> Regular 3G)
2. Go to the `report` form go the "Files" section, upload a large enough file (ex: 500Kb if throttling is enabled)
3. While the file is being uploaded, go to "Save" section and check that the buttons are disabled
4. When the upload is finished, check that the buttons are enabled

To test that the buttons are also properly re-enabled when an ajax request fails, select a file with an unsupported file extension (i.e. not in `csv doc docx jpg jpeg odp ods odt pdf png pps ppt pptx svg xls xlsx zip` and follow the step above. The upload will fail (ajax error) but the buttons will be re-enabled.