### PR TITLE
[RW-15] Media image upload validation

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,7 +1,8 @@
 {
     "patches": {
         "drupal/core" : {
-            "https://www.drupal.org/project/drupal/issues/3047110": "patches/core--drupal--3047110-taxonomy-term-moderation-class.patch"
+            "https://www.drupal.org/project/drupal/issues/3047110": "patches/core--drupal--3047110-taxonomy-term-moderation-class.patch",
+            "https://www.drupal.org/project/drupal/issues/3008292": "patches/core--drupal--3008292-image-upload-validators.patch"
         },
         "drupal/migrate_tools" : {
             "https://www.drupal.org/project/migrate_tools/issues/3256236": "https://www.drupal.org/files/issues/2021-12-28/invalid_placeholder-3256236-3.patch"

--- a/patches/core--drupal--3008292-image-upload-validators.patch
+++ b/patches/core--drupal--3008292-image-upload-validators.patch
@@ -1,0 +1,403 @@
+diff --git a/core/modules/file/src/Plugin/rest/resource/FileUploadResource.php b/core/modules/file/src/Plugin/rest/resource/FileUploadResource.php
+index 0d5425009c04d2da136a57dfe34253e7a9bbd650..0d34c5b19e24b7e6afd2868ede215957b6938b11 100644
+--- a/core/modules/file/src/Plugin/rest/resource/FileUploadResource.php
++++ b/core/modules/file/src/Plugin/rest/resource/FileUploadResource.php
+@@ -2,9 +2,7 @@
+ 
+ namespace Drupal\file\Plugin\rest\resource;
+ 
+-use Drupal\Component\Utility\Bytes;
+ use Drupal\Component\Utility\Crypt;
+-use Drupal\Component\Utility\Environment;
+ use Drupal\Core\Config\Config;
+ use Drupal\Core\Entity\EntityTypeManagerInterface;
+ use Drupal\Core\Field\FieldDefinitionInterface;
+@@ -536,9 +534,6 @@ protected function getUploadLocation(array $settings) {
+   /**
+    * Retrieves the upload validators for a field definition.
+    *
+-   * This is copied from \Drupal\file\Plugin\Field\FieldType\FileItem as there
+-   * is no entity instance available here that a FileItem would exist for.
+-   *
+    * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+    *   The field definition for which to get validators.
+    *
+@@ -547,25 +542,14 @@ protected function getUploadLocation(array $settings) {
+    *   element's '#upload_validators' property.
+    */
+   protected function getUploadValidators(FieldDefinitionInterface $field_definition) {
+-    $validators = [
+-      // Add in our check of the file name length.
+-      'file_validate_name_length' => [],
+-    ];
+-    $settings = $field_definition->getSettings();
+-
+-    // Cap the upload size according to the PHP limit.
+-    $max_filesize = Bytes::toNumber(Environment::getUploadMaxSize());
+-    if (!empty($settings['max_filesize'])) {
+-      $max_filesize = min($max_filesize, Bytes::toNumber($settings['max_filesize']));
+-    }
+-
+-    // There is always a file size limit due to the PHP server limit.
+-    $validators['file_validate_size'] = [$max_filesize];
+-
+-    // Add the extension check if necessary.
+-    if (!empty($settings['file_extensions'])) {
+-      $validators['file_validate_extensions'] = [$settings['file_extensions']];
+-    }
++    $item_definition = $field_definition->getItemDefinition();
++    $class = $item_definition->getClass();
++    /** @var \Drupal\file\Plugin\Field\FieldType\FileItem $item */
++    $item = new $class($item_definition);
++
++    $validators = $item->getUploadValidators();
++    // Add in our check of the file name length.
++    $validators['file_validate_name_length'] = [];
+ 
+     return $validators;
+   }
+diff --git a/core/modules/file/tests/src/Kernel/FileItemValidationTest.php b/core/modules/file/tests/src/Kernel/FileItemValidationTest.php
+index b9a9bd574c618722bbf41a3159a47d01b4716e2a..c0ba3c56b1467c7d4ff4bfb180fe102e4f57e807 100644
+--- a/core/modules/file/tests/src/Kernel/FileItemValidationTest.php
++++ b/core/modules/file/tests/src/Kernel/FileItemValidationTest.php
+@@ -8,7 +8,6 @@
+ use Drupal\file\Entity\File;
+ use Drupal\KernelTests\KernelTestBase;
+ use Drupal\user\Entity\User;
+-use org\bovigo\vfs\vfsStream;
+ 
+ /**
+  * Tests that files referenced in file and image fields are always validated.
+@@ -75,25 +74,20 @@ public function testFileValidationConstraint($file_type) {
+       'bundle' => 'entity_test',
+       'settings' => [
+         'max_filesize' => '2k',
+-        'file_extensions' => 'jpg|png',
++        'file_extensions' => 'jpg',
+       ],
+     ]);
+     $field->save();
+ 
+-    vfsStream::setup('drupal_root');
+-    vfsStream::create([
+-      'sites' => [
+-        'default' => [
+-          'files' => [
+-            'test.txt' => str_repeat('a', 3000),
+-          ],
+-        ],
+-      ],
+-    ]);
++    $image_uri = uniqid('public://') . '.png';
++    $resolution = '1024x768';
++    $image_uri = $this->getRandomGenerator()->image($image_uri, $resolution, $resolution);
++    // The file needs to be bigger than 2 KB for the test to pass.
++    $this->assertGreaterThan(2048, filesize($image_uri));
+ 
+     // Test for max filesize.
+     $file = File::create([
+-      'uri' => 'vfs://drupal_root/sites/default/files/test.txt',
++      'uri' => $image_uri,
+       'uid' => $this->user->id(),
+     ]);
+     $file->setPermanent();
+@@ -109,9 +103,9 @@ public function testFileValidationConstraint($file_type) {
+     $this->assertCount(2, $result);
+ 
+     $this->assertEquals('field_test_file.0', $result->get(0)->getPropertyPath());
+-    $this->assertEquals('The file is <em class="placeholder">2.93 KB</em> exceeding the maximum file size of <em class="placeholder">2 KB</em>.', (string) $result->get(0)->getMessage());
++    $this->assertStringEndsWith('exceeding the maximum file size of <em class="placeholder">2 KB</em>.', (string) $result->get(0)->getMessage());
+     $this->assertEquals('field_test_file.0', $result->get(1)->getPropertyPath());
+-    $this->assertEquals('Only files with the following extensions are allowed: <em class="placeholder">jpg|png</em>.', (string) $result->get(1)->getMessage());
++    $this->assertEquals('Only files with the following extensions are allowed: <em class="placeholder">jpg</em>.', (string) $result->get(1)->getMessage());
+ 
+     // Refer to a file that does not exist.
+     $entity_test = EntityTest::create([
+diff --git a/core/modules/image/src/Controller/QuickEditImageController.php b/core/modules/image/src/Controller/QuickEditImageController.php
+index b3e24c17992ebae9e3c4b0057d6c6f1217330f4a..d0b737b8f9af152d85cfc3defb34f3afcf41f1d1 100644
+--- a/core/modules/image/src/Controller/QuickEditImageController.php
++++ b/core/modules/image/src/Controller/QuickEditImageController.php
+@@ -110,14 +110,8 @@ public static function create(ContainerInterface $container) {
+   public function upload(EntityInterface $entity, $field_name, $langcode, $view_mode_id) {
+     $field = $this->getField($entity, $field_name, $langcode);
+     $field_validators = $field->getUploadValidators();
+-    $field_settings = $field->getFieldDefinition()->getSettings();
+     $destination = $field->getUploadLocation();
+ 
+-    // Add upload resolution validation.
+-    if ($field_settings['max_resolution'] || $field_settings['min_resolution']) {
+-      $field_validators['file_validate_image_resolution'] = [$field_settings['max_resolution'], $field_settings['min_resolution']];
+-    }
+-
+     // Create the destination directory if it does not already exist.
+     if (isset($destination) && !$this->fileSystem->prepareDirectory($destination, FileSystemInterface::CREATE_DIRECTORY)) {
+       return new JsonResponse(['main_error' => $this->t('The destination directory could not be created.'), 'errors' => '']);
+diff --git a/core/modules/image/src/Plugin/Field/FieldType/ImageItem.php b/core/modules/image/src/Plugin/Field/FieldType/ImageItem.php
+index 204a1ac5c70ad8f95e3e48f97d141d340422609e..b04e43b2da410613124342e08f286379567bb9cb 100644
+--- a/core/modules/image/src/Plugin/Field/FieldType/ImageItem.php
++++ b/core/modules/image/src/Plugin/Field/FieldType/ImageItem.php
+@@ -500,4 +500,36 @@ public function isDisplayed() {
+     return TRUE;
+   }
+ 
++  /**
++   * {@inheritdoc}
++   */
++  public function getUploadValidators() {
++    $upload_validators = parent::getUploadValidators();
++    // Always validate that the uploaded file is an image.
++    $upload_validators['file_validate_is_image'] = [];
++
++    // If the image's resolution is constrained by the field settings, validate
++    // that too.
++    $min_resolution = $this->getSetting('min_resolution') ?: 0;
++    $max_resolution = $this->getSetting('max_resolution') ?: 0;
++    if ($min_resolution || $max_resolution) {
++      $upload_validators['file_validate_image_resolution'] = [
++        $max_resolution,
++        $min_resolution,
++      ];
++    }
++
++    if (isset($upload_validators['file_validate_extensions'])) {
++      $extensions = $this->getSetting('file_extensions');
++      $supported_extensions = \Drupal::service('image.factory')->getSupportedExtensions();
++
++      // If using custom extension validation, ensure that the extensions are
++      // supported by the current image toolkit. Otherwise, validate against all
++      // toolkit supported extensions.
++      $extensions = !empty($extensions) ? array_intersect(explode(' ', $extensions), $supported_extensions) : $supported_extensions;
++      $upload_validators['file_validate_extensions'][0] = implode(' ', $extensions);
++    }
++    return $upload_validators;
++  }
++
+ }
+diff --git a/core/modules/image/src/Plugin/Field/FieldWidget/ImageWidget.php b/core/modules/image/src/Plugin/Field/FieldWidget/ImageWidget.php
+index 17360160a35e084665051139dacf7c451e81b6e5..30c7e3876cbbf8cdb67b87f51c925501790f5d16 100644
+--- a/core/modules/image/src/Plugin/Field/FieldWidget/ImageWidget.php
++++ b/core/modules/image/src/Plugin/Field/FieldWidget/ImageWidget.php
+@@ -141,26 +141,10 @@ protected function formMultipleElements(FieldItemListInterface $items, array &$f
+    */
+   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+     $element = parent::formElement($items, $delta, $element, $form, $form_state);
++    $element['#upload_validators'] = $items[$delta]->getUploadValidators();
+ 
+     $field_settings = $this->getFieldSettings();
+ 
+-    // Add image validation.
+-    $element['#upload_validators']['file_validate_is_image'] = [];
+-
+-    // Add upload resolution validation.
+-    if ($field_settings['max_resolution'] || $field_settings['min_resolution']) {
+-      $element['#upload_validators']['file_validate_image_resolution'] = [$field_settings['max_resolution'], $field_settings['min_resolution']];
+-    }
+-
+-    $extensions = $field_settings['file_extensions'];
+-    $supported_extensions = $this->imageFactory->getSupportedExtensions();
+-
+-    // If using custom extension validation, ensure that the extensions are
+-    // supported by the current image toolkit. Otherwise, validate against all
+-    // toolkit supported extensions.
+-    $extensions = !empty($extensions) ? array_intersect(explode(' ', $extensions), $supported_extensions) : $supported_extensions;
+-    $element['#upload_validators']['file_validate_extensions'][0] = implode(' ', $extensions);
+-
+     // Add mobile device image capture acceptance.
+     $element['#accept'] = 'image/*';
+ 
+diff --git a/core/modules/image/tests/src/Kernel/ImageItemTest.php b/core/modules/image/tests/src/Kernel/ImageItemTest.php
+index 28847472133c7243367f7c10a69fdce09a2e0f9e..29977850aef4bbbae167dac3c2ec6f9adb603b1c 100644
+--- a/core/modules/image/tests/src/Kernel/ImageItemTest.php
++++ b/core/modules/image/tests/src/Kernel/ImageItemTest.php
+@@ -159,7 +159,37 @@ public function testImageItemMalformed() {
+       $this->assertEmpty($entity->image_test->width);
+       $this->assertEmpty($entity->image_test->height);
+     }
++  }
+ 
++  /**
++   * Tests that image items register appropriate upload validators.
++   */
++  public function testUploadValidators() {
++    $entity = EntityTest::create();
++    $items = $entity->get('image_test');
++    $item = $items->appendItem();
++    $field_definition = $items->getFieldDefinition();
++
++    $validators = $item->getUploadValidators();
++    $this->assertArrayHasKey('file_validate_is_image', $validators);
++    $this->assertArrayNotHasKey('file_validate_image_resolution', $validators);
++
++    $field_definition->setSetting('min_resolution', '32x32')->save();
++    $validators = $item->getUploadValidators();
++    $this->assertArrayHasKey('file_validate_is_image', $validators);
++    $this->assertSame([0, '32x32'], $validators['file_validate_image_resolution']);
++
++    $field_definition->setSetting('min_resolution', NULL)
++      ->setSetting('max_resolution', '1024x768')
++      ->save();
++    $validators = $item->getUploadValidators();
++    $this->assertArrayHasKey('file_validate_is_image', $validators);
++    $this->assertSame(['1024x768', 0], $validators['file_validate_image_resolution']);
++
++    $field_definition->setSetting('min_resolution', '32x32')->save();
++    $validators = $item->getUploadValidators();
++    $this->assertArrayHasKey('file_validate_is_image', $validators);
++    $this->assertSame(['1024x768', '32x32'], $validators['file_validate_image_resolution']);
+   }
+ 
+ }
+diff --git a/core/modules/jsonapi/src/Controller/TemporaryJsonapiFileFieldUploader.php b/core/modules/jsonapi/src/Controller/TemporaryJsonapiFileFieldUploader.php
+index d07b4562ec84168c794f3cf7d7a27d89949b6aa0..6f720afc43b190d3e3e59e10f77dfc2d21563f62 100644
+--- a/core/modules/jsonapi/src/Controller/TemporaryJsonapiFileFieldUploader.php
++++ b/core/modules/jsonapi/src/Controller/TemporaryJsonapiFileFieldUploader.php
+@@ -2,9 +2,7 @@
+ 
+ namespace Drupal\jsonapi\Controller;
+ 
+-use Drupal\Component\Utility\Bytes;
+ use Drupal\Component\Utility\Crypt;
+-use Drupal\Component\Utility\Environment;
+ use Drupal\Core\Entity\EntityInterface;
+ use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
+ use Drupal\Core\Field\FieldDefinitionInterface;
+@@ -470,9 +468,6 @@ protected function getUploadLocation(array $settings) {
+   /**
+    * Retrieves the upload validators for a field definition.
+    *
+-   * This is copied from \Drupal\file\Plugin\Field\FieldType\FileItem as there
+-   * is no entity instance available here that a FileItem would exist for.
+-   *
+    * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+    *   The field definition for which to get validators.
+    *
+@@ -481,25 +476,14 @@ protected function getUploadLocation(array $settings) {
+    *   element's '#upload_validators' property.
+    */
+   protected function getUploadValidators(FieldDefinitionInterface $field_definition) {
+-    $validators = [
+-      // Add in our check of the file name length.
+-      'file_validate_name_length' => [],
+-    ];
+-    $settings = $field_definition->getSettings();
+-
+-    // Cap the upload size according to the PHP limit.
+-    $max_filesize = Bytes::toNumber(Environment::getUploadMaxSize());
+-    if (!empty($settings['max_filesize'])) {
+-      $max_filesize = min($max_filesize, Bytes::toNumber($settings['max_filesize']));
+-    }
+-
+-    // There is always a file size limit due to the PHP server limit.
+-    $validators['file_validate_size'] = [$max_filesize];
+-
+-    // Add the extension check if necessary.
+-    if (!empty($settings['file_extensions'])) {
+-      $validators['file_validate_extensions'] = [$settings['file_extensions']];
+-    }
++    $item_definition = $field_definition->getItemDefinition();
++    $class = $item_definition->getClass();
++    /** @var \Drupal\file\Plugin\Field\FieldType\FileItem $item */
++    $item = new $class($item_definition);
++
++    $validators = $item->getUploadValidators();
++    // Add in our check of the file name length.
++    $validators['file_validate_name_length'] = [];
+ 
+     return $validators;
+   }
+diff --git a/core/modules/media_library/src/Form/FileUploadForm.php b/core/modules/media_library/src/Form/FileUploadForm.php
+index 2c0a81976d2f4c6817a37cb651d51a634703d022..95b9a6793da88e5660b0930d8c1c3afc6f562cf9 100644
+--- a/core/modules/media_library/src/Form/FileUploadForm.php
++++ b/core/modules/media_library/src/Form/FileUploadForm.php
+@@ -5,7 +5,6 @@
+ use Drupal\Core\Entity\EntityStorageInterface;
+ use Drupal\Core\Entity\EntityTypeManagerInterface;
+ use Drupal\Core\Field\FieldStorageDefinitionInterface;
+-use Drupal\Core\Field\TypedData\FieldItemDataDefinition;
+ use Drupal\Core\File\Exception\FileWriteException;
+ use Drupal\Core\File\FileSystemInterface;
+ use Drupal\Core\Form\FormBuilderInterface;
+@@ -17,7 +16,6 @@
+ use Drupal\file\FileInterface;
+ use Drupal\file\FileUsage\FileUsageInterface;
+ use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
+-use Drupal\file\Plugin\Field\FieldType\FileItem;
+ use Drupal\media\MediaInterface;
+ use Drupal\media\MediaTypeInterface;
+ use Drupal\media_library\MediaLibraryUiBuilder;
+@@ -349,9 +347,10 @@ protected function createMediaFromValue(MediaTypeInterface $media_type, EntitySt
+    *   A created file item.
+    */
+   protected function createFileItem(MediaTypeInterface $media_type) {
+-    $field_definition = $media_type->getSource()->getSourceFieldDefinition($media_type);
+-    $data_definition = FieldItemDataDefinition::create($field_definition);
+-    return new FileItem($data_definition);
++    $data_definition = $media_type->getSource()->getSourceFieldDefinition($media_type)
++      ->getItemDefinition();
++    $class = $data_definition->getClass();
++    return new $class($data_definition);
+   }
+ 
+   /**
+diff --git a/core/modules/media_library/tests/src/FunctionalJavascript/MediaLibraryImageUploadTest.php b/core/modules/media_library/tests/src/FunctionalJavascript/MediaLibraryImageUploadTest.php
+new file mode 100644
+index 0000000000000000000000000000000000000000..7dceef13517e5b1cbc43403fb233b7edc0a6ead3
+--- /dev/null
++++ b/core/modules/media_library/tests/src/FunctionalJavascript/MediaLibraryImageUploadTest.php
+@@ -0,0 +1,56 @@
++<?php
++
++namespace Drupal\Tests\media_library\FunctionalJavascript;
++
++use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
++use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
++
++/**
++ * Tests the handling of images uploaded to the media library.
++ *
++ * @group media_library
++ */
++class MediaLibraryImageUploadTest extends MediaLibraryTestBase {
++
++  use EntityReferenceTestTrait;
++  use MediaTypeCreationTrait;
++
++  /**
++   * Tests that oversized images are automatically resized on upload.
++   */
++  public function testImageResizing() {
++    // Create a media type that only accepts images up to 16x16 in size.
++    $media_type = $this->createMediaType('image');
++    $media_type->getSource()
++      ->getSourceFieldDefinition($media_type)
++      ->setSetting('max_resolution', '16x16')
++      ->save();
++
++    $node_type = $this->drupalCreateContentType()->id();
++    $this->createEntityReferenceField('node', $node_type, 'field_icon', 'Icon', 'media');
++    $this->container->get('entity_display.repository')
++      ->getFormDisplay('node', $node_type)
++      ->setComponent('field_icon', [
++        'type' => 'media_library_widget',
++      ])
++      ->save();
++
++    $account = $this->drupalCreateUser([
++      "create $node_type content",
++      'create ' . $media_type->id() . ' media',
++    ]);
++    $this->drupalLogin($account);
++    $this->drupalGet("/node/add/$node_type");
++    $this->openMediaLibraryForField('field_icon');
++
++    $image_uri = uniqid('public://') . '.png';
++    $image_uri = $this->getRandomGenerator()->image($image_uri, '16x16', '32x32');
++    $image_path = $this->container->get('file_system')->realpath($image_uri);
++    $this->assertNotEmpty($image_path);
++    $this->assertFileExists($image_path);
++
++    $this->waitForFieldExists('Add file')->attachFile($image_path);
++    $this->waitForText('The image was resized to fit within the maximum allowed dimensions of 16x16 pixels.');
++  }
++
++}


### PR DESCRIPTION
Refs: RW-15

This adds the patch from https://www.drupal.org/project/drupal/issues/3008292 so that the upload validators (dimensions, size, file extensions) are respected when uploading an image via the media library (ex:  blog posts).

### Tests

**Before checking out this branch**

1. Create a new blog post, click add an image
2. Upload an image that doesn't have the proper dimensions (ex: https://reliefweb.int/sites/reliefweb.int/files/resources/afg_ocha_250px.png)
3. Check that the upload is allowed even though the width is lower than 700px
4. Try with https://reliefweb.int/sites/reliefweb.int/files/resources/afg_ocha_1000px.png for example, to confirm the upload also works.

**After checking out this branch**

1. Run `composer install` to patch core
2. Follow steps (1) and (2) from above, there should be a form error like
<img width="821" alt="Screen Shot 2022-09-23 at 11 16 00" src="https://user-images.githubusercontent.com/696348/191881552-c12acb75-8c69-4900-8bc5-f452a8aad456.png">
3. Try with https://reliefweb.int/sites/reliefweb.int/files/resources/afg_ocha_1000px.png for example, to confirm the upload works when the dimensions are correct.
