### PR TITLE
[RW-667] Performance improvements

### DIFF
--- a/config/google_tag.settings.yml
+++ b/config/google_tag.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: 65d5DfK5p2hQDpBskbvCIj2hSEqw_Odm2e_d46BH1Lk
 uri: 'public:/'
 compact_snippet: true
-include_file: true
+include_file: false
 rebuild_snippets: true
 flush_snippets: false
 debug_output: false

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -297,10 +297,13 @@ function reliefweb_entities_theme() {
         'attributes' => NULL,
         // Image style.
         'style' => NULL,
-        // Image information with uri, width, height, alt and copyright.
+        // Image information with uri, width, height, alt and copyright
+        // and optionally the loading mode.
         'image' => [],
         // Flag to indicate whether to show the caption or not.
         'caption' => TRUE,
+        // Flag to indicate the default loading mode: lazy or eager.
+        'loading' => 'lazy',
       ],
     ],
     'reliefweb_entities_book_menu' => [

--- a/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-image.html.twig
+++ b/html/modules/custom/reliefweb_entities/templates/reliefweb-entities-entity-image.html.twig
@@ -8,7 +8,9 @@
  * - attributes: figure attributes
  * - style: image style
  * - image: array with uri, alt, width, height, alt and copyright
+ *   and optionally the loading mode.
  * - caption: flag to indicate whether to show the caption or not.
+ * - loading: flag to indicate the default loading mode: lazy or eager.
  *
  * @todo handle responsive image styles when/if introduced.
  */
@@ -29,6 +31,7 @@
       '#alt': image.alt,
       '#attributes': {
         'class': ['rw-entity-image__image'],
+        'loading': image.loading is not empty ? image.loading : loading,
       },
       '#width': image.width,
       '#height': image.height

--- a/html/modules/custom/reliefweb_files/reliefweb_files.module
+++ b/html/modules/custom/reliefweb_files/reliefweb_files.module
@@ -46,6 +46,9 @@ function reliefweb_files_theme() {
         'footer' => NULL,
         // Section footer attributes.
         'footer_attributes' => NULL,
+        // Flag to indicate if the first attachment's preview should be lazy
+        // loaded or not.
+        'lazy_load_first_preview' => TRUE,
       ],
     ],
   ];

--- a/html/modules/custom/reliefweb_files/templates/reliefweb-file-list--interactive.html.twig
+++ b/html/modules/custom/reliefweb_files/templates/reliefweb-file-list--interactive.html.twig
@@ -12,6 +12,18 @@
   <div{{ list_attributes }}>
     {% for item in list %}
     <figure>
+      {% if item.preview is not empty and loop.index == 1 and not lazy_load_first_preview %}
+        {%
+          set item = item|merge({
+            'preview': item.preview|merge({
+              '#attributes': item.preview['#attributes']|merge({
+                'loading': 'eager'
+              })
+            })
+          })
+        %}
+      {% endif %}
+
       {% if item.url is not empty %}
       <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.preview }}</a>
       {% else %}

--- a/html/modules/custom/reliefweb_files/templates/reliefweb-file-list.html.twig
+++ b/html/modules/custom/reliefweb_files/templates/reliefweb-file-list.html.twig
@@ -13,6 +13,18 @@
     {% for item in list %}
     <li>
       <a href="{{ item.url }}">
+        {% if item.preview is not empty and loop.index == 1 and not lazy_load_first_preview %}
+          {%
+            set item = item|merge({
+              'preview': item.preview|merge({
+                '#attributes': item.preview['#attributes']|merge({
+                  'loading': 'eager'
+                })
+              })
+            })
+          %}
+        {% endif %}
+
         {{ item.preview }}
         <strong class="rw-file__label">{{ item.label }}</strong>
         <span class="rw-file__description">{{ item.description }}</span>

--- a/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-announcement.html.twig
+++ b/html/modules/custom/reliefweb_homepage/templates/reliefweb-homepage-announcement.html.twig
@@ -37,7 +37,8 @@
       '#uri': image.url,
       '#alt': image.alt,
       '#attributes': {
-        'class': ['rw-homepage-announcement__image']
+        'class': ['rw-homepage-announcement__image'],
+        'loading': 'eager',
       },
       '#title': image.title,
       '#width': image.width,

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--report.html.twig
@@ -63,7 +63,7 @@
   {% if entity.summary is not empty or entity.preview is not empty %}
   <div class="rw-river-article__content" lang="{{ entity.langcode }}">
     {% if entity.preview is not empty %}
-    <img src="{{ entity.preview.url }}" alt="{{ entity.preview.alt ?? '' }}">
+    <img src="{{ entity.preview.url }}" alt="{{ entity.preview.alt ?? '' }}" loading="lazy">
     {% endif %}
     {% if entity.summary is not empty %}
     <p>{{ entity.summary }}</p>

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -357,6 +357,7 @@ function common_design_subtheme_page_attachments_alter(array &$attachments) {
   // Main SVG sprites and logos used across the site.
   $svg_sprites = [
     '/themes/custom/common_design_subtheme/img/logos/rw-logo-desktop.svg',
+    '/themes/custom/common_design_subtheme/img/logos/rw-logo-mobile.svg',
     '/themes/custom/common_design_subtheme/img/logos/ocha-logo-sprite.svg',
     '/themes/custom/common_design_subtheme/components/rw-icons/img/rw-icons-sprite.svg',
     '/themes/contrib/common_design/img/logos/ocha-lockup.svg',

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -360,7 +360,6 @@ function common_design_subtheme_page_attachments_alter(array &$attachments) {
     '/themes/custom/common_design_subtheme/img/logos/rw-logo-mobile.svg',
     '/themes/custom/common_design_subtheme/img/logos/ocha-logo-sprite.svg',
     '/themes/custom/common_design_subtheme/components/rw-icons/img/rw-icons-sprite.svg',
-    '/themes/contrib/common_design/img/logos/ocha-lockup.svg',
     '/themes/custom/common_design_subtheme/img/logos/rw-logo-sprite.svg',
   ];
   foreach ($svg_sprites as $index => $path) {

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -356,26 +356,29 @@ function common_design_subtheme_reliefweb_form_mark_optional_alter(array &$eleme
 function common_design_subtheme_page_attachments_alter(array &$attachments) {
   // Main SVG sprites and logos used across the site.
   $svg_sprites = [
-    '/themes/custom/common_design_subtheme/img/logos/rw-logo-desktop.svg',
-    '/themes/custom/common_design_subtheme/img/logos/rw-logo-mobile.svg',
-    '/themes/custom/common_design_subtheme/img/logos/ocha-logo-sprite.svg',
-    '/themes/custom/common_design_subtheme/components/rw-icons/img/rw-icons-sprite.svg',
-    '/themes/custom/common_design_subtheme/img/logos/rw-logo-sprite.svg',
+    '/themes/custom/common_design_subtheme/img/logos/rw-logo-desktop.svg' => NULL,
+    '/themes/custom/common_design_subtheme/img/logos/rw-logo-mobile.svg' => '(max-width: 768px)',
+    '/themes/custom/common_design_subtheme/img/logos/ocha-logo-sprite.svg' => NULL,
+    '/themes/custom/common_design_subtheme/components/rw-icons/img/rw-icons-sprite.svg' => NULL,
+    '/themes/custom/common_design_subtheme/img/logos/rw-logo-sprite.svg' => NULL,
   ];
-  foreach ($svg_sprites as $index => $path) {
-    $attachments['#attached']['html_head'][] = [
-      [
-        '#type' => 'html_tag',
-        '#tag' => 'link',
-        '#attributes' => [
-          'rel' => 'preload',
-          'as' => 'image',
-          'href' => Url::fromUserInput($path, ['absolute' => TRUE])->toString(),
-        ],
-        '#weight' => ($index + 1) / 10,
+  $index = 0;
+  foreach ($svg_sprites as $path => $media) {
+    $data = [
+      '#type' => 'html_tag',
+      '#tag' => 'link',
+      '#attributes' => [
+        'rel' => 'preload',
+        'as' => 'image',
+        'href' => Url::fromUserInput($path, ['absolute' => TRUE])->toString(),
       ],
-      $path,
+      '#weight' => ($index + 1) / 10,
     ];
+    if (!empty($media)) {
+      $data['#attributes']['media'] = $media;
+    }
+    $attachments['#attached']['html_head'][] = [$data, $path];
+    $index++;
   }
 
   // Google fonts.

--- a/html/themes/custom/common_design_subtheme/components/rw-cd-header-footer/cd-footer.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-cd-header-footer/cd-footer.css
@@ -2,6 +2,11 @@
   outline: 3px solid var(--cd-reliefweb-brand-blue);
 }
 
+/* Use the OCHA logo sprite so that we have one less file to load. */
+.cd-footer .cd-mandate__logo {
+  background: url("../../img/logos/ocha-logo-sprite.svg") 0 -95px no-repeat;
+}
+
 /**
  * Copyright.
  *

--- a/html/themes/custom/common_design_subtheme/img/logos/ocha-logo-sprite.svg
+++ b/html/themes/custom/common_design_subtheme/img/logos/ocha-logo-sprite.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 149 95" width="149" height="95">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 149 132" width="149" height="132">
   <style>
     .light-grey-lighter {
       fill: #f5f7f9;
@@ -71,4 +71,5 @@
   <use xlink:href="#full-dark-grey-light-grey-background" x="0" y="37" width="80.5" height="20"/>
   <use xlink:href="#full-dark-grey-white-background" x="0" y="57" width="80.5" height="20"/>
   <use xlink:href="#logo-only" x="0" y="77" width="20" height="18" class="white"/>
+  <use xlink:href="#full" x="0" y="95" width="149" height="37" class="white"/>
 </svg>

--- a/html/themes/custom/common_design_subtheme/templates/content/node--blog_post--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--blog_post--full.html.twig
@@ -135,6 +135,7 @@
         '#theme': 'reliefweb_entities_entity_image',
         '#style': 'large',
         '#image': image,
+        '#loading': 'eager',
       }) }}
     {% endif %}
 

--- a/html/themes/custom/common_design_subtheme/templates/content/node--report--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/node--report--full.html.twig
@@ -165,12 +165,14 @@
         '#theme': 'reliefweb_entities_entity_image',
         '#style': 'large',
         '#image': image,
+        '#loading': 'eager',
       }) }}
     {% endif %}
 
     <div class="rw-report__content">
+      {% set attachments = node.getAttachments(content.field_file) %}
 
-      {{ node.getAttachments(content.field_file) }}
+      {{ attachments ? attachments|merge({'#lazy_load_first_preview': image is not empty}) }}
 
       {{ content.body.0|render|sanitize_html(false, 1) }}
 

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_homepage/reliefweb-homepage.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_homepage/reliefweb-homepage.html.twig
@@ -2,4 +2,29 @@
 {{ attach_library('common_design_subtheme/rw-headlines') }}
 {{ attach_library('common_design_subtheme/rw-loading') }}
 
+{# Load the first headline image as fast as possible as it's often the largest
+   contentful paint. #}
+{% if sections.headlines is not empty %}
+  {% set headlines = [] %}
+  {% for headline in sections.headlines['#entities'] %}
+    {% if loop.index == 1 and headline.image is not empty %}
+      {%
+        set headline = headline|merge({
+          'image': headline.image|merge({
+            'loading': 'eager'
+          })
+        })
+      %}
+    {% endif %}
+    {% set headlines = headlines|merge([headline]) %}
+  {% endfor %}
+  {%
+    set sections = sections|merge({
+      'headlines': sections.headlines|merge({
+        '#entities': headlines,
+      })
+    })
+  %}
+{% endif %}
+
 {% include '@reliefweb_homepage/reliefweb-homepage.html.twig' %}


### PR DESCRIPTION
Refs: RW-667

This adds a series of performance improvements:

- RW-660: add loading attribute for river thumbnails
- RW-661:  load the announcement image and first headline image eagerly on the homepage
- RW-662, RW-663:  load the report image or first attachment preview eagerly
- RW-664: load blog image eagerly
- RW-665: inline GTM loading snippet
- RW-666: preload mobile logo
- RW-668: use OCHA logo sprite for OCHA logo in footer

### Tests

**Before checking out this branch**

Run some performance profiling tools (with throttling) on your local site (ex: lighthouse), and record the results for:
- (1) homepage, 
- (2) report with an image, 
- (3) report with an attachment with a preview but no image
- (4) report with an image and an attachment
- (5) blog post with an image

**After checking out this branch**

1. Check that the "loading" attribute is set to "lazy" on the thumbnails of the `/updates?view=maps` for example
2. Check that the "loading" attribute is set to "eager" for the first headline image and the announcement on the homepage (1)
3. Check that the "loading" attribute is set to "eager" on the report (2)'s report image
4. Check that the "loading" attribute is set to "eager" on the report (3)'s attachment preview
5. Check that the "loading" attribute is set to "eager" on the report (4)'s image and set to "lazy" on the attachment preview.
6. Check that the "loading" attribute is set to "eager" on the blog post (5)'s report image
7. Check that the GTM loading snippet is inline in the source of a page
8. Check that there is a meta element to preload the rw-logo-mobile.svg file
9. Check your network tab and ensure `ocha-lockup.svg` is not loaded and that the OCHA logo in the footer is present

Run the same performance tool on the same pages as above and compare the results to confirm there is indeed some improvements. This should notably reduce the "LCP" (Largest Contentful Paint).