### PR TITLE
[RW-221] Add tab navigation for bookmarks

### DIFF
--- a/html/modules/custom/reliefweb_bookmarks/reliefweb_bookmarks.module
+++ b/html/modules/custom/reliefweb_bookmarks/reliefweb_bookmarks.module
@@ -264,6 +264,8 @@ function reliefweb_bookmarks_theme() {
       'variables' => [
         // Wrapper attributes.
         'attributes' => NULL,
+        // Navigation tabs with the overview and bookmark types.
+        'tabs' => [],
         // List of river sections for each bookmarked content type/vocabulary.
         'sections' => [],
         // Link to go back to the bookmark list for example.

--- a/html/modules/custom/reliefweb_bookmarks/src/Controller/UserBookmarksController.php
+++ b/html/modules/custom/reliefweb_bookmarks/src/Controller/UserBookmarksController.php
@@ -202,7 +202,7 @@ class UserBookmarksController extends ControllerBase implements ContainerInjecti
    */
   public function bookmarksByType(UserInterface $user, $entity_type, $bundle) {
     $config = $this->configFactory->get('reliefweb_bookmarks.settings');
-    $uid = $this->account->id();
+    $uid = $user->id();
 
     // Number of items per page.
     $limit = 10;

--- a/html/modules/custom/reliefweb_bookmarks/templates/reliefweb-bookmarks.html.twig
+++ b/html/modules/custom/reliefweb_bookmarks/templates/reliefweb-bookmarks.html.twig
@@ -6,11 +6,13 @@
    *
    * Available variables:
    * - attributes: wrapper attributes.
+   * - tabs: navigation tabs with the overview and bookmark types.
    * - sections: list of rivers fo content.
    */
 
 #}
 <div{{ attributes.addClass('rw-bookmarks') }}>
+  {{ tabs }}
   {% if sections is not empty %}
     {{ sections }}
   {% else %}
@@ -18,6 +20,8 @@
   {% endif %}
 
   {% if link %}
-    <a class="rw-bookmarks__link" href="{{ link.url }}">{{ link.label }}</a>
+    <footer class="rw-bookmarks__footer">
+      <a class="rw-bookmarks__link" href="{{ link.url }}">{{ link.label }}</a>
+    </footer>
   {% endif %}
 </div>

--- a/html/themes/custom/common_design_subtheme/components/rw-user/rw-user-bookmarks.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-user/rw-user-bookmarks.css
@@ -2,6 +2,17 @@
 .rw-bookmarks {
   padding-top: 24px;
 }
+.rw-bookmarks .rw-river-views {
+  margin-bottom: 2rem;
+}
+.rw-bookmarks .rw-river__title {
+  padding-left: 8px;
+  border-left: 8px solid var(--cd-reliefweb-brand-blue);
+}
+.rw-bookmarks .rw-river-results {
+  padding: 0;
+  border: none;
+}
 .rw-bookmarks article {
   position: relative;
   margin: 0 0 20px 0;

--- a/html/themes/custom/common_design_subtheme/components/rw-user/rw-user-bookmarks.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-user/rw-user-bookmarks.css
@@ -32,8 +32,8 @@
   background: var(--rw-icons--content--report--24--grey);
 }
 .rw-bookmarks article.rw-river-article--job:before {
-  background-position-y: 0;
+  background: var(--rw-icons--content--job--24--grey);
 }
 .rw-bookmarks article.rw-river-article--training:before {
-  background-position-y: -24px;
+  background: var(--rw-icons--content--training--24--grey);
 }

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_bookmarks/reliefweb-bookmarks.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_bookmarks/reliefweb-bookmarks.html.twig
@@ -1,2 +1,4 @@
+{{ attach_library('common_design_subtheme/rw-river') }}
 {{ attach_library('common_design_subtheme/rw-user') }}
+{% set attributes = attributes.addClass('rw-river-page', 'cd-flow') %}
 {% include '@reliefweb_bookmarks/reliefweb-bookmarks.html.twig' %}


### PR DESCRIPTION
Refs: RW-221

This fixes a couple of issues with the bookmarks (see first 2 commits) and add some tab navigation.

It's re-using the "views" from the river pages like the `/updates` page and I think the styling is good enough for such a seldom used feature.

### Tests

1. Bookmark some reports, jobs and training
<img width="1191" alt="Screen Shot 2022-09-22 at 12 14 14" src="https://user-images.githubusercontent.com/696348/191650410-2b9d8cb3-275a-4546-b8a1-aeacdbf0af74.png">

2. Go to your account >  bookmarks
3. Check that there the tab navigation appears and that the links show the proper bookmarks4. 

<img width="1233" alt="Screen Shot 2022-09-22 at 12 10 22" src="https://user-images.githubusercontent.com/696348/191649930-ff40add7-31be-4c5d-bd48-d628b1f4e550.png">
