### PR TITLE
[RW-678] prevent twig exception when a file preview doesn't have attributes

### DIFF
--- a/html/modules/custom/reliefweb_files/templates/reliefweb-file-list--interactive.html.twig
+++ b/html/modules/custom/reliefweb_files/templates/reliefweb-file-list--interactive.html.twig
@@ -16,7 +16,7 @@
         {%
           set item = item|merge({
             'preview': item.preview|merge({
-              '#attributes': item.preview['#attributes']|merge({
+              '#attributes': (item.preview['#attributes'] ?? {})|merge({
                 'loading': 'eager'
               })
             })

--- a/html/modules/custom/reliefweb_files/templates/reliefweb-file-list.html.twig
+++ b/html/modules/custom/reliefweb_files/templates/reliefweb-file-list.html.twig
@@ -17,7 +17,7 @@
           {%
             set item = item|merge({
               'preview': item.preview|merge({
-                '#attributes': item.preview['#attributes']|merge({
+                '#attributes': (item.preview['#attributes'] ?? {})|merge({
                   'loading': 'eager'
                 })
               })


### PR DESCRIPTION
Refs: RW-678

This fixes an issue with some reports with attachments without a proper preview.