### PR TITLE
fix: Strip quotes, backticks and dollars from the string we're looking up.

### DIFF
--- a/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
@@ -6,7 +6,7 @@ local attachment_file = ngx.var.attachment_file
 -- the URL, URI in DB and file on disk in D7.
 -- This can also be used to handle aliases for some specific files.
 local symlink = ngx.var.document_root .. '/sites/default/files/legacy-attachments/' .. attachment_file;
-local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', '')
+local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', ''):gsub('%!', '')
 local handle = io.popen('readlink "' .. escaped .. '"')
 local target = handle:read()
 handle:close()

--- a/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_attachment_redirections.lua
@@ -6,7 +6,8 @@ local attachment_file = ngx.var.attachment_file
 -- the URL, URI in DB and file on disk in D7.
 -- This can also be used to handle aliases for some specific files.
 local symlink = ngx.var.document_root .. '/sites/default/files/legacy-attachments/' .. attachment_file;
-local handle = io.popen('readlink "' .. symlink .. '"')
+local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', '')
+local handle = io.popen('readlink "' .. escaped .. '"')
 local target = handle:read()
 handle:close()
 

--- a/docker/etc/nginx/custom/lua/01_legacy_preview_derivative_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_preview_derivative_redirections.lua
@@ -30,7 +30,8 @@ end
 -- Some legacy preview file names cannot be derived from the PDF file name, in
 -- that case there should be a symlink pointing to the new preview.
 local symlink = ngx.var.document_root .. '/sites/default/files/legacy-previews/' .. ngx.var.file_id .. '.' .. image_ext;
-local handle = io.popen('readlink "' .. symlink .. '"')
+local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', '')
+local handle = io.popen('readlink "' .. escaped .. '"')
 local target = handle:read()
 handle:close()
 

--- a/docker/etc/nginx/custom/lua/01_legacy_preview_derivative_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_preview_derivative_redirections.lua
@@ -30,7 +30,7 @@ end
 -- Some legacy preview file names cannot be derived from the PDF file name, in
 -- that case there should be a symlink pointing to the new preview.
 local symlink = ngx.var.document_root .. '/sites/default/files/legacy-previews/' .. ngx.var.file_id .. '.' .. image_ext;
-local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', '')
+local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', ''):gsub('%!', '')
 local handle = io.popen('readlink "' .. escaped .. '"')
 local target = handle:read()
 handle:close()

--- a/docker/etc/nginx/custom/lua/01_legacy_preview_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_preview_redirections.lua
@@ -5,7 +5,7 @@ local image_ext = 'png'
 -- Some legacy preview file names cannot be derived from the PDF file name, in
 -- that case there should be a symlink pointing to the new preview.
 local symlink = ngx.var.document_root .. '/sites/default/files/legacy-previews/' .. ngx.var.file_id .. '.' .. image_ext;
-local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', '')
+local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', ''):gsub('%!', '')
 local handle = io.popen('readlink "' .. escaped .. '"')
 local target = handle:read()
 handle:close()

--- a/docker/etc/nginx/custom/lua/01_legacy_preview_redirections.lua
+++ b/docker/etc/nginx/custom/lua/01_legacy_preview_redirections.lua
@@ -5,7 +5,8 @@ local image_ext = 'png'
 -- Some legacy preview file names cannot be derived from the PDF file name, in
 -- that case there should be a symlink pointing to the new preview.
 local symlink = ngx.var.document_root .. '/sites/default/files/legacy-previews/' .. ngx.var.file_id .. '.' .. image_ext;
-local handle = io.popen('readlink "' .. symlink .. '"')
+local escaped = symlink:gsub('"', ''):gsub("'", ""):gsub('`', ''):gsub('%$', '')
+local handle = io.popen('readlink "' .. escaped .. '"')
 local target = handle:read()
 handle:close()
 


### PR DESCRIPTION
Since io.popen() spawns a shell, we do not want to pass it any special
characters that would end up with a shell exploit.

Refs: OPS-8576