### PR TITLE
[RW-702] Use shortlink in publication notifications

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/Entity/Report.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Report.php
@@ -342,7 +342,10 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
       "ReliefWeb team",
     ]), [
       '@title' => $this->label(),
-      '@url' => $this->toUrl('canonical', ['absolute' => TRUE])->toString(FALSE),
+      '@url' => $this->toUrl('canonical', [
+        'absolute' => TRUE,
+        'path_processing' => FALSE,
+      ])->toString(FALSE),
     ]);
 
     $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();


### PR DESCRIPTION
Refs: RW-702

This adds adds an option to use the short URL (`https://reliefweb.int/node/123456`) instead of the aliased URL in the publication notifications.

### Tests

**Before checking out this branch**

1. Edit a report, add an email address to the `notify` field, save
2. Open local mailhog, check that the report URL in the publication notification email contains the aliased URL

**After checking out this branch**

Repeat the above but this time the email should contain the short URL.