### PR TITLE
[OPS-8495] Add nginx rule for derivative images to reduce Drupal hits

### DIFF
--- a/docker/etc/nginx/apps/drupal/drupal.conf
+++ b/docker/etc/nginx/apps/drupal/drupal.conf
@@ -142,6 +142,32 @@ location / {
         try_files $uri $uri/ @drupal;
     }
 
+    ## Location for public derivative images to avoid hitting Drupal for invalid
+    ## image derivative paths or if the source image doesn't exist.
+    location ^~ /sites/default/files/styles/ {
+
+        ## Valid public derivative image paths.
+        location ~ "^/sites/default/files/styles/[^/]+/public/(?<file_path>.*)$" {
+            access_log off;
+            expires 30d;
+            ## No need to bleed constant updates. Send the all shebang in one
+            ## fell swoop.
+            tcp_nodelay off;
+            ## Set the OS file cache.
+            open_file_cache max=3000 inactive=120s;
+            open_file_cache_valid 45s;
+            open_file_cache_min_uses 2;
+            open_file_cache_errors off;
+
+            ## Return the derivative image if it already exists or ask Drupal
+            ## to generate it otherwise.
+            try_files $uri @drupal-generate-derivative-image;
+        }
+
+        ## Simply return a 404 for unrecognized derivative image paths.
+        return 404;
+    }
+
     ## All static files will be served directly.
     location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|html|otf|ttf|eot|woff|svg)$ {
 
@@ -268,6 +294,18 @@ location @drupal-no-args {
     ## uncomment the two lines below.
     #proxy_pass http://phpapache/index.php?q=$uri;
     #proxy_set_header Connection '';
+}
+
+## Internal location to ask Drupal to generate a derivative image if the source
+## image is present.
+location @drupal-generate-derivative-image {
+  ## If the source image doesn't exist return a 404.
+  if (!-f "$document_root/sites/default/files/$file_path") {
+    return 404;
+  }
+
+  ## Otherwise pass the request to drupal.
+  try_files /dev/null @drupal;
 }
 
 ## Disallow access to .bzr, .git, .hg, .svn, .cvs directories: return


### PR DESCRIPTION
Refs: OPS-8495

Copy of the changes from https://github.com/UN-OCHA/docker-images/pull/306 to update RW's modified version of drupal.conf.

**Note:**  the only difference between the RW's drupal.conf file and the one from the base docker image is the rules for the sitemap.xml and sitemap.xsl. The `location = /sitemap.xml` is too specific to be overridable by another rule so unfortunately we currently have to keep the RW's drupal.conf.