### PR TITLE
[RW-634] do not attempt to fetch source attention message when not an editor

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/Services/JobFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/JobFormAlter.php
@@ -36,9 +36,12 @@ class JobFormAlter extends EntityFormAlterServiceBase {
     $form['field_country']['#attributes']['data-with-autocomplete'] = '';
     $form['field_source']['#attributes']['data-with-autocomplete'] = 'sources';
     $form['field_source']['#attributes']['data-selection-messages'] = '';
-    $form['field_source']['#attributes']['data-autocomplete-path'] = Url::fromRoute('reliefweb_form.node_form.source_attention_messages', [
-      'bundle' => 'job',
-    ])->toString();
+    // Fetch source attention message only if editor.
+    if ($this->currentUser->hasPermission('edit any job content')) {
+      $form['field_source']['#attributes']['data-autocomplete-path'] = Url::fromRoute('reliefweb_form.node_form.source_attention_messages', [
+        'bundle' => 'job',
+      ])->toString();
+    }
 
     // Add the fields to a potential new source.
     $this->addPotentialNewSourceFields($form, $form_state);

--- a/html/modules/custom/reliefweb_entities/src/Services/TrainingFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/TrainingFormAlter.php
@@ -42,9 +42,12 @@ class TrainingFormAlter extends EntityFormAlterServiceBase {
     $form['field_country']['#attributes']['data-with-autocomplete'] = '';
     $form['field_source']['#attributes']['data-with-autocomplete'] = 'sources';
     $form['field_source']['#attributes']['data-selection-messages'] = '';
-    $form['field_source']['#attributes']['data-autocomplete-path'] = Url::fromRoute('reliefweb_form.node_form.source_attention_messages', [
-      'bundle' => 'job',
-    ])->toString();
+    // Fetch source attention message only if editor.
+    if ($this->currentUser->hasPermission('edit any training content')) {
+      $form['field_source']['#attributes']['data-autocomplete-path'] = Url::fromRoute('reliefweb_form.node_form.source_attention_messages', [
+        'bundle' => 'training',
+      ])->toString();
+    }
 
     // Add the fields to a potential new source.
     $this->addPotentialNewSourceFields($form, $form_state);


### PR DESCRIPTION
Refs: RW-634

This disables trying to fetch the attention message when selecting a source in the job or training form when the current is not an editor. Currently this returns unnecessary 403s.

### Tests

**Before checking out this branch**

1. Log in as a normal user (non editor)
2. Go the /node/add/training to create a training
3. Open the network tab in your browser's dev tools
4. Select "UN Women" and check that there is a request to `admin/reliefweb_form/node_form/source_attention_messages/training` that returns a 403 and that no attention message appears 

<img width="929" alt="Screen Shot 2022-09-16 at 14 30 17" src="https://user-images.githubusercontent.com/696348/190563509-612d0278-6393-4f83-bfc2-3af148e74193.png">

5. Login in as an editor, repeat the steps below and check that the request above returns a 200 and that the attention message appears in the form6. 

<img width="919" alt="Screen Shot 2022-09-16 at 14 29 34" src="https://user-images.githubusercontent.com/696348/190563422-a13e3a98-c7a5-43f0-8266-bd10959cb3d1.png">

**After checking out this branch**

Repeat the steps below and check that at (4) there is no ajax request when logged in as a normal user and that there is a proper request returning a 200 with the display of the attention message (5) when logged in as an editor
