### PR TITLE
[RW-630] Nginx rule for derivative images

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This is the drupal 9 codebase for the [ReliefWeb](https://reliefweb.int) site.
 in 1996, the portal now hosts more than 850,000 humanitarian situation reports,
 press releases, evaluations, guidelines, assessments, maps and infographics.
 
+## Images
+
+All the images should be stored under `SCHEME://images/xxx/`.
+
+Attachment previews are stored under `SCHEME://previews/`.
+
+When adding or changing the image styles, update the nginx configuration file
+for [image derivatives](/docker/etc/nginx/custom/03_derivative_images.conf)
+accordingly.
+
 ## Docksal
 
 - `git clone --branch develop git@github.com:UN-OCHA/rwint9-site.git`

--- a/docker/etc/nginx/custom/03_derivative_images.conf
+++ b/docker/etc/nginx/custom/03_derivative_images.conf
@@ -1,0 +1,38 @@
+## Location for derivative images to avoid hitting Drupal for invalid URLs or
+## if the source image doesn't exist.
+location /sites/default/files/styles/ {
+
+  ## Allowed derivative images.
+  ## As mentioned in the main README, this needs to be updated when
+  ## new image styles or different directories to store images are added.
+  location ~ "^/sites/default/files/styles/(announcement|icon|thumbnail|small|medium|large|media_library|guideline_thumbnail)/public/(?<file_path>(images|previews)/[^?]+)" {
+    ## The following lines are copied from the apps/drupal/drupal.conf file.
+    access_log off;
+    expires 30d;
+    ## No need to bleed constant updates. Send the all shebang in one
+    ## fell swoop.
+    tcp_nodelay off;
+    ## Set the OS file cache.
+    open_file_cache max=3000 inactive=120s;
+    open_file_cache_valid 45s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors off;
+
+    try_files $uri @drupal-generate-derivative-image;
+  }
+
+  ## Simply return a 404 for unrecognized derivative URLs.
+  return 404;
+}
+
+## Internal location to ask Drupal to generate a derivative image if the source
+## image is present.
+location @drupal-generate-derivative-image {
+  ## If the source image doesn't exist return a 404.
+  if (!-f "$document_root/sites/default/files/$file_path") {
+    return 404;
+  }
+
+  ## Otherwise pass the request to drupal.
+  try_files /dev/null @drupal;
+}


### PR DESCRIPTION
Refs: RW-630

This adds a nginx rule for **public** derivative images to return a 404 for unrecognized URLs (ex: unrecognized image style) and otherwise, if the derivative image has not yet been generated, check that the source image exists before passing the request to Drupal.
