### PR TITLE
[RW-701] Fix record total in moderation pages

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -1208,6 +1208,9 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
     // Filter the query with the form filters.
     $this->filterQuery($query, $filters);
 
+    // Ensure there are no duplicates (ex: when joining revision tables).
+    $query->distinct();
+
     // Wrap the query in a parent query to which the ordering and limiting is
     // applied.
     //


### PR DESCRIPTION
Refs: RW-701

This adds a `DISTINCT` to the main query of the moderation pages to ensure the counting of the document is correct.

### Tests

**Before checking out this branch**

1. Create or edit a report, add a dummy revision comment, save.
2. Repeat (1).
3. Go to `/moderation/content/report`, select `reviewed date` filter and today's date (so it catches the modification from (1) and (2)).
4. Add a `title` filter with the title of the node modified in (1)
5. There should be only 1 record in the list but the total should be 2 (or more).

**After checking out this branch**

Repeat (3) and (4) but this time the total in (5) should be `1`.