### PR TITLE
[RW-693] Filter accessibility

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8917,16 +8917,16 @@
         },
         {
             "name": "reliefweb/simple-datepicker",
-            "version": "v1.3.3-beta",
+            "version": "v1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/rwint-simple-datepicker.git",
-                "reference": "9f94f47c05ca30009cb4ae641cdf239f5b6fb7be"
+                "reference": "88d9fc1d8695593bb708f639a16011a97ce2fc61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/rwint-simple-datepicker/zipball/9f94f47c05ca30009cb4ae641cdf239f5b6fb7be",
-                "reference": "9f94f47c05ca30009cb4ae641cdf239f5b6fb7be",
+                "url": "https://api.github.com/repos/UN-OCHA/rwint-simple-datepicker/zipball/88d9fc1d8695593bb708f639a16011a97ce2fc61",
+                "reference": "88d9fc1d8695593bb708f639a16011a97ce2fc61",
                 "shasum": ""
             },
             "require": {
@@ -8945,9 +8945,9 @@
                 "reliefweb"
             ],
             "support": {
-                "source": "https://github.com/UN-OCHA/rwint-simple-datepicker/tree/v1.3.3-beta"
+                "source": "https://github.com/UN-OCHA/rwint-simple-datepicker/tree/v1.3.3"
             },
-            "time": "2022-11-02T06:12:51+00:00"
+            "time": "2022-11-04T07:04:06+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/html/modules/custom/reliefweb_moderation/js/moderation.js
+++ b/html/modules/custom/reliefweb_moderation/js/moderation.js
@@ -72,6 +72,12 @@
           namespace: 'rw-datepicker'
         });
 
+        // Prevent closing the datepicker.
+        widget.hide = function () {
+          // Focus the current day instead of the beginning of the month.
+          return this.focusDay(this.today, false);
+        };
+
         // Input to enter the date manually.
         var input = document.createElement('input');
         input.setAttribute('type', 'text');

--- a/html/modules/custom/reliefweb_rivers/js/advanced-search.js
+++ b/html/modules/custom/reliefweb_rivers/js/advanced-search.js
@@ -606,7 +606,7 @@
 
       case 'options':
         widget.select = element.querySelector('select');
-        // Add the filter when after selection when pressing enter.
+        // Add the filter after selection when pressing enter.
         addEventListener(widget.select, 'keyup', function (event) {
           var key = event.which || event.keyCode;
           if (key === KeyCodes.ENTER && this.value) {
@@ -1471,6 +1471,37 @@
 
       widget.clear();
       toggleDialog(advancedSearch);
+    });
+
+    // Cancel when pressing escape and wrap focus inside the dialog.
+    addEventListener(dialog, 'keydown', function (event) {
+      var key = event.which || event.keyCode;
+
+      // Close the dialog when pressing escape.
+      if (key === KeyCodes.ESC) {
+        preventDefault(event);
+        triggerEvent(cancel, 'click');
+      }
+      // Wrap the focus inside the dialog.
+      else if (key === KeyCodes.TAB) {
+        var firstInteractiveElement;
+        if (advancedSearch.advancedMode) {
+          firstInteractiveElement = dialog.querySelector('input, select');
+        }
+        else {
+          firstInteractiveElement = getActiveWidget(advancedSearch.widgets).element.querySelector('input, select');
+        }
+        if (!event.shiftKey && event.target === add) {
+          preventDefault(event);
+          stopPropagation(event);
+          firstInteractiveElement.focus();
+        }
+        else if (event.shiftKey && event.target === firstInteractiveElement) {
+          preventDefault(event);
+          stopPropagation(event);
+          add.focus();
+        }
+      }
     });
 
     return dialog;


### PR DESCRIPTION
Refs: RW-693

This enables closing the filter dialog with `Escape` and wraps the focus inside the dialog in the river filters (ex: /updates) to improve the keyboard navigation.

It also fixes an existing issue when pressing escape in the moderation backend.

## Tests

1. Checkout the branch and go to `/updates`
2. Open a filter (ex:  Country)
3. Check that the focus is wrapped (add -> first input etc.)
4. Check that the dialog closes when pressing `Escape` similarly to clicking `Cancel`