### PR TITLE
[RW-703] Add extra info to job source field's description

### DIFF
--- a/config/field.field.node.job.field_source.yml
+++ b/config/field.field.node.job.field_source.yml
@@ -11,7 +11,7 @@ field_name: field_source
 entity_type: node
 bundle: job
 label: Organization
-description: 'The name of the organization issuing the hiring contract. Please check if your organization is already on our list. New organizations will undergo a brief verification by our team.'
+description: 'The name of the organization issuing the hiring contract. Please check if your organization is already on our list. New organizations will undergo a brief verification by our team. Please use corporate email domain for your job submissions.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
Refs: RW-703

This simply adds "Please use corporate email domain for your job submissions." at the end of the organization field's descriptions on the job form.

### Tests

1. Check out the branch
2. Run `drush cim`
3. Go to `/node/add/job` and check that the text "Please use corporate email domain for your job submissions." appears at the end of the organization field's description