### PR TITLE
RW-680 Fix Telegram icon on homepage

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/layout/html--home.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/html--home.html.twig
@@ -51,7 +51,7 @@
 			{{ page_bottom }}
 
 			{% block icons %}
-				{% include '@common_design/cd/cd-icons/cd-icons.html.twig' %}
+				{% include '@common_design_subtheme/cd/cd-icons/cd-icons.html.twig' %}
 			{% endblock %}
 
 		<js-bottom-placeholder token="{{ placeholder_token }}">


### PR DESCRIPTION
fix: adjust icon sprite path in home html template override so telegram icon displays

Refs: RW-680