### PR TITLE
[RW-690] Fix line break

### DIFF
--- a/config/filter.format.markdown_editor.yml
+++ b/config/filter.format.markdown_editor.yml
@@ -15,7 +15,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<p> <a href hreflang target rel> <em> <strong> <ul type> <ol start type> <li> <h2> <h3> <h4> <h5> <h6>'
+      allowed_html: '<p> <a href hreflang target rel> <em> <strong> <ul type> <ol start type> <li> <h2> <h3> <h4> <h5> <h6> <br>'
       filter_html_help: false
       filter_html_nofollow: true
   filter_htmlcorrector:


### PR DESCRIPTION
Refs: RW-690

This allows `<br>` in fields using the `markdown_editor` text format (jobs, training) so that soft line breaks in imported content or entered in the editor via `shift + enter` are respected when rendering the field's content.

## tests

**Before checking out the branch**

1. Edit or create a job, add some text in the description, use `shift + enter` to break the text into 2 lines.
2. Save and check that the 2 lines are rendered as one (they appear as being separated by a space).

**After checking out the branch**

1. Import the config change (`drush cim`).
2. Edit or create a job, add some text in the description, use `shift + enter` to break the text into 2 lines.
3. Save and check that the 2 lines are rendered as 2 lines.