### PR TITLE
[RW-649] Remove the lang attribute for topics

### DIFF
--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--topic.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-river-article--topic.html.twig
@@ -54,7 +54,7 @@
 
   {# Article summary. #}
   {% if entity.summary is not empty %}
-  <div class="rw-river-article__content" lang="{{ entity.langcode }}">
+  <div class="rw-river-article__content">
     <p>{{ entity.summary }}</p>
   </div>
   {% endif %}


### PR DESCRIPTION
Refs: RW-649

This removes the empty "lang" attribute from the topics river article template because there is currently no way to specify the language of a topic (no language field). We cannot default to English but some topics are mostly in another language like https://reliefweb.int/topics/am-rica-latina-y-el-caribe for example.

### Tests

**Before checking out this branch**

1. Go to /topics, inspect the summary of a topic and check that there is an empty "lang" attribute for the content

<img width="506" alt="Screen Shot 2022-09-16 at 14 46 09" src="https://user-images.githubusercontent.com/696348/190565483-15a3aece-e23b-4461-b36d-70b0348f379e.png">

**After checking out this branch**

1. Clear the cache
2. Go to /topics and check that there si no "lang" attribute anymore

<img width="506" alt="Screen Shot 2022-09-16 at 14 47 17" src="https://user-images.githubusercontent.com/696348/190565613-9eb4016c-7261-431d-a6b9-d4048ccfaf2a.png">


