### PR TITLE
[RW-629] ensure media and files are deleted when deleting a node

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -15,6 +15,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
+use Drupal\media\MediaInterface;
 use Drupal\reliefweb_entities\BundleEntityInterface;
 use Drupal\reliefweb_entities\BundleEntityStorageInterface;
 use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
@@ -22,6 +23,7 @@ use Drupal\reliefweb_utility\Helpers\ClassHelper;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
 use Drupal\reliefweb_utility\Helpers\EntityHelper;
 use Drupal\reliefweb_utility\Helpers\MailHelper;
+use Drupal\reliefweb_utility\Helpers\MediaHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\taxonomy\TermInterface;
@@ -785,4 +787,62 @@ function reliefweb_entities_preprocess_page__403(array &$variables) {
   // and this preprocess hook implementation will not be called when visiting
   // an inaccessible node page afterwards.
   $variables['#cache']['contexts'][] = 'url.path';
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete() for 'media'.
+ *
+ * Remove the source file when deleting a media.
+ */
+function reliefweb_entities_media_delete(MediaInterface $media) {
+  $file = MediaHelper::getMediaSourceFile($media);
+  // Delete the source file if not used anywhere else.
+  if (!empty($file) && empty(\Drupal::service('file.usage')->listUsage($file))) {
+    $file->setTemporary();
+    $file->save();
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_predelete() for 'node'.
+ *
+ * Retrieve the list of referenced media Ids across all revisions before
+ * deleting the entity.
+ */
+function reliefweb_entities_node_predelete(EntityInterface $entity) {
+  // Only the image field for announcements and reports do not allow re-using
+  // existing media.
+  if (in_array($entity->bundle(), ['announcement', 'report'])) {
+    // Get the list of referenced media Ids. We need to do that before the
+    // entity is actually deleted.
+    $entity->_referencedMediaIds = \Drupal::database()
+      ->select('node_revision__field_image', 'f')
+      ->fields('f', ['field_image_target_id'])
+      ->condition('f.entity_id', $entity->id(), '=')
+      ->distinct()
+      ->execute()
+      ?->fetchCol() ?? [];
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_revision_delete().
+ *
+ * Remove referenced media that are not used anymore.
+ */
+function reliefweb_entities_node_delete(EntityInterface $entity) {
+  // Only the image field for announcements and reports do not allow re-using
+  // existing media.
+  if (in_array($entity->bundle(), ['announcement', 'report'])) {
+    // Delete referenced media entities.
+    if (!empty($entity->_referencedMediaIds)) {
+      $media_entities = \Drupal::entityTypeManager()
+        ->getStorage('media')
+        ->loadMultiple($entity->_referencedMediaIds);
+
+      foreach ($media_entities as $media) {
+        $media->delete();
+      }
+    }
+  }
 }

--- a/html/modules/custom/reliefweb_utility/src/Helpers/MediaHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/MediaHelper.php
@@ -116,4 +116,30 @@ class MediaHelper {
     return $image;
   }
 
+  /**
+   * Get the source file from a media entity.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   Media entity.
+   *
+   * @return \Drupal\file\FileInterface
+   *   Source file if defined.
+   */
+  public static function getMediaSourceFile(MediaInterface $media) {
+    $field_name = $media
+      ->getSource()
+      ?->getSourceFieldDefinition($media->bundle->entity)
+      ?->getName();
+
+    if (!empty($field_name)) {
+      return $media
+        ?->get($field_name)
+        ?->first()
+        ?->get('entity')
+        ?->getTarget()
+        ?->getValue();
+    }
+    return NULL;
+  }
+
 }


### PR DESCRIPTION
Refs: RW-629

This ensures the attached media images and their files are deleted when deleting a report or announcement.

### Test

1. Create a node, attach an image (under Files section), save
2. Run `drush sql-query "SELECT * FROM file_managed ORDER BY fid DESC LIMIT 1"` and check the status of  the file is `1`. Note the `fid` and replace `FID` with it in the queries in (4) and (6) below.
3. Delete the node
4. Run `drush sql-query "SELECT * FROM file_managed WHERE fid = FID"` and check the status of  the file is `0`.
5. Run `drush cron`
6.  Run `drush sql-query "SELECT * FROM file_managed WHERE fid = FID"` and check that there is no record anymore.
