### PR TITLE
[RW-694] Apply filters accessibility

### DIFF
--- a/html/modules/custom/reliefweb_rivers/js/advanced-search.js
+++ b/html/modules/custom/reliefweb_rivers/js/advanced-search.js
@@ -1614,6 +1614,9 @@
   function createActions(advancedSearch) {
     var clear = createButton({'data-clear': ''}, advancedSearch.labels.clear);
     var apply = createButton({'data-apply': ''}, advancedSearch.labels.apply);
+    var title = createElement('h' + (advancedSearch.headingLevel + 1), {
+      class: 'visually-hidden'
+    }, advancedSearch.labels.formActions);
 
     // Keep track of the action buttons so they can be hidden/shown depending
     // on the filter selection.
@@ -1634,9 +1637,9 @@
       triggerEvent(advancedSearch.submitForm, 'submit');
     });
 
-    return createElement('div', {
+    return createElement('section', {
       'class': advancedSearch.classPrefix + 'actions'
-    }, [clear, apply]);
+    }, [title, clear, apply]);
   }
 
   // Create the checkbox to active advanced search mode.

--- a/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
+++ b/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
@@ -236,6 +236,7 @@ class AdvancedSearch {
           'cancel' => $this->t('Cancel'),
           'clear' => $this->t('Clear all'),
           'remove' => $this->t('Remove filter'),
+          'formActions' => $this->t('Apply or clear filters'),
           'filterSelector' => $this->t('Add filter'),
           'fieldSelector' => $this->t('Select field'),
           'operatorSelector' => $this->t('Select operator'),
@@ -281,9 +282,9 @@ class AdvancedSearch {
         ],
         'announcements' => [
           'changeFilter' => $this->t('Filter changed to _name_.'),
-          'addFilter' => $this->t('Added _field_ _label_. Your are now looking for documents _selection_. Press apply filters to update the list.'),
-          'removeFilter' => $this->t('Removed _field_ _label_. Your are now looking for documents _selection_. Press apply filters to update the list.'),
-          'removeFilterEmpty' => $this->t('Removed _field_ _label_. Your selection is now empty. Press apply filters to update the list.'),
+          'addFilter' => $this->t('Added _field_ _label_. Your are now looking for documents _selection_. Go to the "Apply or clear filters" section to apply the filters and update the list.'),
+          'removeFilter' => $this->t('Removed _field_ _label_. Your are now looking for documents _selection_. Go to the "Apply or clear filters" section to apply the filters and update the list.'),
+          'removeFilterEmpty' => $this->t('Removed _field_ _label_. Your selection is now empty. Go to the "Apply or clear filters" section to apply the filters and update the list.'),
         ],
         'operators' => [
           [

--- a/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-advanced-search.html.twig
+++ b/html/modules/custom/reliefweb_rivers/templates/reliefweb-rivers-advanced-search.html.twig
@@ -53,7 +53,8 @@
     {% endif %}
 
     <div id="river-advanced-search-selection-announcement" aria-live="polite" class="visually-hidden"></div>
-    <div id="river-advanced-search-selection" class="rw-advanced-search__selection rw-selection" data-selection="{{ selection|length }}">
+    <section id="river-advanced-search-selection" class="rw-advanced-search__selection rw-selection" data-selection="{{ selection|length }}">
+      <h{{ level + 1 }} class="visually-hidden">{{ 'Selected filters'|t }}</h{{ level + 1 }}>
       {#
         Note: this is the initial selection and will be overriden by the
         advanced search javascript library. That means notably that styling
@@ -68,7 +69,7 @@
         </div>
       </div>
       {% endfor %}
-    </div>
+    </section>
 
     <noscript>
       {% if selection is not empty %}
@@ -90,7 +91,9 @@
     </script>
 
     <div id="river-advanced-search-filter-announcement" aria-live="polite" class="visually-hidden"></div>
-    <div id="river-advanced-search-form-content" class="rw-advanced-search__form__content" hidden></div>
+    <section id="river-advanced-search-form-content" class="rw-advanced-search__form__content" hidden>
+      <h{{ level + 1 }} class="visually-hidden">{{ 'Add filters'|t }}</h{{ level + 1 }}>
+    </section>
   </form>
 </section>
 {% endif %}


### PR DESCRIPTION
Refs: RW-694

This adds sections with a heading for the selected filters, apply/cancel filters and list of filters to ease navigation when using a screenreader.

Note: I investigated other options like the `accesskey` attribute or javascript handling to be able to more easily submit the form with the selected filters without having to navigate back up to the "apply filters" button after selecting a filter (ex: disaster type on /updates) but that interfered with natural browser or system shortcuts notably. So adding those headings is the softest touch for now.