### PR TITLE
[RW-21] User revisions - DO NOT MERGE YET

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
     ],
     "repositories": [
         {
+            "type": "vcs",
+            "url": "https://git.drupalcode.org/issue/user_revision-3197068.git"
+        },
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         },
@@ -54,6 +58,7 @@
         "drupal/theme_switcher": "^1.2",
         "drupal/token": "^1.10",
         "drupal/user_display_name": "^1.0",
+        "drupal/user_revision": "dev-3197068-entity-update-api#51f387ec2a22a136d20843cf0054499c3ca1dbce",
         "drush/drush": "^11.0",
         "google/analytics-data": "^0.8.4",
         "google/auth": "^1.21",

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "drupal/theme_switcher": "^1.2",
         "drupal/token": "^1.10",
         "drupal/user_display_name": "^1.0",
-        "drupal/user_revision": "dev-3197068-entity-update-api#51f387ec2a22a136d20843cf0054499c3ca1dbce",
+        "drupal/user_revision": "dev-3197068-entity-update-api#cc6d88bc8d7a261bfb0608c07e350fecfd7141df",
         "drush/drush": "^11.0",
         "google/analytics-data": "^0.8.4",
         "google/auth": "^1.21",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "687ff3598a1528e7325a51c23477da0a",
+    "content-hash": "0a36c3ebcf88afb601a7bf2ca4a1381b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4505,6 +4505,29 @@
                 "source": "https://git.drupal.org/project/user_display_name.git",
                 "issues": "https://www.drupal.org/project/issues/user_display_name"
             }
+        },
+        {
+            "name": "drupal/user_revision",
+            "version": "dev-3197068-entity-update-api",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/issue/user_revision-3197068.git",
+                "reference": "51f387ec2a22a136d20843cf0054499c3ca1dbce"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "type": "drupal-module",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Adds revision support to user entities.",
+            "homepage": "https://www.drupal.org/project/user_revision",
+            "support": {
+                "issues": "https://www.drupal.org/project/issues/user_revision",
+                "source": "https://git.drupal.org/project/user_revision.git"
+            },
+            "time": "2022-08-10T00:52:58+00:00"
         },
         {
             "name": "drush/drush",
@@ -15678,7 +15701,8 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/inline_entity_form": 5,
-        "drupal/taxonomy_term_revision": 20
+        "drupal/taxonomy_term_revision": 20,
+        "drupal/user_revision": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a36c3ebcf88afb601a7bf2ca4a1381b",
+    "content-hash": "39f37899ee2bcf67252c1a4e7fa1459c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4512,7 +4512,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/issue/user_revision-3197068.git",
-                "reference": "51f387ec2a22a136d20843cf0054499c3ca1dbce"
+                "reference": "cc6d88bc8d7a261bfb0608c07e350fecfd7141df"
             },
             "require": {
                 "drupal/core": "^9 || ^10"
@@ -4527,7 +4527,7 @@
                 "issues": "https://www.drupal.org/project/issues/user_revision",
                 "source": "https://git.drupal.org/project/user_revision.git"
             },
-            "time": "2022-08-10T00:52:58+00:00"
+            "time": "2022-08-10T05:06:42+00:00"
         },
         {
             "name": "drush/drush",

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -99,6 +99,7 @@ module:
   update: 0
   user: 0
   user_display_name: 0
+  user_revision: 0
   workflows: 0
   pathauto: 1
   content_translation: 10

--- a/config/user_revision.settings.yml
+++ b/config/user_revision.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: 5L2VrNBkdV0ykQRYkkaWegnhWVy33dKILcYT2vTlLDE
+revision_mode: required
+revision_default_enabled: false
+revision_user_log_enabled: false
+revision_keep_passwords: false
+revision_information_open: true

--- a/html/modules/custom/reliefweb_revisions/reliefweb_revisions.api.php
+++ b/html/modules/custom/reliefweb_revisions/reliefweb_revisions.api.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the reliefweb_revisions module.
+ */
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+
+/**
+ * Alter the list of base fields that can be shown in the revision history.
+ *
+ * @param array $allowed
+ *   List of fields keyed by the field name that can be shown in the revision
+ *   history for the given entity type and bundle. Set the value to TRUE to
+ *   allow computing differences for the field.
+ * @param string $entity_type_id
+ *   Entity type id.
+ * @param string $bundle
+ *   Entity bundle.
+ */
+function hook_reliefweb_revisions_allowed_base_fields_alter(array &$allowed, $entity_type_id, $bundle) {
+  if ($entity_type_id === 'user') {
+    $allowed['mail'] = TRUE;
+  }
+}
+
+/**
+ * Return a custom formatting callback for a field definition.
+ *
+ * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+ *   The definition for the field to format.
+ *
+ * @return callable|null
+ *   A callback that takes the field definition and array of differences and
+ *   return a renderable array of the differences or NULL.
+ */
+function hook_reliefweb_revisions_get_formatting_callback(FieldDefinitionInterface $field_definition) {
+  return 'my_module_format_textfied_revision_diffs';
+}

--- a/html/modules/custom/reliefweb_revisions/reliefweb_revisions.services.yml
+++ b/html/modules/custom/reliefweb_revisions/reliefweb_revisions.services.yml
@@ -1,7 +1,7 @@
 services:
   reliefweb_revisions.entity.history:
     class: Drupal\reliefweb_revisions\Services\EntityHistory
-    arguments: ['@cache.default', '@config.factory', '@current_user', '@database', '@entity_field.manager', '@entity_type.manager', '@string_translation']
+    arguments: ['@cache.default', '@config.factory', '@current_user', '@database', '@entity_field.manager', '@entity_type.manager', '@module_handler', '@string_translation']
   reliefweb_revisions.entity.param_converter:
     class: Drupal\reliefweb_revisions\ParamConverter\EntityRevisionedConverter
     arguments: ['@entity_type.manager', '@entity.repository']

--- a/html/modules/custom/reliefweb_revisions/templates/reliefweb-revisions-history-content.html.twig
+++ b/html/modules/custom/reliefweb_revisions/templates/reliefweb-revisions-history-content.html.twig
@@ -39,7 +39,9 @@
           '@date': entry.date|date('d M Y H:i:s e', 'UTC'),
           '@user': entity_link(entry.user),
         }) }}</h{{ level }}>
+        {% if entry.status is not empty %}
         <div class="rw-moderation-status" data-moderation-status="{{ entry.status.value }}">{{ entry.status.label }}</div>
+        {% endif %}
       </header>
 
       <dl class="rw-revisions-history-entry__content">

--- a/html/modules/custom/reliefweb_users/reliefweb_users.info.yml
+++ b/html/modules/custom/reliefweb_users/reliefweb_users.info.yml
@@ -5,3 +5,6 @@ package: reliefweb
 core_version_requirement: ^9
 dependencies:
   - drupal:user
+  - drupal:user_revision
+  - drupal:reliefweb_entities
+  - drupal:reliefweb_revisions

--- a/html/modules/custom/reliefweb_users/reliefweb_users.module
+++ b/html/modules/custom/reliefweb_users/reliefweb_users.module
@@ -8,9 +8,11 @@
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Url;
+use Drupal\reliefweb_revisions\Services\EntityHistory;
 use Drupal\user\RoleInterface;
 use Drupal\user\UserInterface;
 
@@ -33,6 +35,13 @@ function reliefweb_users_theme() {
     ],
   ];
   return $themes;
+}
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function reliefweb_users_entity_type_alter(array &$entity_types) {
+  $entity_types['user']->setClass('\Drupal\reliefweb_users\Entity\User');
 }
 
 /**
@@ -129,6 +138,48 @@ function reliefweb_users_form_user_form_alter(array &$form, FormStateInterface $
   else {
     $form['account']['roles']['#access'] = FALSE;
   }
+
+  // Display the revision history.
+  EntityHistory::addHistoryToForm($form, $form_state);
+
+  // We need to alter the revision fields later as the user_revision form
+  // alter hook has not yet been called.
+  $form['#process'][] = 'reliefweb_users_user_form_process';
+}
+
+/**
+ * Form process callback to alter the revision fields.
+ *
+ * @param array $form
+ *   Form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ *
+ * @return array
+ *   The form.
+ */
+function reliefweb_users_user_form_process(array $form, FormStateInterface $form_state) {
+  // Update the revision information to be consistent with the other forms.
+  $revision_log_message_field = $form_state
+    ->getFormObject()
+    ->getEntity()
+    ->getEntityType()
+    ->getRevisionMetadataKey('revision_log_message');
+
+  if (isset($revision_log_message_field)) {
+    if (isset($form['revision_information'])) {
+      $form['revision_information']['#type'] = 'fieldset';
+      $form['revision_information']['#title'] = t('Revisions');
+    }
+
+    // Update the title of the revision log message field and make sure it's not
+    // populated with the previous message.
+    if (isset($form[$revision_log_message_field]['widget'][0]['value'])) {
+      $form[$revision_log_message_field]['widget'][0]['value']['#title'] = t('New comment');
+      $form[$revision_log_message_field]['widget'][0]['value']['#default_value'] = '';
+    }
+  }
+  return $form;
 }
 
 /**
@@ -146,7 +197,7 @@ function reliefweb_users_user_form_submit(array $form, FormStateInterface $form_
 }
 
 /**
- * Implements hook_form_user_form_alter().
+ * Validation callback for the email field.
  */
 function reliefweb_users_validate_email(array &$element, FormStateInterface $form_state, array $form) {
   $email = trim($form_state->getValue($element['#parents'], ''));
@@ -288,4 +339,56 @@ function reliefweb_users_get_email_confirmation_hash(UserInterface $user, $times
   $confirmed = !empty($user->field_email_confirmed->value) ? '1' : '0';
   $data = implode('/', [$user->id(), $timestamp, $email, $confirmed]);
   return Crypt::hmacBase64($data, Settings::getHashSalt() . $email);
+}
+
+/**
+ * Implements hook_reliefweb_revisions_allowed_base_fields_alter().
+ */
+function reliefweb_users_reliefweb_revisions_allowed_base_fields_alter(array &$allowed, $entity_type_id, $bundle) {
+  $allowed['name'] = TRUE;
+  $allowed['mail'] = TRUE;
+  $allowed['display_name'] = TRUE;
+  $allowed['roles'] = TRUE;
+  $allowed['status'] = TRUE;
+}
+
+/**
+ * Implements hook_reliefweb_revisions_get_formatting_callback().
+ */
+function reliefweb_users_reliefweb_revisions_get_formatting_callback(FieldDefinitionInterface $field_definition) {
+  if ($field_definition->getTargetEntityTypeId() === 'user' && $field_definition->getName() === 'status') {
+    return 'reliefweb_users_format_user_status_revision_differences';
+  }
+  return NULL;
+}
+
+/**
+ * Format the user status field differences.
+ *
+ * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+ *   Field definition.
+ * @param array $diff
+ *   Field value differences.
+ *
+ * @return array|null
+ *   The render array for the difference or NULL if there is no difference.
+ */
+function reliefweb_users_format_user_status_revision_differences(FieldDefinitionInterface $field_definition, array $diff) {
+  $allowed_values = [
+    '1' => 'active',
+    '0' => 'blocked',
+  ];
+
+  $output = [];
+  foreach (['added', 'removed'] as $key) {
+    foreach ($diff[$key] ?? [] as $value) {
+      if (isset($allowed_values[$value['value']])) {
+        $output['#' . $key][] = $allowed_values[$value['value']];
+      }
+    }
+  }
+
+  return empty($output) ? NULL : [
+    '#theme' => 'reliefweb_revisions_diff_list',
+  ] + $output;
 }

--- a/html/modules/custom/reliefweb_users/src/Entity/User.php
+++ b/html/modules/custom/reliefweb_users/src/Entity/User.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\reliefweb_users\Entity;
+
+use Drupal\Core\Entity\RevisionLogEntityTrait;
+use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\user\Entity\User as UserBase;
+use Drupal\reliefweb_revisions\EntityRevisionedInterface;
+use Drupal\reliefweb_revisions\EntityRevisionedTrait;
+
+/**
+ * User entity class with revision helpers.
+ */
+class User extends UserBase implements EntityRevisionedInterface, RevisionLogInterface {
+
+  use EntityRevisionedTrait;
+  use RevisionLogEntityTrait;
+
+}


### PR DESCRIPTION
Refs: RW-21

This adds the user_revision module (MR3 of https://www.drupal.org/project/user_revision/issues/3197068) and adjusts the reliefweb_revisions module to be more flexible and do not assume all revisioned entities are also moderated ones.

### Tests

1. Checkout this branch and run `composer install` to install the user_revision
2. Run `drush cr` then `drush cim`, this should enable the user_revision module and start a batch to make the user entities revisionable (can take several minutes)
3. Log in with a an existing "normal" user, change the display name or email address
4. Log in with an account with the "User Manager" role, edit the account from (3), there should be the revision history at the bottom of the form showing the change of display name/email address
5. Change something for the account (3), leave a revision comment, save and edit again to confirm the changes and check they also appear in the revision history with the comment

**Important:** This makes changes to the DB so either backup your DB before reviewing this PR or import a fresh dump when done with the review and checking out another branch.