### PR TITLE
fix: Force the file extension to lowercase for file access, as that is how we store it.

### DIFF
--- a/docker/etc/nginx/custom/01_attachment_redirections.conf
+++ b/docker/etc/nginx/custom/01_attachment_redirections.conf
@@ -11,10 +11,15 @@ location /attachments/ {
     ## Force download of the file.
     add_header Content-Disposition 'attachment; filename="$file_name$file_ext"';
 
+    ## Ensure the file extension is lowercase for the try-filed call, as we
+    ## always store it as lowercase, but the request may contain uppercase.
+    # OPS-8473: Unexpected 404 error on uppercase file extension.
+    set_by_lua $file_ext_low "return ngx.arg[1]:lower()" $file_ext;
+
     ## Try the local file first then the remote one.
     # RW-554: Disabled as the docstore is not used.
     # try_files "/sites/default/files/attachments/$1/$2/$1$2$3$file_ext" @docstore-file;
-    try_files "/sites/default/files/attachments/$1/$2/$1$2$3$file_ext" =404;
+    try_files "/sites/default/files/attachments/$1/$2/$1$2$3$file_ext_low" =404;
   }
 
   return 404;


### PR DESCRIPTION
This does not affect the file extension in the content-disposition header, which is the same case as the original upload.

Refs: OPS-8473