### PR TITLE
[RW-564] view attached images when previewing node

### DIFF
--- a/html/modules/custom/reliefweb_form/reliefweb_form.module
+++ b/html/modules/custom/reliefweb_form/reliefweb_form.module
@@ -210,6 +210,15 @@ function reliefweb_form_form_alter(array &$form, FormStateInterface $form_state,
     // Attach the main enhanced form library.
     $form['#attached']['library'][] = 'reliefweb_form/form.main';
   }
+
+  // If the form can be previewed, we add a submit callback before the actual
+  // preview submit callback to prepare the entity with the values from the
+  // inline entity forms.
+  if (isset($form['actions']['preview']['#submit'])) {
+    // This flag will allow the processing of the inline entity form values.
+    // @see \Drupal\inline_entity_form\Plugin\Field\FieldWidget\InlineEntityFormComple::extractFormValues()
+    $form['actions']['preview']['#ief_submit_trigger'] = TRUE;
+  }
 }
 
 /**

--- a/html/modules/custom/reliefweb_form/src/ParamConverter/NodePreviewConverter.php
+++ b/html/modules/custom/reliefweb_form/src/ParamConverter/NodePreviewConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\reliefweb_form\ParamConverter;
+
+use Drupal\node\ParamConverter\NodePreviewConverter as OriginalNodePreviewConverter;
+
+/**
+ * Provides upcasting for a node entity in preview.
+ */
+class NodePreviewConverter extends OriginalNodePreviewConverter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function convert($value, $definition, $name, array $defaults) {
+    $store = $this->tempStoreFactory->get('node_preview');
+    $form_state = $store->get($value);
+    if (!empty($form_state)) {
+      // We repopulate the fields using inline entity forms with the referenced
+      // entities marked as new so that the entity reference field formatter
+      // doesn't try to load the entities and use the given cloned ones with the
+      // changes made to them in the form.
+      $entity = $form_state->getFormObject()->getEntity();
+      $widget_states = $form_state->get('inline_entity_form');
+      if (!empty($widget_states)) {
+        foreach ($widget_states as $widget_state) {
+          $field_name = $widget_state['instance']->getName();
+
+          if (!empty($widget_state['entities'])) {
+            foreach ($widget_state['entities'] as $item) {
+              if (isset($item['entity'])) {
+                $item['entity']->enforceIsNew(TRUE);
+              }
+            }
+
+            $entity->set($field_name, $widget_state['entities']);
+          }
+        }
+      }
+
+      return $entity;
+    }
+  }
+
+}

--- a/html/modules/custom/reliefweb_form/src/ReliefWebFormServiceProvider.php
+++ b/html/modules/custom/reliefweb_form/src/ReliefWebFormServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\reliefweb_form;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Modifies the node preview parameter converter.
+ */
+class ReliefWebFormServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    if ($container->hasDefinition('node_preview')) {
+      $definition = $container->getDefinition('node_preview');
+      $definition->setClass('Drupal\reliefweb_form\ParamConverter\NodePreviewConverter');
+      $definition->setLazy(FALSE);
+    }
+  }
+
+}


### PR DESCRIPTION
Refs: RW-564

This adds a workaround to be able to view the images when previewing a node with fields using an inline entity form for those image (ex: report image).

### Test

1. Create a report, add an image (under the Files section), fill the mandatory fields
2. Click preview and confirm you can see the image
3. Go back to the form and save
4. Edit the report, edit the image (change the uploaded image for example), click "update image"
5. Click preview and confirm you can see the new image
