### PR TITLE
[RW-624] Guideline preview

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "687ff3598a1528e7325a51c23477da0a",
+    "content-hash": "1e82696744ff579e5a3d9cf303eca2f4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3072,17 +3072,17 @@
         },
         {
             "name": "drupal/guidelines",
-            "version": "1.0.4",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/guidelines.git",
-                "reference": "1.0.4"
+                "reference": "1.0.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/guidelines-1.0.4.zip",
-                "reference": "1.0.4",
-                "shasum": "8d20ef379a1f69d481e05d343129d33e01ec9f4a"
+                "url": "https://ftp.drupal.org/files/projects/guidelines-1.0.3.zip",
+                "reference": "1.0.3",
+                "shasum": "04ac058c7d3b7a3b7cbab376354801599f048880"
             },
             "require": {
                 "drupal/core": "^9"
@@ -3090,8 +3090,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.4",
-                    "datestamp": "1658140577",
+                    "version": "1.0.3",
+                    "datestamp": "1646999982",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e82696744ff579e5a3d9cf303eca2f4",
+    "content-hash": "687ff3598a1528e7325a51c23477da0a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3072,17 +3072,17 @@
         },
         {
             "name": "drupal/guidelines",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/guidelines.git",
-                "reference": "1.0.3"
+                "reference": "1.0.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/guidelines-1.0.3.zip",
-                "reference": "1.0.3",
-                "shasum": "04ac058c7d3b7a3b7cbab376354801599f048880"
+                "url": "https://ftp.drupal.org/files/projects/guidelines-1.0.4.zip",
+                "reference": "1.0.4",
+                "shasum": "8d20ef379a1f69d481e05d343129d33e01ec9f4a"
             },
             "require": {
                 "drupal/core": "^9"
@@ -3090,8 +3090,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.3",
-                    "datestamp": "1646999982",
+                    "version": "1.0.4",
+                    "datestamp": "1658140577",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/html/modules/custom/reliefweb_guidelines/src/Controller/GuidelineSinglePageController.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Controller/GuidelineSinglePageController.php
@@ -54,7 +54,6 @@ class GuidelineSinglePageController extends ControllerBase {
     $this->cache = $cache_backend;
     $this->currentUser = $current_user;
     $this->entityTypeManager = $entity_type_manager;
-    $this->extensionPathResolver = $extension_path_resolver;
   }
 
   /**

--- a/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
@@ -93,7 +93,7 @@ class GuidelineForm extends ContentEntityForm {
 
     // Attempt to load from preview when the uuid is present unless we are
     // rebuilding the form.
-    $request_uuid = $this->requestStack->getCurrentRequest()->query->get('uuid');
+    $request_uuid = $this->getRequest()->query->get('uuid');
     if (!$form_state->isRebuilding() && $request_uuid && $preview = $store->get($request_uuid)) {
       /** @var \Drupal\Core\Form\FormStateInterface $preview */
 
@@ -227,7 +227,7 @@ class GuidelineForm extends ContentEntityForm {
    *
    * @param array $form
    *   An associative array containing the structure of the form.
-   * @param Drupal\Core\Form\FormStateInterface $form_state
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The current state of the form.
    */
   public function preview(array $form, FormStateInterface $form_state) {

--- a/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
@@ -2,9 +2,15 @@
 
 namespace Drupal\reliefweb_guidelines\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Link;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -16,26 +22,98 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class GuidelineForm extends ContentEntityForm {
 
   /**
-   * The current user account.
+   * The tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * The Current User object.
    *
    * @var \Drupal\Core\Session\AccountProxyInterface
    */
-  protected $account;
+  protected $currentUser;
+
+  /**
+   * The request stack.
+   *
+   * @var \Drupal\Core\Http\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    TimeInterface $time,
+    PrivateTempStoreFactory $temp_store_factory,
+    AccountProxyInterface $current_user,
+    RequestStack $request_stack,
+  ) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
+    $this->tempStoreFactory = $temp_store_factory;
+    $this->currentUser = $current_user;
+    $this->requestStack = $request_stack;
+  }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    // Instantiates this form class.
-    $instance = parent::create($container);
-    $instance->account = $container->get('current_user');
-    return $instance;
+    return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
+      $container->get('tempstore.private'),
+      $container->get('current_user'),
+      $container->get('request_stack'),
+    );
+  }
+
+  /**
+   * Get the current user.
+   *
+   * @return \Drupal\Core\Session\AccountProxyInterface
+   *   The current user.
+   */
+  protected function currentUser() {
+    return $this->currentUser;
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    // Try to restore from temp store, this must be done before calling
+    // parent::form().
+    $store = $this->tempStoreFactory->get('guideline_preview');
+
+    // Attempt to load from preview when the uuid is present unless we are
+    // rebuilding the form.
+    $request_uuid = $this->getRequest()->query->get('uuid');
+    if (!$form_state->isRebuilding() && $request_uuid && $preview = $store->get($request_uuid)) {
+      /** @var \Drupal\Core\Form\FormStateInterface $preview */
+
+      $form_state->setStorage($preview->getStorage());
+      $form_state->setUserInput($preview->getUserInput());
+
+      // Rebuild the form.
+      $form_state->setRebuild();
+
+      // The combination of having user input and rebuilding the form means
+      // that it will attempt to cache the form state which will fail if it is
+      // a GET request.
+      $form_state->setRequestMethod('POST');
+
+      $this->entity = $preview->getFormObject()->getEntity();
+      $this->entity->in_preview = NULL;
+
+      $form_state->set('has_been_previewed', TRUE);
+    }
+
     /** @var \Drupal\guidelines\Entity\Guideline $this->entity */
     $form = parent::buildForm($form, $form_state);
 
@@ -122,13 +200,65 @@ class GuidelineForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
+  protected function actions(array $form, FormStateInterface $form_state) {
+    $element = parent::actions($form, $form_state);
+    $guideline = $this->entity;
+    $preview_mode = $guideline->type->entity->getPreviewMode();
+
+    $element['submit']['#access'] = $preview_mode != DRUPAL_REQUIRED || $form_state->get('has_been_previewed');
+
+    $element['preview'] = [
+      '#type' => 'submit',
+      '#access' => $preview_mode != DRUPAL_DISABLED && ($guideline->access('create') || $guideline->access('update')),
+      '#value' => $this->t('Preview'),
+      '#weight' => 20,
+      '#submit' => ['::submitForm', '::preview'],
+    ];
+
+    if (array_key_exists('delete', $element)) {
+      $element['delete']['#weight'] = 100;
+    }
+
+    return $element;
+  }
+
+  /**
+   * Form submission handler for the 'preview' action.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function preview(array $form, FormStateInterface $form_state) {
+    $store = $this->tempStoreFactory->get('guideline_preview');
+    $this->entity->in_preview = TRUE;
+    $store->set($this->entity->uuid(), $form_state);
+
+    $route_parameters = [
+      'guideline_preview' => $this->entity->uuid(),
+      'view_mode_id' => 'full',
+    ];
+
+    $options = [];
+    $query = $this->getRequest()->query;
+    if ($query->has('destination')) {
+      $options['query']['destination'] = $query->get('destination');
+      $query->remove('destination');
+    }
+    $form_state->setRedirect('entity.guideline.preview', $route_parameters, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
 
     // Always create a new revision.
     $entity->setNewRevision(TRUE);
     $entity->setRevisionCreationTime($this->time->getRequestTime());
-    $entity->setRevisionUserId($this->account->id());
+    $entity->setRevisionUserId($this->currentUser()->id());
 
     $status = parent::save($form, $form_state);
 
@@ -146,6 +276,10 @@ class GuidelineForm extends ContentEntityForm {
     }
 
     $form_state->setRedirect('entity.guideline.canonical', ['guideline' => $entity->id()]);
+
+    // Remove the preview entry from the temp store, if any.
+    $store = $this->tempStoreFactory->get('guideline_preview');
+    $store->delete($entity->uuid());
   }
 
 }

--- a/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
@@ -2,9 +2,15 @@
 
 namespace Drupal\reliefweb_guidelines\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Link;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -16,26 +22,98 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class GuidelineForm extends ContentEntityForm {
 
   /**
-   * The current user account.
+   * The tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * The Current User object.
    *
    * @var \Drupal\Core\Session\AccountProxyInterface
    */
-  protected $account;
+  protected $currentUser;
+
+  /**
+   * The request stack.
+   *
+   * @var \Drupal\Core\Http\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    TimeInterface $time,
+    PrivateTempStoreFactory $temp_store_factory,
+    AccountProxyInterface $current_user,
+    RequestStack $request_stack,
+  ) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
+    $this->tempStoreFactory = $temp_store_factory;
+    $this->currentUser = $current_user;
+    $this->requestStack = $request_stack;
+  }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    // Instantiates this form class.
-    $instance = parent::create($container);
-    $instance->account = $container->get('current_user');
-    return $instance;
+    return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
+      $container->get('tempstore.private'),
+      $container->get('current_user'),
+      $container->get('request_stack'),
+    );
+  }
+
+  /**
+   * Get the current user.
+   *
+   * @return \Drupal\Core\Session\AccountProxyInterface
+   *   The current user.
+   */
+  protected function currentUser() {
+    return $this->currentUser;
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    // Try to restore from temp store, this must be done before calling
+    // parent::form().
+    $store = $this->tempStoreFactory->get('guideline_preview');
+
+    // Attempt to load from preview when the uuid is present unless we are
+    // rebuilding the form.
+    $request_uuid = $this->requestStack->getCurrentRequest()->query->get('uuid');
+    if (!$form_state->isRebuilding() && $request_uuid && $preview = $store->get($request_uuid)) {
+      /** @var \Drupal\Core\Form\FormStateInterface $preview */
+
+      $form_state->setStorage($preview->getStorage());
+      $form_state->setUserInput($preview->getUserInput());
+
+      // Rebuild the form.
+      $form_state->setRebuild();
+
+      // The combination of having user input and rebuilding the form means
+      // that it will attempt to cache the form state which will fail if it is
+      // a GET request.
+      $form_state->setRequestMethod('POST');
+
+      $this->entity = $preview->getFormObject()->getEntity();
+      $this->entity->in_preview = NULL;
+
+      $form_state->set('has_been_previewed', TRUE);
+    }
+
     /** @var \Drupal\guidelines\Entity\Guideline $this->entity */
     $form = parent::buildForm($form, $form_state);
 
@@ -122,13 +200,65 @@ class GuidelineForm extends ContentEntityForm {
   /**
    * {@inheritdoc}
    */
+  protected function actions(array $form, FormStateInterface $form_state) {
+    $element = parent::actions($form, $form_state);
+    $guideline = $this->entity;
+    $preview_mode = $guideline->type->entity->getPreviewMode();
+
+    $element['submit']['#access'] = $preview_mode != DRUPAL_REQUIRED || $form_state->get('has_been_previewed');
+
+    $element['preview'] = [
+      '#type' => 'submit',
+      '#access' => $preview_mode != DRUPAL_DISABLED && ($guideline->access('create') || $guideline->access('update')),
+      '#value' => $this->t('Preview'),
+      '#weight' => 20,
+      '#submit' => ['::submitForm', '::preview'],
+    ];
+
+    if (array_key_exists('delete', $element)) {
+      $element['delete']['#weight'] = 100;
+    }
+
+    return $element;
+  }
+
+  /**
+   * Form submission handler for the 'preview' action.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function preview(array $form, FormStateInterface $form_state) {
+    $store = $this->tempStoreFactory->get('guideline_preview');
+    $this->entity->in_preview = TRUE;
+    $store->set($this->entity->uuid(), $form_state);
+
+    $route_parameters = [
+      'guideline_preview' => $this->entity->uuid(),
+      'view_mode_id' => 'full',
+    ];
+
+    $options = [];
+    $query = $this->getRequest()->query;
+    if ($query->has('destination')) {
+      $options['query']['destination'] = $query->get('destination');
+      $query->remove('destination');
+    }
+    $form_state->setRedirect('entity.guideline.preview', $route_parameters, $options);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
 
     // Always create a new revision.
     $entity->setNewRevision(TRUE);
     $entity->setRevisionCreationTime($this->time->getRequestTime());
-    $entity->setRevisionUserId($this->account->id());
+    $entity->setRevisionUserId($this->currentUser()->id());
 
     $status = parent::save($form, $form_state);
 
@@ -146,6 +276,10 @@ class GuidelineForm extends ContentEntityForm {
     }
 
     $form_state->setRedirect('entity.guideline.canonical', ['guideline' => $entity->id()]);
+
+    // Remove the preview entry from the temp store, if any.
+    $store = $this->tempStoreFactory->get('guideline_preview');
+    $store->delete($entity->uuid());
   }
 
 }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -74,3 +74,7 @@ libraries-override:
     css:
       component:
         components/guidelines-json/guidelines-json.css: false
+  guidelines/guideline.preview:
+    css:
+      component:
+        components/preview/guidelines.preview.css: components/rw-guidelines/rw-guidelines--preview.css

--- a/html/themes/custom/common_design_subtheme/components/rw-guidelines/rw-guidelines--preview.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-guidelines/rw-guidelines--preview.css
@@ -1,0 +1,51 @@
+.guideline-preview-container {
+  padding: 0;
+}
+.guideline-preview-container header {
+  position: sticky;
+  height: 40px;
+  text-align: center;
+  color: var(--cd-white);
+  background: var(--cd-red);
+}
+.guideline-preview-container header h3 {
+  height: 40px;
+  margin: 0;
+  color: var(--cd-white);
+  line-height: 40px;
+}
+.guideline-preview-container .form-type-select {
+  margin-left: 0;
+}
+.guideline-preview-form-select .guideline-preview-backlink {
+  position: absolute;
+  z-index: 1000;
+  top: 40px; /* Height of Preview header */
+  left: 50%;
+  display: inline-block;
+  padding: 2px 8px 4px;
+  transform: translateX(-50%);
+  color: var(--cd-white);
+  border-radius: 0 0 10px 10px;
+  background: var(--cd-black);
+  font-size: var(--cd-font-size--small);
+  font-weight: 500;
+}
+.guideline-preview-form-select .guideline-preview-backlink:hover {
+  background: var(--brand-primary--dark);
+}
+.guideline-preview-form-select .form-item-view-mode {
+  /* Or hide View mode select element */
+  /* display: none; */
+  position: absolute;
+  top: 0;
+  left: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.guideline-preview-form-select .form-item-view-mode label {
+  flex: 1 0 auto;
+  margin-inline-end: 0.5rem;
+  color: var(--cd-black);
+}

--- a/html/themes/custom/common_design_subtheme/components/rw-preview/rw-preview.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-preview/rw-preview.css
@@ -1,12 +1,15 @@
+.guideline-preview-container header,
 .node-preview-container header,
 .term-preview-container header {
   background: var(--cd-reliefweb-brand-red--dark);
 }
+.guideline-preview-form-select .node-preview-backlink:hover,
 .node-preview-form-select .node-preview-backlink:hover,
 .term-preview-form-select .term-preview-backlink:hover {
   background: var(--cd-reliefweb-brand-blue);
 }
 /* Hide View mode select element */
+.guideline-preview-form-select .form-item-view-mode,
 .node-preview-form-select .form-item-view-mode,
 .term-preview-form-select .form-item-view-mode {
   display: none;

--- a/html/themes/custom/common_design_subtheme/templates/form/form--guideline-preview-form-select.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/form/form--guideline-preview-form-select.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Theme override for a 'form' element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the wrapper element.
+ * - children: The child elements of the form.
+ *
+ * @see template_preprocess_form()
+ */
+#}
+{{ attach_library('common_design/cd-form--preview') }}
+<header>
+  <h3>{{ 'Preview'|t }}</h3>
+</header>
+<form{{ attributes }}>
+  {{ children }}
+</form>


### PR DESCRIPTION
Reds: RW-624

This PR updates the GuidelineForm class override to handle the preview added in https://www.drupal.org/project/guidelines/releases/1.0.4 and style the preview to be consistent with the node and term preview on RW.

### Test

Run `composer install` after checking out the branch to update the `guidelines` module.

1. Open a guideline page
2. Edit it, make some changes
3. Click Preview, check that the preview looks like the guideline page from (1) but with the changes
4. Click a link and check that there is a confirmation popup
5. Click "back to content editing"
6. Check that changes from (2) are still present 
7. Save and check that the changes were applied