### PR TITLE
[RW-697] Filter select accessibility

### DIFF
--- a/html/modules/custom/reliefweb_rivers/js/advanced-search.js
+++ b/html/modules/custom/reliefweb_rivers/js/advanced-search.js
@@ -1336,7 +1336,9 @@
     var id = 'river-advanced-search-options-widget-' + filter.code;
     var values = filter.widget.options;
 
-    var options = [createOption('', advancedSearch.labels.emptyOption)];
+    var options = [createOption('', advancedSearch.labels.emptyOption, {
+      selected: 'selected'
+    })];
     for (var i = 0, l = values.length; i < l; i++) {
       var value = values[i];
       options.push(createOption(value.id, value.name));


### PR DESCRIPTION
Refs: RW-697

This adds the `selected` attribute to the first option in the river filters using a `select` element (ex:  disaster type on /updates).

Note: this doesn't really improve anything in terms of accessibility. It's just to have check1st shut up.