### PR TITLE
RW-640 Global Search section heading

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
@@ -10,7 +10,7 @@
     .setAttribute('data-cd-focus-target', 'site-search-input')
     .addClass('cd-search__form')
   }}>
-    <h2 id="site-search-title" class="visually-hidden"><?php rwpt("Content Search"); ?></h2>
+    <h2 id="site-search-title" class="visually-hidden">{{ 'Content Search'|t }}</h2>
     <form action="/search/results" method="GET" accept-charset="UTF-8" class="[ cd-flow ]">
       <div class="cd-form__item">
         <label for="site-search-input" class="visually-hidden">{{ 'What are you looking for?'|t }}</label>


### PR DESCRIPTION
This PR replaces some D7 syntax with D9 twig translation for the Search section heading

Refs: RW-640