### PR TITLE
[RW-622] Editing taxonomy terms

### DIFF
--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -37,6 +37,7 @@ weight: 4
 is_admin: null
 permissions:
   - 'access editorial guidelines'
+  - 'access taxonomy overview'
   - 'add content to books'
   - 'add guideline entities'
   - 'administer google tag manager'

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -13,6 +13,7 @@ use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Render\Element;
 use Drupal\reliefweb_entities\BundleEntityInterface;
 use Drupal\reliefweb_entities\BundleEntityStorageInterface;
 use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
@@ -412,6 +413,37 @@ function reliefweb_entities_form_taxonomy_term_form_alter(array &$form, FormStat
   // Add an entity builder callback that will ensure the proper revisio
   // user id and timestamp are set.
   $form['#entity_builders'][] = 'reliefweb_entities_term_form_entity_builder';
+}
+
+/**
+ * Implements hook_form_HOOK_alter() for "taxonomy_overview_vocabularies".
+ */
+function reliefweb_entities_form_taxonomy_overview_vocabularies_alter(array &$form, FormStateInterface $form_state) {
+  // Prevent re-ordering the vocabularies without the appropriate permission.
+  if (!\Drupal::currentUser()->hasPermission('administer taxonomy')) {
+    $form['actions']['#access'] = FALSE;
+    unset($form['vocabularies']['#tabledrag']);
+    unset($form['vocabularies']['#header']['weight']);
+    foreach (Element::children($form['vocabularies']) as $key) {
+      unset($form['vocabularies'][$key]['weight']);
+    }
+  }
+}
+
+/**
+ * Implements hook_form_HOOK_alter() for "taxonomy_overview_terms".
+ */
+function reliefweb_entities_form_taxonomy_overview_terms_alter(array &$form, FormStateInterface $form_state) {
+  // Prevent re-ordering the terms without the appropriate permission.
+  if (!\Drupal::currentUser()->hasPermission('administer taxonomy')) {
+    $form['actions']['#access'] = FALSE;
+    $form['help']['#access'] = FALSE;
+    unset($form['terms']['#tabledrag']);
+    unset($form['terms']['#header']['weight']);
+    foreach (Element::children($form['terms']) as $key) {
+      unset($form['terms'][$key]['weight']);
+    }
+  }
 }
 
 /**

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.services.yml
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.services.yml
@@ -39,3 +39,6 @@ services:
   reliefweb_entities.training.form_alter:
     class: Drupal\reliefweb_entities\Services\TrainingFormAlter
     arguments: ['@database', '@current_user', '@entity_field.manager', '@entity_type.manager', '@state', '@string_translation']
+  reliefweb_entities.taxonomy_term.form_alter:
+    class: Drupal\reliefweb_entities\Services\TaxonomyTermFormAlter
+    arguments: ['@database', '@current_user', '@entity_field.manager', '@entity_type.manager', '@state', '@string_translation']

--- a/html/modules/custom/reliefweb_entities/src/Entity/TaxonomyTermBase.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/TaxonomyTermBase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\reliefweb_entities\Entity;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\reliefweb_entities\BundleEntityInterface;
+use Drupal\reliefweb_moderation\EntityModeratedInterface;
+use Drupal\reliefweb_moderation\EntityModeratedTrait;
+use Drupal\reliefweb_revisions\EntityRevisionedInterface;
+use Drupal\reliefweb_revisions\EntityRevisionedTrait;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Default bundle class for taxonomy terms.
+ */
+class TaxonomyTermBase extends Term implements BundleEntityInterface, EntityModeratedInterface, EntityRevisionedInterface {
+
+  use EntityRevisionedTrait;
+  use EntityModeratedTrait;
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getApiResource() {
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function addFieldConstraints(&$fields) {
+    // No specific constraints.
+  }
+
+}

--- a/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
+++ b/html/modules/custom/reliefweb_entities/src/EntityFormAlterServiceBase.php
@@ -920,9 +920,9 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
   /**
    * {@inheritdoc}
    */
-  public static function getFormAlterService($bundle) {
+  public static function getFormAlterService($name) {
     try {
-      return \Drupal::service('reliefweb_entities.' . $bundle . '.form_alter');
+      return \Drupal::service('reliefweb_entities.' . $name . '.form_alter');
     }
     catch (ServiceNotFoundException $exception) {
       return NULL;
@@ -936,6 +936,9 @@ abstract class EntityFormAlterServiceBase implements EntityFormAlterServiceInter
     $form_object = $form_state->getFormObject();
     if (isset($form_object) && $form_object instanceof ContentEntityForm) {
       $service = static::getFormAlterService($form_object->getEntity()->bundle());
+      if (empty($service)) {
+        $service = static::getFormAlterService($form_object->getEntity()->getEntityTypeId());
+      }
       if (!empty($service)) {
         $service->alterForm($form, $form_state);
       }

--- a/html/modules/custom/reliefweb_entities/src/Services/TaxonomyTermFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/TaxonomyTermFormAlter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\reliefweb_entities\Services;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
+
+/**
+ * Default taxonomy term form alteration service.
+ */
+class TaxonomyTermFormAlter extends EntityFormAlterServiceBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterForm(array &$form, FormStateInterface $form_state) {
+    parent::alterForm($form, $form_state);
+
+    // Restrict the description to the plain_text format.
+    $form['description']['widget'][0]['#format'] = 'plain_text';
+    $form['description']['widget'][0]['#allowed_formats'] = [
+      'plain_text' => 'plain_text',
+    ];
+
+    // Hide term relations as they are not used.
+    $form['relations']['#access'] = FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function addBundleFormAlterations(array &$form, FormStateInterface $form_state) {
+    // No customizations.
+  }
+
+}

--- a/html/themes/custom/common_design_subtheme/templates/block/block--local-actions-block.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/block/block--local-actions-block.html.twig
@@ -1,0 +1,12 @@
+{% extends "block.html.twig" %}
+{#
+/**
+ * @file
+ * Theme override for local actions (primary admin actions.)
+ */
+#}
+{% block content %}
+  {% if content %}
+    <nav class="action-links"><ul>{{ content }}</ul></nav>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Refs: RW-622

This PR adds a missing permission for the Webmaster role to view the list of vocabularies at  `/admin/structure/taxonomy` (Admin menu > Manage > Taxonomy), so that they can notably change the term descriptions used in the popup in the job/training form for example. (This just restores the behavior from RW7.)

It also gives some love to the taxonomy forms to ease the edition of the terms:
- Disallow re-ordering the vocabularies and terms to prevent mistakes (like setting a term as a child of another term which is not something currently allowed on RW)
- Restrict the description text format to "plain text" (like on RW7)
- Show the revision history

### Test

1. Log in with an Editor account, check that you cannot access `/admin/structure/taxonomy` and `/taxonomy/term/12570/edit` for example.
2. Log in with a Webmaster account, check that you have access to the pages above and can edit the term
3. Check that the changes to the term are reflected in the revision history
4. Check that using some markdown like markup for the description doesn't result in the this markup being converted to HTML when viewing the term `/taxonomy/term/12570`
