### PR TITLE
[RW-626] Fix posting rights filter on moderation backend

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/Helpers/UserPostingRightsHelper.php
+++ b/html/modules/custom/reliefweb_moderation/src/Helpers/UserPostingRightsHelper.php
@@ -59,13 +59,15 @@ class UserPostingRightsHelper {
         continue;
       }
 
+      // Default to unverified if the owner has no right defined for the source.
+      $right = 'unverified';
       foreach ($source_entity->get('field_user_posting_rights') as $item) {
         if ($item->get('id')->getValue() != $uid) {
           continue;
         }
-        $right = $item->get($bundle)->getValue();
-        $rights[$rights_keys[$right] ?? 'unverified']++;
+        $right = $rights_keys[$item->get($bundle)->getValue()] ?? 'unverified';
       }
+      $rights[$right]++;
     }
 
     // Compute the consolidated right for the user.

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -1884,8 +1884,8 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
 
     // Join the user posting rights table.
     $user_rights_table = $this->getFieldTableName('taxonomy_term', 'field_user_posting_rights');
-    $user_rights_id_field = $this->getFieldTableName('taxonomy_term', 'field_user_posting_rights', 'id');
-    $user_rights_bundle_field = $this->getFieldTableName('taxonomy_term', 'field_user_posting_rights', $bundle);
+    $user_rights_id_field = $this->getFieldColumnName('taxonomy_term', 'field_user_posting_rights', 'id');
+    $user_rights_bundle_field = $this->getFieldColumnName('taxonomy_term', 'field_user_posting_rights', $bundle);
     $user_rights_alias = $subquery->leftJoin($user_rights_table, $user_rights_table, "%alias.entity_id = {$source_alias}.{$source_field} AND %alias.{$user_rights_id_field} = {$users_alias}.uid");
 
     // Count the number of sources for a node for which the user has the


### PR DESCRIPTION
Ref: RW-626

There were actually 2 issues:

- Invalid query for the filter resulting in a PHP error
- Invalid logic to get the author posting rights in case there is no record for its account for a source (should be unverified).