### PR TITLE
[RW-274] View of revisions

### DIFF
--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
@@ -982,8 +982,14 @@ class ReliefWebFile extends FieldItemBase {
       return NULL;
     }
     // Only people with access to the private files can have a link to the file.
-    elseif ($private && !$this->getCurrentUser()->hasPermission('access reliefweb private files')) {
-      return NULL;
+    elseif ($private) {
+      if (!$this->getCurrentUser()->hasPermission('access reliefweb private files')) {
+        return NULL;
+      }
+      else {
+        $url = UrlHelper::getAbsoluteFileUri($uri);
+        return empty($url) ? NULL : Url::fromUri($url);
+      }
     }
     // New or replaced files have an empty revision id and there should be a
     // file on disk for them. However we need to check for the page count to

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -36,8 +36,43 @@ function common_design_subtheme_preprocess_taxonomy_term(&$variables) {
       common_design_set_page_title($variables, $term->label(), TRUE);
     }
     elseif ($route_name === 'entity.taxonomy_term.preview') {
-      common_design_set_page_title($variables, $term->label(), TRUE);
+      common_design_set_page_title($variables, $term->label(), FALSE);
     }
+    elseif ($route_name === 'taxonomy_term_revision.view') {
+      $label = t('Revision of %title from %date', [
+        '%title' => $term->label(),
+        '%date' => \Drupal::service('date.formatter')->format($term->getRevisionCreationTime()),
+      ]);
+      common_design_set_page_title($variables, $label, FALSE);
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_node().
+ *
+ * Use the page title block for the node title if the view mode was selected
+ * in the theme settings.
+ *
+ * Important: this assumes there is a template for the view mode that uses
+ * the `title` (and `local_tasks`) variables added by
+ * common_design_use_node_page_title(). See `node--full.html.twig`.
+ *
+ * @see common_design_preprocess_page()
+ * @see common_design_set_page_title()
+ */
+function common_design_subtheme_preprocess_node(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  $node = $variables['node'] ?? NULL;
+  $view_mode = $variables['view_mode'] ?? '';
+
+  // If the node view mode was selected to use the page title block for the
+  // node title in the template, then we add the page title to the template
+  // variables. We only do that if we are on the canonical node page or on
+  // the node preview page.
+  if (isset($node) && $route_name === 'entity.node.revision' && common_design_use_node_page_title($view_mode)) {
+    common_design_set_page_title($variables, $node->label(), TRUE);
   }
 }
 
@@ -76,6 +111,18 @@ function common_design_subtheme_preprocess_page(&$variables) {
   }
   // Hide the page title block on the taxonomy term preview page.
   elseif ($route_name === 'entity.taxonomy_term.preview') {
+    common_design_hide_rendered_blocks_from_page($variables, [
+      'page_title_block',
+    ]);
+  }
+  // Hide the page title block on a taxonomy term revision page.
+  elseif ($route_name === 'taxonomy_term_revision.view') {
+    common_design_hide_rendered_blocks_from_page($variables, [
+      'page_title_block',
+    ]);
+  }
+  // Hide the page title block on a node revision page.
+  elseif ($route_name === 'entity.node.revision') {
     common_design_hide_rendered_blocks_from_page($variables, [
       'page_title_block',
     ]);


### PR DESCRIPTION
Refs: RW-274

This fixes an issue with the entity title that preventing viewing a revision.

It also contains a fix to display private files from old revisions for people with the proper permission.

### Test

**Node revision**

1. Create a report with an attachment and save
2. Edit the report, remove the file, change title, save
3. Check that the file doesn't appear anymore
4. Go to the "revisions" tab for the report, click the first revision
5. Check that this displays the file and the original title

**Term revision**

1. Create a disaster or source and save
2. Edit the term and change the title
3. Go to the "revisions" tab for the term, click the first revision
4. Check that this displays the original title