### PR TITLE
[RW-513] Message for 403 on node page

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -14,11 +14,13 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Url;
 use Drupal\reliefweb_entities\BundleEntityInterface;
 use Drupal\reliefweb_entities\BundleEntityStorageInterface;
 use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
 use Drupal\reliefweb_utility\Helpers\ClassHelper;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
+use Drupal\reliefweb_utility\Helpers\EntityHelper;
 use Drupal\reliefweb_utility\Helpers\MailHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
@@ -738,4 +740,49 @@ function reliefweb_entities_menu_local_tasks_alter(&$data, $route_name, Refinabl
   if (isset($data['tabs'][0]['content_entity_clone.clone']['#link'])) {
     $data['tabs'][0]['content_entity_clone.clone']['#link']['localized_options']['attributes']['target'] = '_blank';
   }
+}
+
+/**
+ * Implements hook_preprocess_page__403().
+ *
+ * Add a user friendly message on inaccessible node pages to indicate it's
+ * no longer available (we assume the URL was previously accessible, which is
+ * probably true in most cases).
+ */
+function reliefweb_entities_preprocess_page__403(array &$variables) {
+  $route_info = \Drupal::service('router.no_access_checks')
+    ->matchRequest(\Drupal::request());
+
+  if (isset($route_info['node']) && $route_info['node'] instanceof BundleEntityInterface) {
+    $type = mb_strtolower(EntityHelper::getBundleLabelFromEntity($route_info['node']));
+    $title = $route_info['node']->label();
+    $anonymous = \Drupal::currentUser()->isAnonymous();
+
+    if ($anonymous && in_array($type, ['job', 'training'])) {
+      $message = t('The @type %title is no longer available.<br>If you posted this @type, please <a href="@url">log in</a> to get access.', [
+        '@type' => $type,
+        '%title' => $title,
+        '@url' => Url::fromUserInput('/user/login', [
+          'query' => \Drupal::destination()->getAsArray(),
+        ])->toString(),
+      ]);
+    }
+    else {
+      $message = t('The @type %title is no longer available.', [
+        '@type' => $type,
+        '%title' => $title,
+      ]);
+    }
+
+    $variables['page']['content']['message'] = [
+      '#type' => 'markup',
+      '#markup' => $message,
+    ];
+  }
+
+  // We need to vary the cache whether or not we are on a node page
+  // otherwise visiting a non node inaccessible page will cache the result
+  // and this preprocess hook implementation will not be called when visiting
+  // an inaccessible node page afterwards.
+  $variables['#cache']['contexts'][] = 'url.path';
 }

--- a/html/modules/custom/reliefweb_utility/src/Helpers/EntityHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/EntityHelper.php
@@ -46,6 +46,35 @@ class EntityHelper {
   }
 
   /**
+   * Get a bundle's label from an entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
+   *
+   * @return string
+   *   Bundle label.
+   */
+  public static function getBundleLabelFromEntity(EntityInterface $entity) {
+    return static::getBundleLabel($entity->getEntityTypeId(), $entity->bundle());
+  }
+
+  /**
+   * Get a bundle's label.
+   *
+   * @param string $entity_type_id
+   *   Entity type ID.
+   * @param string $bundle
+   *   Entity bundle.
+   *
+   * @return string
+   *   Bundle label.
+   */
+  public static function getBundleLabel($entity_type_id, $bundle) {
+    $bundle_info = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type_id);
+    return $bundle_info[$bundle]['label'] ?? $bundle;
+  }
+
+  /**
    * Format a revision log message.
    *
    * @param string $message

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--403.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--403.html.twig
@@ -19,6 +19,9 @@
             <header>
               <h1 class="rw-page-title">{{ '403 - Access denied'|t }}</h1>
             </header>
+            {% if page.content.message is not empty %}
+            <p><strong>{{ page.content.message }}</strong></p>
+            {% endif %}
             <p>{{ 'Sorry for any inconvenience.'|t }}</p>
             <p>{{ 'Here are some useful pages to help you get back on track:'|t }}</p>
             <div class="rw-entity-useful-links">


### PR DESCRIPTION
Refs: RW-513

This adds back the display of a message for node pages when access is denied to indicate the node is no longer available.

This takes the assumption that people getting a 403 is because the page previously accessible like a published job but is no longer available because the job has expired. The displayed message makes the 403 page a bit more user friendly:

<img width="1217" alt="Screen Shot 2022-07-20 at 10 59 00" src="https://user-images.githubusercontent.com/696348/179879429-7e30b8df-0030-4869-b886-e57ee4f575c6.png">

### Test

1. Log in and find or create a non published (ex: expired) job, training or report, copy the URL
2. Open an incognito tab for example and paste the URL and confirm that the message "The XXX blabla is not available anymore" appears.
3. View another page anonymously like`/moderation/content/report` and confirm there no "not available ..." message on the 403 page.

