### PR TITLE
[RW-89] Use utility summarizer for subscription emails

### DIFF
--- a/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSummarizer.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSummarizer.php
@@ -150,7 +150,7 @@ class HtmlSummarizer {
    * @param int $length
    *   Maximum length of the summary.
    * @param int $separator_length
-   *   Length of the separator used to combined the paragraphs in the summary.
+   *   Length of the separator used to combine the paragraphs in the summary.
    *
    * @return array
    *   Summarized paragraphs.

--- a/html/modules/custom/reliefweb_utility/tests/src/Unit/HtmlSummarizerTest.php
+++ b/html/modules/custom/reliefweb_utility/tests/src/Unit/HtmlSummarizerTest.php
@@ -150,4 +150,77 @@ class HtmlSummarizerTest extends UnitTestCase {
     $this->assertNotEquals(HtmlSummarizer::summarize($html, 50, FALSE), $expected);
   }
 
+  /**
+   * Test whitespace sanitation.
+   *
+   * @covers \Drupal\reliefweb_utility\Helpers\HtmlSummarizer::sanitizeText
+   */
+  public function testSanitizeText() {
+    $input = '';
+    $expected = '';
+    $this->assertEquals(HtmlSummarizer::sanitizeText($input), $expected);
+
+    $input = ' test ';
+    $expected = 'test';
+    $this->assertEquals(HtmlSummarizer::sanitizeText($input), $expected);
+
+    $input = 'test   test';
+    $expected = 'test test';
+    $this->assertEquals(HtmlSummarizer::sanitizeText($input), $expected);
+
+    $input = ' test  test
+    test ';
+    $expected = 'test test test';
+    $this->assertEquals(HtmlSummarizer::sanitizeText($input), $expected);
+  }
+
+  /**
+   * Test whitespace sanitation.
+   *
+   * @covers \Drupal\reliefweb_utility\Helpers\HtmlSummarizer::summarizeParagraphs
+   */
+  public function testSummarizeParagraphs() {
+    $input = [];
+    $length = 0;
+    $separator_length = 0;
+    $expected = [];
+    $this->assertEquals($expected, HtmlSummarizer::summarizeParagraphs($input, $length, $separator_length));
+
+    $input = ['test1', 'test2', 'test3'];
+    $length = 20;
+    $separator_length = 1;
+    $expected = ['test1', 'test2', 'test3'];
+    $this->assertEquals($expected, HtmlSummarizer::summarizeParagraphs($input, $length, $separator_length));
+
+    $input = ['test1', 'test2', 'test3! test4'];
+    $length = 19;
+    $separator_length = 1;
+    $expected = ['test1', 'test2', 'test3...'];
+    $this->assertEquals($expected, HtmlSummarizer::summarizeParagraphs($input, $length, $separator_length));
+
+    $input = ['test1', 'test2', 'test3'];
+    $length = 14;
+    $separator_length = 1;
+    $expected = ['test1', 'test2', '...'];
+    $this->assertEquals($expected, HtmlSummarizer::summarizeParagraphs($input, $length, $separator_length));
+
+    $input = ['test1', 'test2', 'test3'];
+    $length = 14;
+    $separator_length = 3;
+    $expected = ['test1', 'test2', '...'];
+    $this->assertEquals($expected, HtmlSummarizer::summarizeParagraphs($input, $length, $separator_length));
+
+    $input = ['test1', 'test2', 'test3'];
+    $length = 14;
+    $separator_length = 4;
+    $expected = ['test1', '...'];
+    $this->assertEquals($expected, HtmlSummarizer::summarizeParagraphs($input, $length, $separator_length));
+
+    $input = ['test1', 'test2', 'test3'];
+    $length = 14;
+    $separator_length = 6;
+    $expected = ['test1', '...'];
+    $this->assertEquals($expected, HtmlSummarizer::summarizeParagraphs($input, $length, $separator_length));
+  }
+
 }

--- a/html/modules/custom/reliefweb_utility/tests/src/Unit/HtmlSummarizerTest.php
+++ b/html/modules/custom/reliefweb_utility/tests/src/Unit/HtmlSummarizerTest.php
@@ -175,7 +175,7 @@ class HtmlSummarizerTest extends UnitTestCase {
   }
 
   /**
-   * Test whitespace sanitation.
+   * Test paragraph summaries.
    *
    * @covers \Drupal\reliefweb_utility\Helpers\HtmlSummarizer::summarizeParagraphs
    */


### PR DESCRIPTION
Refs: RW-89

This updates the reliefweb_utility's `HtmlSummarizer` (split logic into 3 methods) and uses it for the subscriptions to reduce duplicate code.

### Tests

**Before checking out this branch**

1. Set the `reliefweb_api.settings` `api_url` to `https://api.reliefweb.int/v1` to be sure to have fresh content
2. Log in as an admin
3. Go to `/admin/subscriptions/preview/headlines` (or appeals for example to find something with content), click preview
4. Inspect the preview email and take note of the "preheader" div element's content.
5. Take note of the summary of some articles in the preview
6. Go to `/admin/subscriptions/preview/disaster`, inspect and take note of the `preheader`

**After checking out this branch**

1. Repeat steps from above
2. Compare the preheaders and summaries with the ones above, they should be identical or fairly similar.