### PR TITLE
[RW-658] Ensure source status field is properly updated

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
@@ -208,6 +208,8 @@ class SourceModeration extends ModerationServiceBase {
    * {@inheritdoc}
    */
   public function entityPresave(EntityModeratedInterface $entity) {
+    parent::entityPresave($entity);
+
     // Ensure all posting rights are 'blocked' if the status is 'blocked'.
     $status = $entity->getModerationStatus();
     if ($status === 'blocked') {
@@ -233,8 +235,6 @@ class SourceModeration extends ModerationServiceBase {
         ])));
       }
     }
-
-    return $status;
   }
 
   /**


### PR DESCRIPTION
Refs: RW-658

This updates the `SourceModeration` service to call the parent `entityPresave` to ensure the term `status` field is properly updated when the moderation status changes.

### Tests

**Before checking out this branch**

1. Find a source with a "status" of 0: `SELECT tid FROM taxonomy_term_field_data WHERE status = 0 LIMIT 1`
2. Edit the source, save it as `active`
3. Check that the status is still `0`: `SELECT status FROM taxonomy_term_field_data WHERE tid = TID` (replace `TID`)

**After checking out this branch**

1. Find a source with a "status" of 0: `SELECT tid FROM taxonomy_term_field_data WHERE status = 0 LIMIT 1`
2. Edit the source, save it as `active`
3. Check that the status is now `1`: `SELECT status FROM taxonomy_term_field_data WHERE tid = TID` (replace `TID`)
4. Edit the source, save it as `archive`
5. Check that the status is now `0`: `SELECT status FROM taxonomy_term_field_data WHERE tid = TID` (replace `TID`)
