### PR TITLE
[RW-389] Add search converter to RW

### DIFF
--- a/config/reliefweb_rivers.settings.yml
+++ b/config/reliefweb_rivers.settings.yml
@@ -1,1 +1,1 @@
-search_converter_url: 'https://reliefweb.github.io/search-converter'
+search_converter_url: ''

--- a/html/modules/custom/reliefweb_api/src/Services/ReliefWebApiClient.php
+++ b/html/modules/custom/reliefweb_api/src/Services/ReliefWebApiClient.php
@@ -357,6 +357,7 @@ class ReliefWebApiClient {
     // Optimize the filter if any.
     if (isset($payload['filter'])) {
       $filter = static::optimizeFilter($payload['filter'], $combine);
+
       if (!empty($filter)) {
         $payload['filter'] = $filter;
       }
@@ -445,13 +446,13 @@ class ReliefWebApiClient {
     $result = [];
 
     foreach ($conditions as $condition) {
-      $field = $condition['field'];
+      $field = $condition['field'] ?? NULL;
       $value = $condition['value'] ?? NULL;
       $condition_operator = $condition['operator'] ?? NULL;
 
       // Nested conditions - flatten the condition's conditions.
       if (!empty($condition['conditions'])) {
-        $condition['conditions'] = static::combineConditions($condition_operator, $condition['conditions']);
+        $condition['conditions'] = static::combineConditions($condition['conditions'], $condition_operator);
         $result[] = $condition;
       }
       // Existence filter - keep as is.

--- a/html/modules/custom/reliefweb_rivers/config/install/reliefweb_rivers.settings.yml
+++ b/html/modules/custom/reliefweb_rivers/config/install/reliefweb_rivers.settings.yml
@@ -1,2 +1,2 @@
 # URL to the API search converter.
-search_converter_url: https://reliefweb.github.io/search-converter
+search_converter_url: ''

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
@@ -247,7 +247,8 @@ function reliefweb_rivers_theme() {
         'title_attributes' => NULL,
         // Form with the appname and search URL.
         'form' => NULL,
-        // Associative array with the query string, API URL and payload.
+        // Associative array with the query string, API URL, payload and URL
+        // to the JSON result.
         'results' => [],
       ],
     ],

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.module
@@ -237,6 +237,20 @@ function reliefweb_rivers_theme() {
         'sections' => [],
       ],
     ],
+    'reliefweb_rivers_search_converter' => [
+      'variables' => [
+        // Wrapper attributes.
+        'attributes' => NULL,
+        // Page title.
+        'title' => t('Search Results'),
+        // Title attributes.
+        'title_attributes' => NULL,
+        // Form with the appname and search URL.
+        'form' => NULL,
+        // Associative array with the query string, API URL and payload.
+        'results' => [],
+      ],
+    ],
     'reliefweb_rivers_rss' => [
       'variables' => [
         // The site URL.

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
@@ -65,6 +65,15 @@ reliefweb_rivers.search.results:
   requirements:
     _permission: 'access content'
 
+# Search converter.
+reliefweb_rivers.search.converter:
+  path: '/search/converter'
+  defaults:
+    _title: 'Search to API query converter'
+    _controller: '\Drupal\reliefweb_rivers\Controller\SearchConverter::getPageContent'
+  requirements:
+     _permission: 'access content'
+
 # RSS.
 reliefweb_rivers.blog_post.rss:
   path: '/blog/rss.xml'

--- a/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
+++ b/html/modules/custom/reliefweb_rivers/reliefweb_rivers.routing.yml
@@ -73,6 +73,13 @@ reliefweb_rivers.search.converter:
     _controller: '\Drupal\reliefweb_rivers\Controller\SearchConverter::getPageContent'
   requirements:
      _permission: 'access content'
+reliefweb_rivers.search.converter.json:
+  path: '/search/converter/json'
+  defaults:
+    _title: 'Search to API query converter'
+    _controller: '\Drupal\reliefweb_rivers\Controller\SearchConverter::getJsonResult'
+  requirements:
+     _permission: 'access content'
 
 # RSS.
 reliefweb_rivers.blog_post.rss:

--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
@@ -135,6 +135,13 @@ class SearchConverter extends ControllerBase {
       '#title' => $this->t('Search to API query converter'),
       '#form' => $form,
       '#results' => $results ?? [],
+      '#cache' => [
+        'contexts' => [
+          'user',
+          'url.query_args:appname',
+          'url.query_args:search_url',
+        ],
+      ],
     ];
   }
 

--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
@@ -138,15 +138,7 @@ class SearchConverter extends ControllerBase {
    */
   protected function getAppname() {
     $appname = $this->requestStack->getCurrentRequest()->query->get('appname', '');
-    if (empty($appname)) {
-      if ($this->currentUser->isAnonymous()) {
-        $appname = 'rw-user-0';
-      }
-      else {
-        $appname = 'rw-user-' . $this->currentUser->id();
-      }
-    }
-    return $appname;
+    return $appname ?: 'rw-user-' . $this->currentUser->id();
   }
 
   /**
@@ -315,6 +307,9 @@ class SearchConverter extends ControllerBase {
    *   JSON encoded payload.
    */
   protected function getJsonPayload(array $payload) {
+    if (empty($payload)) {
+      return '';
+    }
     $json = json_encode($payload, \JSON_PRETTY_PRINT);
     return $json === FALSE ? '' : preg_replace('/ {4}/', '  ', $json);
   }

--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace Drupal\reliefweb_rivers\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Http\RequestStack;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\reliefweb_api\Services\ReliefWebApiClient;
+use Drupal\reliefweb_rivers\AdvancedSearch;
+use Drupal\reliefweb_rivers\Parameters;
+use Drupal\reliefweb_rivers\RiverServiceBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for the reliefweb_rivers.search.converter route.
+ */
+class SearchConverter extends ControllerBase {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * The request stack.
+   *
+   * @var \Drupal\Core\Http\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The ReliefWeb API client.
+   *
+   * @var \Drupal\reliefweb_api\Services\ReliefWebApiClient
+   */
+  protected $reliefWebApiClient;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The form builder.
+   * @param \Drupal\Core\Http\RequestStack $request_stack
+   *   The request stack.
+   * @param \Drupal\reliefweb_api\Services\ReliefWebApiClient $reliefweb_api_client
+   *   The reliefweb api client service.
+   */
+  public function __construct(
+    AccountProxyInterface $current_user,
+    FormBuilderInterface $form_builder,
+    RequestStack $request_stack,
+    ReliefWebApiClient $reliefweb_api_client
+  ) {
+    $this->currentUser = $current_user;
+    $this->formBuilder = $form_builder;
+    $this->requestStack = $request_stack;
+    $this->reliefWebApiClient = $reliefweb_api_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_user'),
+      $container->get('form_builder'),
+      $container->get('request_stack'),
+      $container->get('reliefweb_api.client')
+    );
+  }
+
+  /**
+   * Get the page content.
+   *
+   * @return array
+   *   Render array for the homepage.
+   */
+  public function getPageContent() {
+    $search_url = $this->getSearchUrl();
+    $appname = $this->getAppname();
+
+    // We want the editors to be able to bookmark a moderation page with
+    // a selection of filters so we set the method as GET.
+    $form_state = new FormState();
+    $form_state->setMethod('GET');
+    $form_state->setProgrammed(TRUE);
+    $form_state->setProcessInput(TRUE);
+    $form_state->disableCache();
+    $form_state->setValue('search-url', $search_url);
+    $form_state->setValue('appname', $appname);
+
+    // Build the filters form and remove unecessary elements.
+    $form = $this->formBuilder
+      ->buildForm('\Drupal\reliefweb_rivers\Form\SearchConverterForm', $form_state);
+    foreach ($form_state->getCleanValueKeys() as $key) {
+      $form[$key]['#access'] = FALSE;
+    }
+
+    // Parse the search URL to retrieve the API resource and payload.
+    $data = $this->parseSearchUrl($search_url);
+    if (!empty($data)) {
+      $query = $this->getQueryString($data['payload']);
+
+      $results = [
+        'query' => Markup::create($query),
+        'url' => Markup::create($this->getApiUrl($data['resource'], $query, $appname)),
+        'payload' => Markup::create($this->getJsonPayload($data['payload'])),
+      ];
+    }
+
+    return [
+      '#theme' => 'reliefweb_rivers_search_converter',
+      '#title' => $this->t('Search to API query converter'),
+      '#form' => $form,
+      '#results' => $results ?? [],
+    ];
+  }
+
+  /**
+   * Get the appname parameter.
+   *
+   * @return string
+   *   The appname parameter.
+   */
+  protected function getAppname() {
+    $appname = $this->requestStack->getCurrentRequest()->query->get('appname', '');
+    if (empty($appname)) {
+      if ($this->currentUser->isAnonymous()) {
+        $appname = 'rw-user-0';
+      }
+      else {
+        $appname = 'rw-user-' . $this->currentUser->id();
+      }
+    }
+    return $appname;
+  }
+
+  /**
+   * Get the search URL parameter.
+   *
+   * @return string
+   *   The search URL parameter.
+   */
+  protected function getSearchUrl() {
+    return $this->requestStack->getCurrentRequest()->query->get('search-url', '');
+  }
+
+  /**
+   * Parse as search URL.
+   *
+   * @param string $search_url
+   *   Search URL.
+   *
+   * @return array
+   *   Associative array with the API resource and payload for the search URL.
+   */
+  protected function parseSearchUrl($search_url) {
+    if (empty($search_url)) {
+      return [];
+    }
+
+    $river_data = RiverServiceBase::getRiverServiceFromUrl($search_url);
+    if (empty($river_data)) {
+      return [];
+    }
+
+    $service = $river_data['service'];
+
+    // Parse the query from the search URL.
+    parse_str(parse_url($search_url, PHP_URL_QUERY) ?? '', $query);
+    $parameters = new Parameters($query);
+    if (isset($river['view'])) {
+      $parameters->set('view', $river['view']);
+    }
+
+    // Retrieve the view used in the search URL to get the proper API payload.
+    $view = $parameters->get('view');
+    $views = $service->getViews();
+    $view = isset($views[$view]) ? $view : $service->getDefaultView();
+
+    // Get the base API payload for the view.
+    $payload = $service->getApiPayload($view);
+
+    // Add the full text search query if any.
+    $search = trim($parameters->get('search', ''));
+    if (!empty($search)) {
+      $payload['query']['value'] = $search;
+    }
+    else {
+      unset($payload['query']);
+    }
+
+    // Retrieve the API filter for the advanced search.
+    $advanced_search = new AdvancedSearch(
+      $service->getBundle(),
+      $service->getRiver(),
+      $parameters,
+      $service->getFilters(),
+      $service->getFilterSample()
+    );
+
+    // Merge the advanced search API filter with any other filter present
+    // in the API payload.
+    $filter = $advanced_search->getApiFilter();
+    if (!empty($filter)) {
+      // Update the payload filter.
+      if (!empty($payload['filter'])) {
+        $payload['filter'] = [
+          'conditions' => [
+            $payload['filter'],
+            $filter,
+          ],
+          'operator' => 'AND',
+        ];
+      }
+      else {
+        $payload['filter'] = $filter;
+      }
+    }
+
+    // Remove the fields and sort option as we, instead, add the preset and
+    // profile to the API URL.
+    unset($payload['query']['fields']);
+    unset($payload['fields']);
+    unset($payload['sort']);
+
+    // Sanitize the payload.
+    $payload = $this->reliefWebApiClient->sanitizePayload($payload, TRUE);
+
+    return [
+      'resource' => $service->getResource(),
+      'payload' => $payload,
+    ];
+  }
+
+  /**
+   * Get the API query string from the API payload.
+   *
+   * @param array $payload
+   *   API payload.
+   *
+   * @return string
+   *   The query string.
+   */
+  protected function getQueryString(array $payload) {
+    if (empty($payload)) {
+      return '';
+    }
+
+    // Join the full text search query and the filters.
+    $filters = array_filter([
+      !empty($payload['query']['value']) ? '(' . $payload['query']['value'] . ')' : '',
+      !empty($payload['filter']) ? $this->stringifyFilter($payload['filter']) : '',
+    ]);
+
+    $query = '';
+    if (count($filters) > 1) {
+      $query = implode(' AND ', $filters);
+    }
+    elseif (!empty($filters)) {
+      $query = $this->trimFilter(reset($filters));
+    }
+    return $query;
+  }
+
+  /**
+   * Get the API url from the generated query string.
+   *
+   * @param string $resource
+   *   API resource.
+   * @param string $query
+   *   Search query.
+   * @param string $appname
+   *   Application name.
+   *
+   * @return string
+   *   API URL.
+   */
+  protected function getApiUrl($resource, $query, $appname) {
+    $parameters = [
+      'appname' => $appname,
+      'profile' => 'list',
+      'preset' => 'latest',
+      'slim' => 1,
+    ];
+    if (!empty($query)) {
+      $parameters['query']['value'] = $query;
+      $parameters['query']['operator'] = 'AND';
+    }
+
+    return $this->reliefWebApiClient->buildApiUrl($resource, $parameters, FALSE);
+  }
+
+  /**
+   * Get the API url from the generated query string.
+   *
+   * @param array $payload
+   *   API payload.
+   *
+   * @return string
+   *   JSON encoded payload.
+   */
+  protected function getJsonPayload(array $payload) {
+    $json = json_encode($payload, \JSON_PRETTY_PRINT);
+    return $json === FALSE ? '' : preg_replace('/ {4}/', '  ', $json);
+  }
+
+  /**
+   * Remove excessive outter parentheses.
+   *
+   * @param string $filter
+   *   Stringified filter.
+   *
+   * @return string
+   *   Filter with outer parentheses removed.
+   */
+  protected function trimFilter($filter) {
+    return strpos($filter, '(') === 0 ? substr($filter, 1, strlen($filter) - 2) : $filter;
+  }
+
+  /**
+   * Return the query string representation of an API filter.
+   *
+   * @param array $filter
+   *   API filter.
+   *
+   * @return string
+   *   Query representation of the filter.
+   */
+  protected function stringifyFilter(array $filter) {
+    if (empty($filter)) {
+      return '';
+    }
+
+    $result = '';
+    $operator = ' ' . ($filter['operator'] ?? 'AND') . ' ';
+
+    if (!empty($filter['conditions'])) {
+      $group = [];
+
+      foreach ($filter['conditions'] as $condition) {
+        $group[] = $this->stringifyFilter($condition);
+      }
+      $result = '(' . implode($operator, $group) . ')';
+    }
+    elseif (empty($filter['value'])) {
+      $result = '_exists_:' . $filter['field'];
+    }
+    else {
+      $value = $filter['value'];
+
+      if (is_array($value)) {
+        // Date.
+        if (isset($value['from']) || isset($value['to'])) {
+          $from = isset($value['from']) ? substr($value['from'], 0, 10) : '';
+          $to = isset($value['to']) ? substr($value['to'], 0, 10) : '';
+          if (empty($from)) {
+            $value = '<' . $to;
+          }
+          elseif (empty($to)) {
+            $value = '>=' . $from;
+          }
+          else {
+            $value = '[' . $from . ' TO ' . $to . '}';
+          }
+        }
+        // Multiple values.
+        else {
+          $value = '(' . implode($operator, $value) . ')';
+        }
+      }
+
+      $result = $filter['field'] . ':' . $value;
+    }
+    return (!empty($filter['negate']) ? 'NOT ' : '') . $result;
+  }
+
+}

--- a/html/modules/custom/reliefweb_rivers/src/Form/SearchConverterForm.php
+++ b/html/modules/custom/reliefweb_rivers/src/Form/SearchConverterForm.php
@@ -33,6 +33,7 @@ class SearchConverterForm extends FormBase {
       '#title' => $this->t('Search URL'),
       '#default_value' => $form_state->getValue('search-url') ?? '',
       '#not_required' => TRUE,
+      '#maxlength' => NULL,
     ];
 
     $form['actions'] = [

--- a/html/modules/custom/reliefweb_rivers/src/Form/SearchConverterForm.php
+++ b/html/modules/custom/reliefweb_rivers/src/Form/SearchConverterForm.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\reliefweb_rivers\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * From to convert a search query to an API query.
+ */
+class SearchConverterForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'search_converter_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['appname'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Application name'),
+      '#default_value' => $form_state->getValue('appname'),
+      '#not_required' => TRUE,
+    ];
+
+    $form['search-url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search URL'),
+      '#default_value' => $form_state->getValue('search-url') ?? '',
+      '#not_required' => TRUE,
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#theme_wrappers' => [
+        'fieldset' => [
+          '#id' => 'actions',
+          '#title' => $this->t('Form actions'),
+          '#title_display' => 'invisible',
+        ],
+      ],
+      '#weight' => 99,
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#name' => 'submit',
+      '#value' => $this->t('Convert'),
+    ];
+    $form['actions']['reset'] = [
+      '#type' => 'submit',
+      '#name' => 'reset',
+      '#value' => $this->t('Reset'),
+      '#submit' => ['::resetForm'],
+      '#limit_validation_errors' => [
+        ['actions', 'reset'],
+      ],
+    ];
+
+    // Mark the form for enhancement by the reliefweb_form module.
+    $form['#attributes']['data-enhanced'] = '';
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * Reset the form.
+   *
+   * @param array $form
+   *   Form data.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   */
+  public function resetForm(array $form, FormStateInterface $form_state) {
+    $form_state->setProgrammed(FALSE);
+    $form_state->setRedirect('<current>');
+  }
+
+}

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -526,23 +526,26 @@ abstract class RiverServiceBase implements RiverServiceInterface {
    * {@inheritdoc}
    */
   public function getApiLink() {
-    $url = $this->configFactory
-      ->get('reliefweb_rivers.settings')
-      ->get('search_converter_url');
-
-    if (empty($url)) {
-      return '';
-    }
-
     $parameters = $this->getParameters()->get();
     $search_url = static::getRiverUrl($this->getBundle(), $parameters, TRUE);
-
-    return Url::fromUri($url, [
+    $options = [
       'query' => [
         'appname' => 'rwint-user-' . $this->currentUser->id(),
         'search-url' => $search_url,
       ],
-    ]);
+    ];
+
+    // Use the URL from the config if defined.
+    $url = $this->configFactory
+      ->get('reliefweb_rivers.settings')
+      ->get('search_converter_url');
+
+    if (!empty($url)) {
+      return Url::fromUri($url, $options);
+    }
+
+    // Otherwise use the search converter route.
+    return Url::fromRoute('reliefweb_rivers.search.converter', [], $options);
   }
 
   /**

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search-converter.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search-converter.html.twig
@@ -1,0 +1,46 @@
+{#
+
+/**
+ * @file
+ * Template for the search converter page.
+ *
+ * Available variables:
+ * - attributes: wrapper attributes
+ * - title: page title
+ * - title_attributes: title attributes
+ * - form: the form with the appname and search URL
+ * - results: Associative array with the query string, API URL and payload.
+ */
+
+#}
+<section{{ attributes.addClass('rw-search-converter') }}>
+  <header class="rw-search-converter__header">
+    <h1{{ title_attributes.addClass('rw-search-converter__title') }}>{{ title }}</h1>
+  </header>
+
+  <p class="rw-search-converter__description">
+  {%- trans -%}Convert a search query on <a href="https://reliefweb.int">reliefweb.int</a> to an API query (see <a href="https://apidoc.rwlabs.org/" rel="noopener" target="_blank">API documentation</a>).{%- endtrans -%}
+  </p>
+
+  <section class="rw-search-converter__form">
+    <h2>{{ 'Search Information'|t }}</h2>
+    {{ form }}
+  </section>
+
+  <section class="rw-search-converter__results">
+    <h2>{{ 'Results'|t }}</h2>
+
+    {% if results is empty %}
+    <p>{{ 'Please enter a search URL to convert, above, to see the results.'|t }}</p>
+    {% else %}
+    <h3>{{ 'Query String'|t }}</h3>
+    <pre>{{ results.query }}</pre>
+
+    <h3>{{ 'API URL'|t }}</h3>
+    <pre>{{ results.url }}</pre>
+
+    <h3>{{ 'JSON payload'|t }}</h3>
+    <pre>{{ results.payload }}</pre>
+    {% endif %}
+  </section>
+</section>

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search-converter.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-search-converter.html.twig
@@ -9,7 +9,8 @@
  * - title: page title
  * - title_attributes: title attributes
  * - form: the form with the appname and search URL
- * - results: Associative array with the query string, API URL and payload.
+ * - results: Associative array with the query string, API URL, payload and URL
+ *   to the JSON result.
  */
 
 #}
@@ -41,6 +42,9 @@
 
     <h3>{{ 'JSON payload'|t }}</h3>
     <pre>{{ results.payload }}</pre>
+
+    <h3>{{ 'Results as JSON'|t }}</h3>
+    <p><a href="{{ results.json_url }}">{{ 'View as JSON'|t }}</a></p>
     {% endif %}
   </section>
 </section>

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -326,6 +326,12 @@ rw-search:
     theme:
       components/rw-search/rw-search.css: {}
 
+rw-search-converter:
+  css:
+    theme:
+      components/rw-search-converter/rw-search-converter.css: {}
+
+
 rw-section-links:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -86,6 +86,12 @@ function common_design_subtheme_preprocess_page(&$variables) {
       'page_title_block',
     ]);
   }
+  // Remove the page title block from the search converter page.
+  elseif ($route_name === 'reliefweb_rivers.search.converter') {
+    common_design_hide_rendered_blocks_from_page($variables, [
+      'page_title_block',
+    ]);
+  }
   // Remove the page title block on river pages.
   elseif (preg_match('#^reliefweb_rivers\.[^\.]+\.river$#', $route_name) === 1) {
     common_design_hide_rendered_blocks_from_page($variables, [

--- a/html/themes/custom/common_design_subtheme/components/rw-search-converter/rw-search-converter.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-search-converter/rw-search-converter.css
@@ -1,0 +1,15 @@
+.rw-search-converter__form {
+  margin-top: 2rem;
+}
+.rw-search-converter__results {
+  margin-top: 2rem;
+}
+.rw-search-converter__results pre {
+  display: block;
+  padding: 24px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-all;
+  background: var(--cd-reliefweb-brand-grey--light);
+  font-size: 16px;
+}

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-search-converter.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_rivers/reliefweb-rivers-search-converter.html.twig
@@ -1,0 +1,6 @@
+{% set title_attributes = title_attributes.addClass('rw-page-title') %}
+
+{{ attach_library('common_design_subtheme/rw-page-title') }}
+{{ attach_library('common_design_subtheme/rw-search-converter') }}
+
+{% include '@reliefweb_rivers/reliefweb-rivers-search-converter.html.twig' %}


### PR DESCRIPTION
Refs: RW-389

At the bottom of the rivers like https://reliefweb.int/updates there is an `API` link that redirects to the RW search converter that converts the river URL to an API query which can be used to get data similar to what is displayed in the river.

This search converter is currently a github page: https://reliefweb.github.io/search-converter.

This PR adds a search converter page directly on the RW site so that we don't have to duplicate the conversion logic which is already used for the rivers: `/search/converter` which is accessible via the API link at the bottom of the rivers.

### Test

Checkout this branch and run `drush cr` and `drush cim`.

1. Go the https://reliefweb.int/updates, select some filters and add a full text search query
2. Click the `API` link at the bottom to go the github page search converter
3. Go to your local RW9 site, select the same filters and search query
4. Click the `API` link at the bottom to go the search converter page on RW
5. Compare the `query string`, `api url` and `payload`, they should be identical between both search converter pages

Note: there may be some slight differences if you select some weird combination of filters because the github page is a bit outdated.