### PR TITLE
[RW-646] Disaster/country description visibility toggler

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -68,6 +68,9 @@ ckeditor_stylesheets:
   - css/styles.css
 
 libraries-override:
+  common_design/cd-dropdown:
+    js:
+      js/cd-dropdown.js: js/cd-dropdown.js
   guidelines/guidelines-json:
     js:
       components/guidelines-json/guidelines-json.js: false

--- a/html/themes/custom/common_design_subtheme/components/rw-entity-text/rw-entity-text.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-entity-text/rw-entity-text.css
@@ -1,7 +1,3 @@
-.rw-entity-text {
-  display: flex;
-  flex-direction: column;
-}
 .rw-entity-text .rw-entity-text__content {
   padding-top: 0;
 }
@@ -27,7 +23,6 @@
 /* Javascript enabled */
 .js .rw-entity-text--collapsible button {
   display: block;
-  order: 3;
   margin: 24px auto 0 auto;
   padding: 8px 12px;
   color: var(--cd-reliefweb-brand-blue--dark);

--- a/html/themes/custom/common_design_subtheme/js/cd-dropdown.js
+++ b/html/themes/custom/common_design_subtheme/js/cd-dropdown.js
@@ -1,0 +1,472 @@
+(function (Drupal) {
+  'use strict';
+
+  Drupal.behaviors.cdDropdown = {
+    idPrefix: 'cd-dropdown-toggable-',
+    idMax: 0,
+
+    attach: function (context, settings) {
+      document.documentElement.classList.remove('no-js');
+
+      // Bind the event handlers so that `this` corresponds to the current
+      // object and can be used inside the event handling functions.
+      this.handleClickAway = this.handleClickAway.bind(this);
+      this.handleEscape = this.handleEscape.bind(this);
+      this.handleResize = this.handleResize.bind(this);
+      this.handleToggle = this.handleToggle.bind(this);
+
+      // Store context where all our private functions can access it.
+      // Leaving this here for posterity sake.
+      // this.context = context;
+
+      // Initialize toggable dropdown.
+      this.initializeToggables();
+
+      // Update nested Drupal menus in the header.
+      this.updateDrupalTogglableMenus();
+    },
+
+    /**
+     * Get the toggler element form the togglable element.
+     */
+    getTogglerElement: function (element) {
+      var id = this.getToggableId(element);
+      return document.querySelector('[data-cd-toggler][aria-controls="' + id + '"]');
+    },
+
+    /**
+     * Get the togglable element form the toggler element.
+     */
+    getTogglableElement: function (toggler) {
+      return document.getElementById(toggler.getAttribute('aria-controls'));
+    },
+
+    /**
+     * Get the toggable ID, generate it if doesn't have one.
+     */
+    getToggableId: function (element) {
+      if (!element.hasAttribute('id')) {
+        this.idMax++;
+        element.id = this.idPrefix + this.idMax;
+      }
+      return element.id;
+    },
+
+    /**
+     * Toggle the visibility of a toggable element.
+     */
+    toggle: function (toggler, collapse) {
+      var element = this.getTogglableElement(toggler);
+      if (element) {
+        var expanded = collapse || toggler.getAttribute('aria-expanded') === 'true';
+
+        // Switch the expanded/collapsed states.
+        toggler.setAttribute('aria-expanded', !expanded);
+        element.setAttribute('data-cd-hidden', expanded);
+
+        // Switch the labels.
+        var labelWrapper = toggler.querySelector('[data-cd-label-switch]');
+        if (labelWrapper) {
+          var label = labelWrapper.getAttribute('data-cd-label-switch');
+          labelWrapper.setAttribute('data-cd-label-switch', labelWrapper.textContent);
+          labelWrapper.textContent = label;
+        }
+
+        // Change the focus when expanded if a target is specified.
+        if (element.hasAttribute('data-cd-focus-target') && !expanded) {
+          var target = document.getElementById(element.getAttribute('data-cd-focus-target'));
+          if (target) {
+            target.focus();
+          }
+        }
+      }
+    },
+
+    /**
+     * Collapse all toggable elements.
+     */
+    collapseAll: function (exceptions) {
+      var elements = document.querySelectorAll('[data-cd-toggler][aria-expanded="true"]');
+      exceptions = exceptions || [];
+      var cdDropdown = this;
+
+      elements.forEach(function (element) {
+        // Elements can be directed to stay open in two ways:
+        //  * We can apply an attribute directly in DOM
+        //  * We can mark it as an exception when calling this function
+        //
+        // If neither apply, then close the element.
+        if (!element.hasAttribute('data-cd-toggable-keep') && exceptions.indexOf(element) === -1) {
+          cdDropdown.toggle(element, true);
+        }
+      });
+    },
+
+    /**
+     * Get the togglable parents of the toggler element.
+     */
+    getToggableParents: function (element) {
+      var elements = [];
+      while (element && element !== document) {
+        if (element.hasAttribute && element.hasAttribute('data-cd-toggable')) {
+          if (element.hasAttribute('data-cd-insert-after')) {
+            element = element.nextElementSibling;
+          }
+          else {
+            element = element.previousElementSibling;
+          }
+        }
+
+        // Skip if the there was no sibling as that means there is no toggler
+        // for the toggable element.
+        if (!element) {
+          break;
+        }
+
+        // Store the toggling button of the togglable parent so that it can
+        // be ignored when collapsing the opened toggables.
+        if (element.hasAttribute && element.hasAttribute('data-cd-toggler')) {
+          elements.push(element);
+        }
+        element = element.parentNode;
+      }
+      return elements;
+    },
+
+    /**
+     * Handle toggling of toggable elements.
+     */
+    handleToggle: function (event) {
+      var target = event.currentTarget;
+      if (target) {
+        this.collapseAll(this.getToggableParents(target));
+        this.toggle(target);
+      }
+      event.preventDefault();
+      event.stopPropagation();
+    },
+
+    /**
+     * Handle togglable element visibility when pressing escape.
+     *
+     * Hide a toggable element when escape is pressed and the focus is on it
+     * or on its toggler.
+     *
+     * This is to meet the WCAG 2.1 1.4.13: Content on Hover or Focus
+     * criterion.
+     *
+     * @see https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html
+     */
+    handleEscape: function (event) {
+      var key = event.which || event.keyCode;
+      // Escape.
+      if (key === 27) {
+        var target = event.currentTarget;
+        // Toggable element, get the toggling button.
+        if (!target.hasAttribute('data-cd-toggler')) {
+          target = this.getTogglerElement(target);
+        }
+        // Focus the button and hide the content.
+        if (target && target.hasAttribute('data-cd-toggler')) {
+          target.focus();
+          this.toggle(target, true);
+        }
+      }
+    },
+
+    /**
+     * Handle global clicks outside of toggable elements, close them in this
+     * case.
+     */
+    handleClickAway: function (event) {
+      var target = event.target;
+      if (target) {
+        if (target.nodeName === 'A' && !target.hasAttribute('data-cd-toggler')) {
+          this.collapseAll();
+        }
+        else {
+          // Loop until we find a parent which is a toggable or toggler element
+          // or we reach the "context" element.
+          while (target && target !== document) {
+            if (target.hasAttribute) {
+              // Skip if the clicked element belong to a toggler or a toggable
+              // element.
+              if (target.hasAttribute('data-cd-toggler') || target.hasAttribute('data-cd-toggable')) {
+                return;
+              }
+            }
+            target = target.parentNode;
+          }
+        }
+        this.collapseAll();
+      }
+    },
+
+    /**
+     * Update the toggable elements when the window is resized.
+     */
+    handleResize: function (selector) {
+      var elements = document.querySelectorAll('[data-cd-toggable]');
+      for (var i = 0, l = elements.length; i < l; i++) {
+        this.updateToggable(elements[i]);
+      }
+    },
+
+    /**
+     * Create a svg icon.
+     */
+    createIcon: function (name, component, type) {
+      var svgElem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      var useElem = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+      useElem.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', '#cd-icon--' + name);
+      svgElem.setAttribute('width', '16');
+      svgElem.setAttribute('height', '16');
+      svgElem.setAttribute('aria-hidden', 'true');
+      svgElem.setAttribute('focusable', 'false');
+
+      var classes = [
+        'cd-icon',
+        'cd-icon--' + name
+      ];
+
+      if (component && type) {
+        classes.push(component + '__' + type);
+      }
+
+      // Note: IE 11 doesn't support classList on SVG elements.
+      svgElem.setAttribute('class', classes.join(' '));
+
+      svgElem.appendChild(useElem);
+
+      return svgElem;
+    },
+
+    /**
+     * Create a button to toggle a dropdown.
+     */
+    createButton: function (element) {
+      var id = this.getToggableId(element);
+      var label = element.getAttribute('data-cd-toggable');
+      var logo = element.getAttribute('data-cd-logo');
+      var logoOnly = element.hasAttribute('data-cd-logo-only');
+      var icon = element.getAttribute('data-cd-icon');
+      var component = element.getAttribute('data-cd-component');
+
+      // Create the button.
+      var button = document.createElement('button');
+      button.setAttribute('type', 'button');
+
+      // ID.
+      button.setAttribute('id', id + '-toggler');
+
+      // @todo rename logo/icon to be more inclusive if needed.
+      //  Eg. prefix/suffix or pre/post
+      // Pre-label SVG icon.
+      if (logo) {
+        button.appendChild(this.createIcon(logo, component, 'logo'));
+      }
+
+      // Button label.
+      var labelWrapper = document.createElement('span');
+      labelWrapper.appendChild(document.createTextNode(label));
+      button.appendChild(labelWrapper);
+
+      // Only show the logo icon if requested but keep the title visible
+      // to assistive technologies.
+      if (logo && logoOnly) {
+        labelWrapper.classList.add('visually-hidden');
+      }
+
+      // Post-label SVG icon.
+      if (icon) {
+        // @todo This could default to dropdown arrow icon.
+        button.appendChild(this.createIcon(icon, component, 'icon'));
+      }
+
+      // BEM for class selectors.
+      if (component) {
+        button.classList.add(component + '__btn');
+        labelWrapper.classList.add(component + '__btn-label');
+      }
+
+      // Do not collapse the dropdown when clicking outside.
+      if (element.hasAttribute('data-cd-toggable-keep')) {
+        button.setAttribute('data-cd-toggable-keep', '');
+      }
+
+      // Alternate label for when the button is expanded.
+      if (element.hasAttribute('data-cd-toggable-expanded')) {
+        labelWrapper.setAttribute('data-cd-label-switch', element.getAttribute('data-cd-toggable-expanded'));
+      }
+
+      return button;
+    },
+
+    /**
+     * Transform the element into a dropdown menu.
+     */
+    setToggable: function (element) {
+      var toggler = this.getTogglerElement(element) || element.previousElementSibling;
+
+      // Skip if the toggler is not a button or has already been processed.
+      if (toggler) {
+        // Togglers should be buttons to avoid mis-processing elements
+        // appearing before the toggable element. There is still a risk of
+        // mis-processing if, for whatever reason, there is a button which is
+        // not the toggler before the toggable element.
+        if (toggler.nodeName !== 'BUTTON') {
+          // For some dropdown elements, we want to replace a fallback element
+          // (like a link) with the toggler button.
+          if (!element.hasAttribute('data-cd-replace')) {
+            return;
+          }
+        }
+        // We assume that if a button has the "data-cd-toggler" attribute then
+        // it has been processed by the "setToggable" function. That means
+        // this attribute should not be used directly in the markup otherwise
+        // the toggable element will not be processed by this script and event
+        // handlers will not be attached.
+        else if (toggler.hasAttribute('data-cd-toggler')) {
+          return;
+        }
+      }
+
+      // Create a button to toggle the element.
+      if (!toggler || element.hasAttribute('data-cd-replace')) {
+        toggler = this.createButton(element);
+      }
+
+      // Flag to indicate that the toggable element is initially expanded.
+      var expand = element.hasAttribute('data-cd-toggable-expand') || false;
+
+      // Set the toggling attributes of the toggler.
+      toggler.setAttribute('data-cd-toggler', '');
+      toggler.setAttribute('aria-expanded', expand !== false);
+      toggler.setAttribute('aria-haspopup', true);
+
+      // For better conformance with the aria specs though it doesn't do
+      // much in most screen reader right now (2020/01), we had the
+      // `aria-controls` attribute.
+      toggler.setAttribute('aria-controls', this.getToggableId(element));
+
+      // Add toggling function.
+      toggler.addEventListener('click', this.handleToggle);
+
+      // Collapse when pressing scape.
+      toggler.addEventListener('keydown', this.handleEscape);
+      element.addEventListener('keydown', this.handleEscape);
+
+      // Mark the element as toggable so that it can be handled properly
+      // by the global click handler.
+      if (!element.hasAttribute('data-cd-toggable')) {
+        element.setAttribute('data-cd-toggable', '');
+      }
+
+      // Hide the element.
+      element.setAttribute('data-cd-hidden', expand === false);
+
+      // Remove the button fallback element if any.
+      if (element.hasAttribute('data-cd-replace')) {
+        var fallback = document.getElementById(element.getAttribute('data-cd-replace'));
+        if (fallback) {
+          fallback.parentNode.removeChild(fallback);
+        }
+        element.removeAttribute('data-cd-replace');
+      }
+
+      // Insert the toggler after the toggable element. For example for
+      // "Show more/Show less" togglers.
+      if (element.hasAttribute('data-cd-insert-after') && element.nextElementSibling !== toggler) {
+        element.parentNode.insertBefore(toggler, element.nextElementSibling);
+      }
+      // Add the toggler before the toggable element if not already.
+      else if (element.previousElementSibling !== toggler) {
+        element.parentNode.insertBefore(toggler, element);
+      }
+    },
+
+    /**
+     * Remove the element's toggler.
+     */
+    unsetToggable: function (element) {
+      var toggler = this.getTogglerElement(element);
+      if (toggler && toggler.hasAttribute('data-cd-toggler')) {
+        // Remove event handler to avoid leaking.
+        toggler.addEventListener('click', this.handleToggle);
+        toggler.addEventListener('keydown', this.handleEscape);
+        element.addEventListener('keydown', this.handleEscape);
+
+        // Delete toggling button.
+        toggler.parentNode.removeChild(toggler);
+
+        // Reset attributes on the toggable element.
+        element.removeEventListener('keydown', this.handleEscape);
+        element.removeAttribute('data-cd-hidden');
+      }
+    },
+
+    /**
+     * Update a toggable element, setting or removing the toggling button and
+     * attributes depending on the `dropdown` css property. When set to false
+     * we remove the toggler and reset the toggable attributes so that the HTML
+     * markup reflects the current behavior of the element.
+     */
+    updateToggable: function (element) {
+      if (window.getComputedStyle(element, null).getPropertyValue('--dropdown').trim() === 'false') {
+        this.unsetToggable(element);
+      }
+      else {
+        this.setToggable(element);
+      }
+
+      // Mark the element as processed. This is notably used to remove the
+      // initial hidden state that is used to prevent flash of content.
+      if (!element.hasAttribute('data-cd-processed')) {
+        element.setAttribute('data-cd-processed', true);
+      }
+    },
+
+    /**
+     * Initialize the toggable menus, adding a toggle button and event
+     * handling.
+     */
+    initializeToggables: function () {
+      // Retrieve the max ID for generated toggable IDs so we can generate new
+      // unique ones.
+      var toggables = document.querySelectorAll('[data-cd-toggable]');
+      for (var i = 0, l = toggables.length; i < l; i++) {
+        var toggable = toggables[i];
+        if (toggable.hasAttribute('id') && toggable.id.indexOf(this.idPrefix) === 0) {
+          var id = parseInt(toggable.id.slice(this.idPrefix.length - 1), 10);
+          if (id > this.idMax) {
+            this.idMax = id;
+          }
+        }
+      }
+
+      // Collapse dropdowns when clicking outside of the toggable target.
+      document.addEventListener('click', this.handleClickAway);
+
+      // Loop through the toggable elements and set/unset the toggling button
+      // depending on the screen size.
+      window.addEventListener('resize', this.handleResize);
+
+      // Initial setup.
+      this.handleResize();
+    },
+
+    /**
+     * Update Drupal toggable nested menus.
+     */
+    updateDrupalTogglableMenus: function (selector) {
+      // If selector wasn't supplied, set the default.
+      selector = typeof selector !== 'undefined' ? selector : '.cd-nav .menu a + .menu';
+
+      // Nested drupal menus are always toggable.
+      var elements = document.querySelectorAll(selector);
+      for (var i = 0, l = elements.length; i < l; i++) {
+        this.setToggable(elements[i]);
+      }
+    }
+  };
+})(Drupal);

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_entities/reliefweb-entities-entity-text.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_entities/reliefweb-entities-entity-text.html.twig
@@ -59,7 +59,7 @@
                   title.removeAttribute('tabindex');
                 }
               }
-              else {
+              else if (mutation.oldValue === 'false') {
                 var toggler = document.getElementById('{{ content_id }}-toggler');
                 if (toggler) {
                   toggler.scrollIntoView();
@@ -68,7 +68,7 @@
             }
           }
         });
-        observer.observe(content, {attributes: true});
+        observer.observe(content, {attributes: true, attributeOldValue: true});
       }
     })();
   </script>

--- a/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_entities/reliefweb-entities-entity-text.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-modules/reliefweb_entities/reliefweb-entities-entity-text.html.twig
@@ -1,4 +1,8 @@
-{% set title_attributes = title_attributes.addClass('cd-block-title') %}
+{% set title_id = (id ~ '-title')|clean_id %}
+{% set title_attributes = title_attributes
+  .addClass('cd-block-title')
+  .setAttribute('id', title_id)
+%}
 
 {{ attach_library('common_design/cd-block-title') }}
 {{ attach_library('common_design_subtheme/rw-entity-text') }}
@@ -21,6 +25,7 @@
       // display the last 3 ones and add a toggling button to show the full
       // content.
       var content = document.getElementById('{{ content_id }}');
+      var title = document.getElementById('{{ title_id }}');
       var children = content.childNodes;
       var count = 0;
       for (var i = 0, l = children.length; i < l; i++) {
@@ -32,19 +37,34 @@
         content.setAttribute('data-cd-toggable', '{% trans %}Show full {{ content_title }}{% endtrans %}');
         content.setAttribute('data-cd-toggable-expanded', '{% trans %}Hide full {{ content_title }}{% endtrans %}');
         content.setAttribute('data-cd-toggable-keep', '');
+        content.setAttribute('data-cd-insert-after', '');
         content.setAttribute('data-cd-icon', 'arrow-down');
         content.setAttribute('data-cd-component', 'rw-entity-text');
         content.setAttribute('data-cd-replace', '{{ content_id }}-dummy');
       }
 
-      // Scroll to the top of the text content when expanding it.
+      // Scroll to the title of the section containing the text content when
+      // expanding it so that users can read the full description and use the
+      // keyboard navigation to go through the content. When hiding the text,
+      // scroll to the toggler to avoid jumping lower on the page.
       if ('MutationObserver' in window) {
         var observer = new MutationObserver(function (mutations) {
           for (var mutation of mutations) {
-            if (mutation.type === 'attributes' &&
-                mutation.attributeName === 'data-cd-hidden' &&
-                mutation.target.getAttribute('data-cd-hidden') === 'false') {
-              mutation.target.parentNode.scrollIntoView();
+            if (mutation.type === 'attributes' && mutation.attributeName === 'data-cd-hidden') {
+              if (mutation.target.getAttribute('data-cd-hidden') === 'false') {
+                if (title) {
+                  title.setAttribute('tabindex', 0);
+                  title.focus();
+                  title.scrollIntoView();
+                  title.removeAttribute('tabindex');
+                }
+              }
+              else {
+                var toggler = document.getElementById('{{ content_id }}-toggler');
+                if (toggler) {
+                  toggler.scrollIntoView();
+                }
+              }
             }
           }
         });


### PR DESCRIPTION
Refs: RW-646

This moves the "show/hide description" toggler for countries and disasters after the description to preserve the keyboard navigation order (visual order was different than source order) to improve accessibility.

It also set the focus on the description title when expanding the description to make it easier for the user to read the description and navigate through it with the keyboard.

When pressing the "hide description", the page scrolls to the description toggler button which provides a consistent experience across browsers while otherwise the user can be sent much lower in the page (ex: Maps) depending on the browser.

For that, this PR intoduces some improvements and changes to the `cd-dropdown.js`:
- New methods to get the toggler from the toggable and vice versa using the `aria-controls` attribute and toggler id. This avoids relying on the `previousElementSibling`.
- Add a new attribute `data-cd-insert-after` to insert the toggler after the toggable element which is useful for "show more/show less" toggles.
- Generate a unique ID for the toggable elements that don't have one to be able to use the `aria-controls` mentioned above.

Those changes should not impact existing sites and so the changes should probably make their way to the base theme after review at some point.

### Tests

1. Go to  `/disaster/ep-2016-000126-nga` for example to see an example of a disaster with a large description.
2. Click the "show full description" button and check that the view scrolls back to the "disaster description" title and keyboard navigation allows to go through the links in the description.
3. Click "hide the description" and check that the view scrolls to the toggler button (on prod, the view jumps to middle of the "Maps and Infographics" or some other place depending on the browser).
4. Use the keyboard navigation and confirm (2, pressing enter instead clicking) and (3)

