### PR TITLE
[RW-672] Disaster map accessibility

### DIFF
--- a/html/modules/custom/reliefweb_disaster_map/js/disaster-map.js
+++ b/html/modules/custom/reliefweb_disaster_map/js/disaster-map.js
@@ -240,6 +240,13 @@
           }
         });
 
+        // Unset the active marker when pressing escape.
+        container.addEventListener('keydown', function (event) {
+          if (event.keyCode === 27) {
+            active = unsetActiveMarker(active);
+          }
+        });
+
         // Set a marker as the active one when focusing its disaster article.
         container.addEventListener('focusin', function (event) {
           var article = findParentArticle(container, event.target);

--- a/html/modules/custom/reliefweb_disaster_map/js/disaster-map.js
+++ b/html/modules/custom/reliefweb_disaster_map/js/disaster-map.js
@@ -5,7 +5,6 @@
 
   Drupal.behaviors.reliefwebDisasterMap = {
     attach: function (context, settings) {
-      console.log(settings);
       // Requirements.
       if (!reliefweb || !reliefweb.mapbox || !settings || !settings.reliefwebDisasterMap) {
         return;
@@ -74,6 +73,8 @@
         element.setAttribute('data-disaster-status', node.getAttribute('data-disaster-status'));
         element.setAttribute('data-disaster-type', node.getAttribute('data-disaster-type'));
 
+        node.setAttribute('data-marker-id', id);
+
         var marker = new mapboxgl.Marker({
           element: element,
           anchor: 'bottom'
@@ -89,7 +90,19 @@
         });
         marker.id = id;
         marker.disaster = node;
+        marker.disasterLink = node.querySelector('a');
         return marker;
+      }
+
+      // Find a parent disaster article from a child element.
+      function findParentArticle(container, element) {
+        while (element && element !== container) {
+          if (element.hasAttribute('data-marker-id')) {
+            return element;
+          }
+          element = element.parentNode;
+        }
+        return null;
       }
 
       // Create the map legend.
@@ -220,7 +233,18 @@
         container.addEventListener('click', function (event) {
           var target = event.target;
           if (target.hasAttribute && target.hasAttribute('data-id')) {
-            active = setActiveMarker(map, markers[target.getAttribute('data-id')], active, true);
+            markers[target.getAttribute('data-id')].disasterLink.focus();
+          }
+          else {
+            active = unsetActiveMarker(active);
+          }
+        });
+
+        // Set a marker as the active one when focusing its disaster article.
+        container.addEventListener('focusin', function (event) {
+          var article = findParentArticle(container, event.target);
+          if (article && article.hasAttribute && article.hasAttribute('data-marker-id')) {
+            active = setActiveMarker(map, markers[article.getAttribute('data-marker-id')], active, false);
           }
           else {
             active = unsetActiveMarker(active);

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--disaster.html.twig
@@ -88,7 +88,7 @@
     {% if entity.related_disasters %}
       <section class="rw-river-article--disaster__related-disasters">
         <h{{ level + 1 }} class="rw-river-article--disaster__related-disasters__title">{{ 'Related disasters'|t }}</h{{ level + 1 }}>
-        <ul class="rw-river-article--disaster__related-disasters__list">
+        <ul class="rw-river-article--disaster__related-disasters__list" aria-label="{{ 'Disasters related to @label'|t({'@label': entity.title}) }}">
           {% for related_disaster in entity.related_disasters %}
           <li{{ create_attribute()
             .addClass('rw-river-article--disaster__related-disasters__list__item')

--- a/html/themes/custom/common_design_subtheme/components/rw-disaster-map/rw-disaster-map.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-disaster-map/rw-disaster-map.css
@@ -147,6 +147,11 @@
   border: none;
   clip-path: inset(100%);
 }
+/* To help with accessibility and because it's not visible in the map popup,
+ * we hide the article footer. */
+.js .rw-disaster-map[data-map-enabled] .rw-disaster-map__article .rw-river-article__footer .rw-article-meta {
+  display: none;
+}
 
 /**
  * Map markers.

--- a/html/themes/custom/common_design_subtheme/components/rw-disasters/rw-disasters.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-disasters/rw-disasters.css
@@ -186,7 +186,7 @@
 }
 .rw-river-article--disaster .rw-river-article--disaster__related-disasters__list__item[data-disaster-status="current"]:before,
 .rw-river-article--disaster .rw-river-article--disaster__related-disasters__list__item[data-disaster-status="ongoing"]:before {
-  background-position-x: var(--rw-icons--disaster-type--24--red--x);
+  background-position-x: var(--rw-icons--disaster-type--16--red--x);
 }
 
 /**


### PR DESCRIPTION
Refs: RW-672, RW-671, RW-646

This improves the accessibility of the disaster map by highlighting the disaster markers on the map and showing the popup when navigating by keyboard.

There is also a tiny fix for the icons of the related disasters where the use of the wrong css variable resulted in a wrong position.

### Tests

1. Checkout this branch, clear the cache
2. Open the /disasters page and use `tab` to navigate until reaching the map
3. Check that this highlight markers on the map and shows the popup.
4. Check that related disasters can also be reached with `tab`
5. Check that pressing `escape` closes the popup and than `tab` jumps to the next disaster

Re. (4), here's a screenshot showing related disasters (you may need to tab through several disasters to find one with related disasters):

<img width="1181" alt="Screen Shot 2022-09-15 at 11 21 01" src="https://user-images.githubusercontent.com/696348/190298291-f8e1c1df-d256-4bcb-ad62-577a7c3b7ce6.png">
