### PR TITLE
[RW-696] Catch exception in search conversion when input is invalid

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
@@ -180,7 +180,15 @@ class SearchConverter extends ControllerBase {
       ];
     }
 
-    return new JsonResponse($result);
+    try {
+      return new JsonResponse($result);
+    }
+    catch (\Exception $exception) {
+      $this->getLogger('reliefweb_river')->error('Unable to generate search conversion JSON result: @error', [
+        '@error' => $exception->getMessage(),
+      ]);
+      return new JsonResponse(['error' => $this->t('Invalid input')], 400);
+    }
   }
 
   /**


### PR DESCRIPTION
Refs: RW-696

This catches and logs error when generating the JSON output of a search conversion when the input is invalid.

## Tests.

**Before checking out this branch**

1. go to `/search/converter/json?appname=1%00%C0%A7%C0%A2%252527%252522&search-url=https%3A%2F%2Freliefweb.int%2Fupdates%3Fsearch%3Dthe%26view%3Dheadlines` on your local
2. check there is an uncaught exception

**After checking out this branch**

1. go to `/search/converter/json?appname=1%00%C0%A7%C0%A2%252527%252522&search-url=https%3A%2F%2Freliefweb.int%2Fupdates%3Fsearch%3Dthe%26view%3Dheadlines` on your local
2. check that the result is a JSON object with `Invalid input` and that the page status is 400.