### PR TITLE
[RW-689] Embeddable disaster map

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir -p /etc/nginx/custom && \
     cp lua-resty-jit-uuid/lib/resty/jit-uuid.lua /usr/share/lua/common/resty/ && \
     rm -rf /tmp/lua-resty-jit-uuid && \
     # Permit nginx access to the X_DOCSTORE_PROVIDER_UUID env variable.
-    sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;/' /etc/nginx/nginx.conf
+    sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;\n\n## Mapbox access token.\nenv MAPBOX_TOKEN;/' /etc/nginx/nginx.conf
 
 COPY --from=builder /srv/www/assets /srv/www/assets/
 COPY --from=builder /srv/www/config /srv/www/config/
@@ -69,3 +69,4 @@ COPY --from=builder /srv/www/docker/etc/nginx/apps/drupal/fastcgi_drupal.conf /e
 COPY --from=builder /srv/www/docker/etc/nginx/apps/drupal/drupal.conf /etc/nginx/apps/drupal/drupal.conf
 COPY --from=builder /srv/www/docker/etc/nginx/custom /etc/nginx/custom/
 COPY --from=builder /srv/www/docker/etc/nginx/sites-enabled/01_uuid.conf /etc/nginx/sites-enabled/01_uuid.conf
+COPY --from=builder /srv/www/docker/etc/nginx/sites-enabled/02_mapbox_proxy_cache.conf /etc/nginx/sites-enabled/02_mapbox_proxy_cache.conf

--- a/docker/etc/nginx/custom/03_disaster_map.conf
+++ b/docker/etc/nginx/custom/03_disaster_map.conf
@@ -1,0 +1,21 @@
+## Embeddable disaster map routes.
+location /disaster-map {
+  location ~ "^/disaster-map(/([A-Z]|[0-9]+)(-([A-Z]|[0-9]+))*)?$" {
+    try_files /dev/null @disaster-map;
+  }
+
+  return 404;
+}
+
+## Pseudo location to handle headers for the disaster map.
+location @disaster-map {
+  ## Remove the Cookie header so that the map is always served as anonymous.
+  more_clear_input_headers Cookie;
+
+  ## Same as @drupal.
+  include apps/drupal/fastcgi_drupal.conf;
+  fastcgi_pass phpcgi;
+
+  ## Remove the X-Frame-Options header so that the page can be embedded.
+  more_clear_headers X-Frame-Options;
+}

--- a/docker/etc/nginx/custom/03_disaster_map.conf
+++ b/docker/etc/nginx/custom/03_disaster_map.conf
@@ -1,6 +1,6 @@
 ## Embeddable disaster map routes.
 location /disaster-map {
-  location ~ "^/disaster-map(/([A-Z]|[0-9]+)(-([A-Z]|[0-9]+))*)?$" {
+  location ~ "^/disaster-map(/([a-zA-Z]{2}|[0-9]+)(-([a-zA-Z]{2}|[0-9]+))*)?$" {
     try_files /dev/null @disaster-map;
   }
 

--- a/docker/etc/nginx/custom/03_mapbox.conf
+++ b/docker/etc/nginx/custom/03_mapbox.conf
@@ -1,0 +1,51 @@
+## Mapbox proxy.
+location /mapbox/ {
+  ## Retrieve the mapbox access token.
+  set_by_lua $mapbox_token 'return os.getenv("MAPBOX_TOKEN") or ""';
+  if ($mapbox_token = "") {
+    return 404;
+  }
+
+  ## Replace the mapbox access token.
+  set_by_lua_block $mapbox_request_uri {
+    local token = ngx.var.mapbox_token
+    local args = ngx.var.request_uri
+    if (args ~= nil) then
+      args = args:gsub("^/mapbox", "", 1)
+      args = args:gsub("access_token=token", "access_token=" .. token, 1)
+    end
+    return args
+  }
+
+  ## Remove cookies.
+  more_clear_input_headers Cookie;
+
+  ## Proxy the request to the mapbox API.
+  proxy_set_header Host "api.mapbox.com";
+  proxy_pass https://api.mapbox.com$mapbox_request_uri;
+  proxy_http_version 1.1;
+  proxy_redirect off;
+  proxy_intercept_errors on;
+
+  ## Remove the sku parameter as it's always different.
+  set $cache_uri $mapbox_request_uri;
+  if ($cache_uri ~ "^(.*)[?&]sku=[^&]+(.*)$") {
+    set $cache_uri $1$2;
+  }
+
+  ## Cache the resources for 14 days.
+  proxy_buffering on;
+  proxy_cache mapbox_proxy_cache;
+  proxy_cache_key $scheme$proxy_host$cache_uri;
+  proxy_ignore_headers Expires Cache-Control Set-Cookie Vary;
+  proxy_cache_valid 200 14d;
+  proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+  proxy_cache_background_update on;
+  proxy_cache_lock on;
+  proxy_cache_lock_age 25s;
+  proxy_cache_lock_timeout 30s;
+  proxy_cache_revalidate on;
+
+  ## Add an header to be check if we hit the cache.
+  add_header X-Nginx-Cache $upstream_cache_status;
+}

--- a/docker/etc/nginx/sites-enabled/02_mapbox_proxy_cache.conf
+++ b/docker/etc/nginx/sites-enabled/02_mapbox_proxy_cache.conf
@@ -1,0 +1,6 @@
+proxy_cache_path /var/cache/nginx/mapbox
+								levels=1:2
+								keys_zone=mapbox_proxy_cache:128m
+								max_size=2048m
+								inactive=30d
+								use_temp_path=off;

--- a/html/modules/custom/reliefweb_disaster_map/js/disaster-map.js
+++ b/html/modules/custom/reliefweb_disaster_map/js/disaster-map.js
@@ -173,7 +173,7 @@
 
         // Map options.
         var options = {
-          accessToken: reliefweb.mapbox.token,
+          accessToken: 'token',
           style: 'mapbox://styles/reliefweb/' + reliefweb.mapbox.key + '?optimize=true',
           container: mapContainer,
           center: [10, 10],
@@ -198,6 +198,9 @@
           options.minZoom = 0;
         }
 
+        // Replace the mapbox base API with the proxied version.
+        mapboxgl.baseApiUrl = window.location.origin + '/mapbox';
+
         // Create a map.
         var map = new mapboxgl.Map(options)
         // Add the zoom control buttons, bottom left to limit overlap with the
@@ -219,7 +222,9 @@
         // Restore visibility of the list if the map couldn't be loaded.
         .on('error', function (event) {
           element.removeAttribute('data-map-enabled');
-          element.removeChild(figure);
+          if (figure && figure.parentNode) {
+            figure.parentNode.removeChild(figure);
+          }
         })
         // Unset the active marker when clicking on the map.
         .on('click', function (event) {

--- a/html/modules/custom/reliefweb_disaster_map/js/mapbox.js
+++ b/html/modules/custom/reliefweb_disaster_map/js/mapbox.js
@@ -20,7 +20,7 @@
       if (document.documentElement.clientWidth < 768) {
         return false;
       }
-      return this.key && this.token && mapboxgl && mapboxgl.supported({
+      return this.key && this.token && typeof mapboxgl !== 'undefined' && typeof mapboxgl.supported !== 'undefined' && mapboxgl.supported({
         failIfMajorPerformanceCaveat: strict === true
       });
     },

--- a/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.libraries.yml
+++ b/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.libraries.yml
@@ -1,9 +1,9 @@
 mapbox:
   css:
     component:
-      mapbox/mapbox-gl-js/v1.7.0/mapbox-gl.css: { type: external, minified: true }
+      /mapbox/mapbox-gl-js/v1.7.0/mapbox-gl.css: { type: external, minified: true }
   js:
-    mapbox/mapbox-gl-js/v1.7.0/mapbox-gl.js: { type: external, minified: true, weight: -50 }
+    /mapbox/mapbox-gl-js/v1.7.0/mapbox-gl.js: { type: external, minified: true, weight: -50 }
     js/mapbox.js: { weight: -20 }
 
 map:

--- a/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.libraries.yml
+++ b/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.libraries.yml
@@ -1,9 +1,9 @@
 mapbox:
   css:
     component:
-      https://api.mapbox.com/mapbox-gl-js/v1.7.0/mapbox-gl.css: { type: external, minified: true }
+      mapbox/mapbox-gl-js/v1.7.0/mapbox-gl.css: { type: external, minified: true }
   js:
-    https://api.mapbox.com/mapbox-gl-js/v1.7.0/mapbox-gl.js: { type: external, minified: true, weight: -50 }
+    mapbox/mapbox-gl-js/v1.7.0/mapbox-gl.js: { type: external, minified: true, weight: -50 }
     js/mapbox.js: { weight: -20 }
 
 map:

--- a/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.module
+++ b/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.module
@@ -78,7 +78,8 @@ function reliefweb_disaster_map_get_disaster_type_tokens() {
     $disaster_type_tokens = [];
     foreach ($terms as $term) {
       if (!$term->field_disaster_type_code->isEmpty()) {
-        $disaster_type_tokens[$term->field_disaster_type_code->value] = $term;
+        $code = strtoupper($term->field_disaster_type_code->value);
+        $disaster_type_tokens[$code] = $term;
       }
     }
   }
@@ -100,7 +101,7 @@ function reliefweb_disaster_map_get_disaster_type_tokens() {
  */
 function reliefweb_disaster_map_get_disaster_map_token_replacement($token, BubbleableMetadata $bubbleable_metadata = NULL, $render = TRUE) {
   $tokens = reliefweb_disaster_map_get_disaster_type_tokens();
-  $values = explode('-', $token);
+  $values = explode('-', strtoupper($token));
   $options = [];
   $id = strtolower('disaster-map-' . $token);
 

--- a/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.module
+++ b/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.module
@@ -140,3 +140,29 @@ function reliefweb_disaster_map_get_disaster_map_token_replacement($token, Bubbl
   }
   return '';
 }
+
+/**
+ * Implements hook_metatags_alter().
+ */
+function reliefweb_disaster_map_metatags_alter(array &$metatags, array &$context) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  if (strpos($route_name, 'reliefweb_disaster_map.map.embeddable') === 0) {
+    $metatags = [
+      'title' => t('Disaster map'),
+    ];
+  }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * Run our metatags_alter hook implementation last.
+ */
+function reliefweb_disaster_map_module_implements_alter(array &$implementations, $hook) {
+  if ($hook === 'metatags_alter') {
+    $group = $implementations['reliefweb_disaster_map'];
+    unset($implementations['reliefweb_disaster_map']);
+    $implementations['reliefweb_disaster_map'] = $group;
+  }
+}

--- a/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.module
+++ b/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.module
@@ -90,13 +90,15 @@ function reliefweb_disaster_map_get_disaster_type_tokens() {
  *
  * @param string $token
  *   Token to replace.
- * @param \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata
+ * @param \Drupal\Core\Render\BubbleableMetadata|null $bubbleable_metadata
  *   Metadata to bubble to the renderer.
+ * @param bool $render
+ *   Whether to render the map or return the render array.
  *
  * @return \Drupal\Component\Render\MarkupInterface|string
  *   The rendered disaster map HTML content to use as token replacement.
  */
-function reliefweb_disaster_map_get_disaster_map_token_replacement($token, BubbleableMetadata $bubbleable_metadata) {
+function reliefweb_disaster_map_get_disaster_map_token_replacement($token, BubbleableMetadata $bubbleable_metadata = NULL, $render = TRUE) {
   $tokens = reliefweb_disaster_map_get_disaster_type_tokens();
   $values = explode('-', $token);
   $options = [];
@@ -134,7 +136,7 @@ function reliefweb_disaster_map_get_disaster_map_token_replacement($token, Bubbl
 
   if (!empty($title)) {
     return \Drupal::service('reliefweb_disaster_map.service')
-      ->getDisasterMap($id, $title, $options, TRUE);
+      ->getDisasterMap($id, $title, $options, $render);
   }
   return '';
 }

--- a/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.routing.yml
+++ b/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.routing.yml
@@ -1,0 +1,15 @@
+reliefweb_disaster_map.map.embeddable.type:
+  path: '/disaster-map/{type}'
+  defaults:
+    _title: 'ReliefWeb'
+    _controller: '\Drupal\reliefweb_disaster_map\Controller\DisasterMap::getEmbeddableMap'
+  requirements:
+    _permission: 'access content'
+    type: ([A-Z]{2}|\d+)(-([A-Z]{2}|\d+))*
+reliefweb_disaster_map.map.embeddable:
+  path: '/disaster-map'
+  defaults:
+    _title: 'ReliefWeb'
+    _controller: '\Drupal\reliefweb_disaster_map\Controller\DisasterMap::getEmbeddableMap'
+  requirements:
+    _permission: 'access content'

--- a/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.routing.yml
+++ b/html/modules/custom/reliefweb_disaster_map/reliefweb_disaster_map.routing.yml
@@ -5,7 +5,7 @@ reliefweb_disaster_map.map.embeddable.type:
     _controller: '\Drupal\reliefweb_disaster_map\Controller\DisasterMap::getEmbeddableMap'
   requirements:
     _permission: 'access content'
-    type: ([A-Z]{2}|\d+)(-([A-Z]{2}|\d+))*
+    type: ([a-zA-Z]{2}|\d+)(-([a-zA-Z]{2}|\d+))*
 reliefweb_disaster_map.map.embeddable:
   path: '/disaster-map'
   defaults:

--- a/html/modules/custom/reliefweb_disaster_map/src/Controller/DisasterMap.php
+++ b/html/modules/custom/reliefweb_disaster_map/src/Controller/DisasterMap.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\reliefweb_disaster_map\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\reliefweb_disaster_map\DisasterMapService;
+
+/**
+ * Controller for the disaster-map route.
+ */
+class DisasterMap extends ControllerBase {
+
+  /**
+   * Get the embeddable map render array.
+   *
+   * Additional parameters can be passed as query parameters:
+   * - title: custom title (other wise it will default to the title generated
+   *   from the given type(s).
+   * - link: if set, a link to the /disasters page will be provided.
+   * - ratio: the width/height ratio.
+   *
+   * @param string $type
+   *   Type of disaser map to return. This can be a disaster type code (ex: FL
+   *   for floods) or a disaster ID or a list of those with each type/id
+   *   separated by a `-`. If empty the map of the alert and ongoing disasters
+   *   will be shown instead.
+   *
+   * @return array
+   *   Render array for the disaster map.
+   *
+   * @todo maybe reduce the number of styles, scripts etc. and allow additional
+   * query parameters like:
+   * - title: custom title (other wise it will default to the title generated
+   *   from the given type(s))
+   * - link: to add a link to the /disasters page
+   * - ratio: the width/height ratio
+   * - since: to get a different date range for the disasters instead of a year.
+   */
+  public function getEmbeddableMap($type = '') {
+    if (!empty($type)) {
+      return reliefweb_disaster_map_get_disaster_map_token_replacement($type, NULL, FALSE);
+    }
+    else {
+      return DisasterMapService::getAlertAndOngoingDisasterMap();
+    }
+  }
+
+}

--- a/html/modules/custom/reliefweb_disaster_map/src/DisasterMapService.php
+++ b/html/modules/custom/reliefweb_disaster_map/src/DisasterMapService.php
@@ -232,7 +232,8 @@ class DisasterMapService {
         'drupalSettings' => [
           'reliefwebDisasterMap' => [
             'mapboxKey' => $this->config->get('mapbox_key') ?? '',
-            'mapboxToken' => $this->config->get('mapbox_token') ?? '',
+            // It's replaced server side.
+            'mapboxToken' => 'token',
             'maps' => [
               $id => $settings,
             ],

--- a/html/modules/custom/reliefweb_disaster_map/src/DisasterMapService.php
+++ b/html/modules/custom/reliefweb_disaster_map/src/DisasterMapService.php
@@ -254,14 +254,17 @@ class DisasterMapService {
   /**
    * Get the map of the latest alert and ongoing diasters.
    *
+   * @param bool $render
+   *   Whether to render the map or return the render array.
+   *
    * @return array
    *   The disaster map render array.
    */
-  public static function getAlertAndOngoingDisasterMap() {
+  public static function getAlertAndOngoingDisasterMap($render = FALSE) {
     return \Drupal::service('reliefweb_disaster_map.service')
       ->getDisasterMap('disaster-map', t('Alert and Ongoing Disasters'), [
         'statuses' => ['alert', 'ongoing'],
-      ], FALSE);
+      ], $render);
   }
 
 }

--- a/html/themes/custom/common_design_subtheme/templates/layout/html--disaster-map.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/html--disaster-map.html.twig
@@ -1,0 +1,42 @@
+{#
+/**
+ * @file
+ * Theme override for the basic structure of a single Drupal page.
+ *
+ * Variables:
+ * - logged_in: A flag indicating if user is logged in.
+ * - root_path: The root path of the current page (e.g., node, admin, user).
+ * - node_type: The content type for the current node, if the page is a node.
+ * - head_title: List of text elements that make up the head_title variable.
+ *   May contain one or more of the following:
+ *   - title: The title of the page.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site.
+ * - page_top: Initial rendered markup. This should be printed before 'page'.
+ * - page: The rendered page markup.
+ * - page_bottom: Closing rendered markup. This variable should be printed after
+ *   'page'.
+ * - db_offline: A flag indicating if the database is offline.
+ * - placeholder_token: The token for generating head, css, js and js-bottom
+ *   placeholders.
+ *
+ * @see template_preprocess_html()
+ */
+#}
+{%
+  set body_classes = []
+%}
+<!DOCTYPE html>
+<html{{ html_attributes.addClass('no-js') }}>
+  <head>
+    <head-placeholder token="{{ placeholder_token }}">
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token }}">
+    <js-placeholder token="{{ placeholder_token }}">
+    <base target="_blank">
+  </head>
+  <body{{ attributes.addClass(body_classes) }}>
+    {{ page }}
+    <js-bottom-placeholder token="{{ placeholder_token }}">
+  </body>
+</html>

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--disaster-map.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--disaster-map.html.twig
@@ -1,0 +1,1 @@
+{{ page.content.system_main }}


### PR DESCRIPTION
Refs: RW-689

This adds a route to embed disaster maps at `/disaster-map` or `/disaster/map/XX` where `XX` is a list of disaster type codes separated by a `-`.

To avoid excessive requests to the mapbox API, they are proxied and cached via nginx.

In addition, the access token is injected server side via a `MAPBOX_TOKEN` env variable visible to nginx.

**Notes**

[OPS-8731] is the ticket to add the env variable.

[OPS-8731]: https://humanitarian.atlassian.net/browse/OPS-8731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Tests**

1. Make sure the `MAPBOX_TOKEN` (same value as the `reliefweb_distater_map.settings`'s `mapbox_token` config value) is available. This can be added via the `docker-compose.yml` for the local stack.
2. Checkout the branch and rebuild the image and container for the RW site to take into account the nginx changes
3. Visit `/disaster-map` and check that it displays the "Alert and Ongoing Disasters" map
4. Visit `/disaster-map/EP-FL` and check that it displays the map "Flood and Epidemic disasters covered by ReliefWeb in the last 12 months."