### PR TITLE
[RW-635] Add sitemap entry to robots.txt

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Ignore everything except for the files necessary to build the codebase.
 *
+!assets
 !config
 !docker
 !html/modules/custom

--- a/assets/robots.txt.append
+++ b/assets/robots.txt.append
@@ -1,0 +1,2 @@
+# Sitemap
+Sitemap: https://reliefweb.int/sitemap.xml

--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,10 @@
                     "mode": "replace",
                     "path": "html/core/assets/scaffold/files/default.settings.php",
                     "overwrite": false
-                }
+                },
+                "[web-root]/robots.txt": {
+                    "append": "assets/robots.txt.append"
+               }
             },
             "locations": {
                 "web-root": "html/"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,7 @@ RUN mkdir -p /etc/nginx/custom && \
     # Permit nginx access to the X_DOCSTORE_PROVIDER_UUID env variable.
     sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;/' /etc/nginx/nginx.conf
 
+COPY --from=builder /srv/www/assets /srv/www/assets/
 COPY --from=builder /srv/www/config /srv/www/config/
 COPY --from=builder /srv/www/html /srv/www/html/
 COPY --from=builder /srv/www/vendor /srv/www/vendor/


### PR DESCRIPTION
Refs: RW-635

This simply appends back (was in D7) the sitemap location to the robots.txt

### Tests

1. Checkout the branch
2. Build the image with make and rebuild container
3. Check /robots.txt to confirm there is "Sitemap: https://reliefweb.int/sitemap.xml" at the end