### PR TITLE
[RW-659] Use collation field to sort organizations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "league/html-to-markdown": "^5.0",
         "lolli42/finediff": "^1.0",
         "pelago/emogrifier": "^6.0",
-        "reliefweb/api-indexer": "^v2.3",
+        "reliefweb/api-indexer": "v2.5.0-alpha",
         "reliefweb/simple-autocomplete": "^v1.3",
         "reliefweb/simple-datepicker": "^v1.3",
         "symfony/flex": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "league/html-to-markdown": "^5.0",
         "lolli42/finediff": "^1.0",
         "pelago/emogrifier": "^6.0",
-        "reliefweb/api-indexer": "v2.5.0-alpha",
+        "reliefweb/api-indexer": "^v2.5.0",
         "reliefweb/simple-autocomplete": "^v1.3",
         "reliefweb/simple-datepicker": "^v1.3",
         "symfony/flex": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4f03471cdd9d43a16488220e8d1550c",
+    "content-hash": "caeb4e1f8a7b894b5b215d8c8eebe06a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8831,16 +8831,16 @@
         },
         {
             "name": "reliefweb/api-indexer",
-            "version": "v2.4.0",
+            "version": "v2.5.0-alpha",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/rwint-api-indexer.git",
-                "reference": "1f85af7255811c6c0aae95596b8830e4e734ddaa"
+                "reference": "329e76c7a0395bcc6da28d7ed634a54f03f4b975"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/rwint-api-indexer/zipball/1f85af7255811c6c0aae95596b8830e4e734ddaa",
-                "reference": "1f85af7255811c6c0aae95596b8830e4e734ddaa",
+                "url": "https://api.github.com/repos/UN-OCHA/rwint-api-indexer/zipball/329e76c7a0395bcc6da28d7ed634a54f03f4b975",
+                "reference": "329e76c7a0395bcc6da28d7ed634a54f03f4b975",
                 "shasum": ""
             },
             "require": {
@@ -8866,9 +8866,9 @@
             ],
             "support": {
                 "issues": "https://github.com/UN-OCHA/rwint-api-indexer/issues",
-                "source": "https://github.com/UN-OCHA/rwint-api-indexer/tree/v2.4.0"
+                "source": "https://github.com/UN-OCHA/rwint-api-indexer/tree/v2.5.0-alpha"
             },
-            "time": "2022-08-16T13:04:48+00:00"
+            "time": "2022-09-02T01:40:48+00:00"
         },
         {
             "name": "reliefweb/simple-autocomplete",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "caeb4e1f8a7b894b5b215d8c8eebe06a",
+    "content-hash": "f4be5fdb0fe25a16d016f2b9bc4cdc69",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8831,16 +8831,16 @@
         },
         {
             "name": "reliefweb/api-indexer",
-            "version": "v2.5.0-alpha",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/rwint-api-indexer.git",
-                "reference": "329e76c7a0395bcc6da28d7ed634a54f03f4b975"
+                "reference": "eac207e5abd4003ac1cbe9c9eba6b0ac04f3a8c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/rwint-api-indexer/zipball/329e76c7a0395bcc6da28d7ed634a54f03f4b975",
-                "reference": "329e76c7a0395bcc6da28d7ed634a54f03f4b975",
+                "url": "https://api.github.com/repos/UN-OCHA/rwint-api-indexer/zipball/eac207e5abd4003ac1cbe9c9eba6b0ac04f3a8c0",
+                "reference": "eac207e5abd4003ac1cbe9c9eba6b0ac04f3a8c0",
                 "shasum": ""
             },
             "require": {
@@ -8866,9 +8866,9 @@
             ],
             "support": {
                 "issues": "https://github.com/UN-OCHA/rwint-api-indexer/issues",
-                "source": "https://github.com/UN-OCHA/rwint-api-indexer/tree/v2.5.0-alpha"
+                "source": "https://github.com/UN-OCHA/rwint-api-indexer/tree/v2.5.0"
             },
-            "time": "2022-09-02T01:40:48+00:00"
+            "time": "2022-09-06T02:31:12+00:00"
         },
         {
             "name": "reliefweb/simple-autocomplete",

--- a/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
@@ -115,9 +115,7 @@ class SourceRiver extends RiverServiceBase {
         'field' => 'status',
         'value' => 'active',
       ],
-      // @todo just a reminder to try to find a way for the API to sort in
-      // language aware way.
-      'sort' => ['name:asc'],
+      'sort' => ['name.collation_en:asc'],
     ];
 
     // Add a filter on the selected letter.


### PR DESCRIPTION
Refs: RW-659

This uses the collation field introduced in https://github.com/UN-OCHA/rwint-api-indexer/pull/42 to sort the organizations alphabetically.

**Important**

This requires the update of the API indexer in https://github.com/UN-OCHA/rwint-api-indexer/pull/42 and the corresponding update of the API: https://github.com/UN-OCHA/rwint-api/pull/102

This uses the temporary `v2.5.0-alpha` tag of the API indexer for the purpose of testing and that will need to be changed to v2.5.0 when available.

### Tests

**Prerequisites**

1. Install the `analysis-icu` plugin in the elasticsearch container: `docker exec -it rwint9-elasticsearch bin/elasticsearch-plugin install analysis-icu`
2. Update the local API with https://github.com/UN-OCHA/rwint-api/pull/102

**Before checking out this branch**

1. Go to your local RW site organizations page and click on the `I` letter filter
2. Check that `iMMAP` is not on the first page
3. Click "last" in the page and check that iMMAP is towards the end of the page

**After checking out this branch**

1. Run `composer install` to switch to the `v2.5.0-alpha` version of the api-indexer
2. Re-index the sources: `drush rapi-i --tag=rw-659-test1 --replace --alias source`
3. Clear the cache `drush cr`
4. Go to your local RW site organizations page and click on the `I` letter filter
5. Check that `iMMAP` is on the first page and correctly placed among other sources alphabetically speaking