### PR TITLE
[RW-681] Ensure that the entity publication status and moderation status are in sync

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -17,7 +17,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
@@ -209,7 +208,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
    * {@inheritdoc}
    */
   public function isViewableStatus($status, ?AccountInterface $account = NULL) {
-    return $status === 'published';
+    return $this->isPublishedStatus($status);
   }
 
   /**
@@ -217,6 +216,13 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
    */
   public function isEditableStatus($status, ?AccountInterface $account = NULL) {
     return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isPublishedStatus($status) {
+    return $status === 'published';
   }
 
   /**
@@ -251,9 +257,11 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
       }
     }
 
-    // Mark as published if the status is viewable by everybody.
+    // Set the entity as published (drupal status field) if the moderation
+    // status corresponds to a published state. This ensures the moderation
+    // status and the drupal publication status are in sync.
     if ($entity instanceof EntityPublishedInterface) {
-      if ($this->isViewableStatus($status, new AnonymousUserSession())) {
+      if ($this->isPublishedStatus($status)) {
         $entity->setPublished();
       }
       else {

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceInterface.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceInterface.php
@@ -119,6 +119,19 @@ interface ModerationServiceInterface {
   public function isEditableStatus($status, ?AccountInterface $account = NULL);
 
   /**
+   * Check if an entity with the given status is considered published.
+   *
+   * Note: published doesn't mean that the entity is accessible to everybody.
+   *
+   * @param string $status
+   *   Entity moderation status.
+   *
+   * @return bool
+   *   TRUE if the entity is considered published.
+   */
+  public function isPublishedStatus($status);
+
+  /**
    * Check if the entity has the given status.
    *
    * @param string $status

--- a/html/modules/custom/reliefweb_moderation/src/Services/CountryModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/CountryModeration.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\reliefweb_moderation\Services;
 
-use Drupal\Core\Session\AccountInterface;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
 
@@ -124,8 +123,8 @@ class CountryModeration extends ModerationServiceBase {
   /**
    * {@inheritdoc}
    */
-  public function isViewableStatus($status, ?AccountInterface $account = NULL) {
-    return TRUE;
+  public function isPublishedStatus($status) {
+    return $status === 'normal' || $status === 'ongoing';
   }
 
   /**

--- a/html/modules/custom/reliefweb_moderation/src/Services/DisasterModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/DisasterModeration.php
@@ -250,11 +250,14 @@ class DisasterModeration extends ModerationServiceBase {
     elseif (UserHelper::userHasRoles(['editor'], $account)) {
       return TRUE;
     }
-    // Hide draft and archive disasters.
-    else {
-      return in_array($status, ['alert', 'current', 'ongoing', 'past']);
-    }
-    return FALSE;
+    return parent::isViewableStatus($status, $account);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isPublishedStatus($status) {
+    return in_array($status, ['alert', 'current', 'ongoing', 'past']);
   }
 
   /**

--- a/html/modules/custom/reliefweb_moderation/src/Services/ReportModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/ReportModeration.php
@@ -252,14 +252,14 @@ class ReportModeration extends ModerationServiceBase {
   /**
    * {@inheritdoc}
    */
-  public function isViewableStatus($status, $account = NULL) {
-    return in_array($status, ['to-review', 'published']);
+  public function isPublishedStatus($status) {
+    return $status === 'to-review' || $status === 'published';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isEditableStatus($status, $account = NULL) {
+  public function isEditableStatus($status, ?AccountInterface $account = NULL) {
     if ($status === 'archive') {
       return UserHelper::userHasRoles(['administrator', 'webmaster'], $account);
     }

--- a/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
@@ -201,7 +201,14 @@ class SourceModeration extends ModerationServiceBase {
    * {@inheritdoc}
    */
   public function isViewableStatus($status, ?AccountInterface $account = NULL) {
-    return $status === 'active' || $status === 'inactive' || UserHelper::userHasRoles(['editor'], $account);
+    return parent::isViewableStatus($status, $account) || UserHelper::userHasRoles(['editor'], $account);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isPublishedStatus($status, ?AccountInterface $account = NULL) {
+    return $status === 'active' || $status === 'inactive';
   }
 
   /**


### PR DESCRIPTION
Refs: RW-681

The logic for deciding whether or not to set the drupal status field to 0 or 1 was faulty for the announcement, resulting in the status field to be always 0 preventing published announcements from being displayed on the homepage.

### Tests

1. Create a new announcement, save as draft
2. Check that the announcement page is not accessible to anonymous or normal users but that editors can see it
3. Check that the announcement does **not** appear on the homepage
4. Save the announcement as published
5. Check that the announcement page is not accessible to anonymous or normal users but that editors can see it
6. Check that the announcement appears on the homepage

Ideally the following tests should be conducted for all the other existing main content types (jobs, training, disasters etc.):

1. Edit an entity (ex: report), save it with an unpublished status like "draft", "on-hold" or "archive"
2. Check that the page is not accessible to anonymous or normal users but that editors can see it
3. Run `drush sql-query `SELECT status FROM node_field_data WHERE nid = %nid%` (replacing the `%nid%` with the entity id, adjust if the entity is a term)
4. Check that the returned status is 0
5. Save the entity with the a published status like "to-review", "published" or "active"
6. Check that the page is accessible to everybody
7. Run `drush sql-query `SELECT status FROM node_field_data WHERE nid = %nid%` (replacing the `%nid%` with the entity id, adjust if the entity is a term)
8. Check that the returned status is 1

