### PR TITLE
[RW-654] Allow topics to be archived

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/Services/TopicModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/TopicModeration.php
@@ -104,6 +104,34 @@ class TopicModeration extends ModerationServiceBase {
   /**
    * {@inheritdoc}
    */
+  public function getStatuses() {
+    return [
+      'draft' => $this->t('Draft'),
+      'published' => $this->t('Published'),
+      'archive' => $this->t('Archived'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityFormSubmitButtons($status, EntityModeratedInterface $entity) {
+    return [
+      'draft' => [
+        '#value' => $this->t('Save as draft'),
+      ],
+      'published' => [
+        '#value' => $this->t('Publish'),
+      ],
+      'archive' => [
+        '#value' => $this->t('Archive'),
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function entityAccess(EntityModeratedInterface $entity, $operation = 'view', ?AccountInterface $account = NULL) {
     // Trello #y0B0wxLi: allow beta tested to view unpublished topics.
     if ($operation === 'view' && UserHelper::userHasRoles(['beta_tester'], $account)) {


### PR DESCRIPTION
Refs: RW-654

This simply enables the "archive" status for topics.

### Tests

1. Select a published topic, check that it can be accessed as anonymous
2. Log in as an Editor
3. Edit the topic, check that there is an "Archive" button, click on it
4. Check that the topic status is "archived" and that the topic is not accessible anonymously anymore5. 
5. Check that, as an Editor the topic is accessible and editable
6. Log in as a normal user and check that the topic is not accessible
