### PR TITLE
[RW-656] Migrate career categories field revisions

### DIFF
--- a/config/migrate_plus.migration.reliefweb_node_revision__job.yml
+++ b/config/migrate_plus.migration.reliefweb_node_revision__job.yml
@@ -17,7 +17,7 @@ process:
   body/format:
     plugin: default_value
     default_value: markdown_editor
-  field_career_categories/value:
+  field_career_categories:
     plugin: sub_process
     source: field_career_categories
     process:

--- a/config/migrate_plus.migration.reliefweb_node_revision__report.yml
+++ b/config/migrate_plus.migration.reliefweb_node_revision__report.yml
@@ -19,7 +19,7 @@ process:
     plugin: skip_on_empty
     method: process
     source: field_bury/0/value
-  field_content_format/value:
+  field_content_format:
     plugin: sub_process
     source: field_content_format
     process:

--- a/config/migrate_plus.migration.reliefweb_node_revision__training.yml
+++ b/config/migrate_plus.migration.reliefweb_node_revision__training.yml
@@ -17,7 +17,7 @@ process:
   body/format:
     plugin: default_value
     default_value: markdown_editor
-  field_career_categories/value:
+  field_career_categories:
     plugin: sub_process
     source: field_career_categories
     process:

--- a/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_node_revision__job.yml
+++ b/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_node_revision__job.yml
@@ -8,7 +8,7 @@ process:
   body/format:
     plugin: default_value
     default_value: "markdown_editor"
-  field_career_categories/value:
+  field_career_categories:
     plugin: sub_process
     source: field_career_categories
     process:

--- a/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_node_revision__report.yml
+++ b/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_node_revision__report.yml
@@ -10,7 +10,7 @@ process:
     plugin: skip_on_empty
     method: process
     source: field_bury/0/value
-  field_content_format/value:
+  field_content_format:
     plugin: sub_process
     source: field_content_format
     process:

--- a/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_node_revision__training.yml
+++ b/html/modules/custom/reliefweb_migrate/config/install/migrate_plus.migration.reliefweb_node_revision__training.yml
@@ -8,7 +8,7 @@ process:
   body/format:
     plugin: default_value
     default_value: "markdown_editor"
-  field_career_categories/value:
+  field_career_categories:
     plugin: sub_process
     source: field_career_categories
     process:


### PR DESCRIPTION
Refs: RW-656

This adds a drush command `rw-migrate:migrate-career-categories-revisions` to migrate the career categories field revisions for jobs and training.

Note: this is a copy of the command for the migration of the report content format field revisions which was run on prod some weeks ago.

### Tests

**Before running command**

Check some of the jobs/training below (they may not all be present depending on the freshness of the DB):
- 3815248
- 3815474
- 3827433
- 3829452
- 3829454
- 3830059
- 3834284
- 3834655
- 3837945
- 3839887
- 3839888
- 3839889
- 3839890
- 3839892
- 3839894
- 3841988

The `professional function` for training or the `career categories` field in the revision history should be missing from the oldest revisions (before May 15).

**After running the command**

Check the same node IDs and verify that the oldest revision has and entry for the `professional function` for training or the `career categories` field.