### PR TITLE
[RW-632] Encode file name when doing legacy redirections

### DIFF
--- a/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
@@ -25,10 +25,10 @@ if target == nil or target == '' then
   local jit_uuid = require 'resty.jit-uuid'
   local uuid = jit_uuid.generate_v3('6ba7b811-9dad-11d1-80b4-00c04fd430c8', legacy_url)
 
-  target = uuid .. '/' .. attachment_file
+  target = uuid .. '/' .. ngx.escape_uri(attachment_file)
 else
   local uuid = string.gsub(target, '../attachments/[^/]+/[^/]+/([^.]+).+', '%1')
-  target = uuid .. '/' .. attachment_file
+  target = uuid .. '/' .. ngx.escape_uri(attachment_file)
 end
 
 -- Redirect to the new URL.


### PR DESCRIPTION
Refs: RW-632

Found some occasional nginx 500 in the logs for legacy attachment URLs. It turned out those URLs contained bytes like `\x1` that are considered unsafe when redirecting.

This PR makes sure the file name is encoded before redirecting.

### Test

1. Before switching to this PR's branch, check this URL: `/sites/reliefweb.int/files/resources/ED1EF744FE93A788C%1F1257428003110CB-gvtSweden_feb2006.pdf`, it should return a 500
2. Checkout this PR's branch, **restart the container** and check the same URL, it should return a 404