### PR TITLE
[RW-710] Fix validation of query parameters

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/Entity/Topic.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Topic.php
@@ -269,7 +269,7 @@ class Topic extends Node implements BundleEntityInterface, EntityModeratedInterf
     $river = $service->getRiver();
 
     // Get the river view.
-    $view = $data['view'] ?? $info['view'] ?? $parameters->get('view', '');
+    $view = $data['view'] ?? $info['view'] ?? $parameters->getString('view');
     $views = $service->getViews();
     $view = isset($views[$view]) ? $view : $service->getDefaultView();
     if ($view === $service->getDefaultView()) {
@@ -289,7 +289,7 @@ class Topic extends Node implements BundleEntityInterface, EntityModeratedInterf
     );
 
     // Get the sanitized search parameter.
-    $search = $parameters->get('search', '');
+    $search = $parameters->getString('search');
 
     // Get the API payload for the river and set the limit.
     $payload = $service->getApiPayload($view);

--- a/html/modules/custom/reliefweb_files/src/Controller/FileDownloadController.php
+++ b/html/modules/custom/reliefweb_files/src/Controller/FileDownloadController.php
@@ -110,7 +110,13 @@ class FileDownloadController extends OriginalFileDownloadController {
    * {@inheritdoc}
    */
   public function download(Request $request, $scheme = 'private') {
-    $uri = $scheme . '://' . $request->query->get('file');
+    $file = $request->query->get('file');
+    if (!is_string($file)) {
+      throw new NotFoundHttpException();
+    }
+
+    // This is normally the URI of the source file.
+    $uri = $scheme . '://' . trim($file);
 
     // Retrieve the base directory in which the previews are stored.
     $file_directory = $this->config->get('file_directory') ?? 'attachments';

--- a/html/modules/custom/reliefweb_files/src/Controller/ImageStyleDownloadController.php
+++ b/html/modules/custom/reliefweb_files/src/Controller/ImageStyleDownloadController.php
@@ -103,8 +103,13 @@ class ImageStyleDownloadController extends OriginalImageStyleDownloadController 
       throw new NotFoundHttpException();
     }
 
+    $file = $request->query->get('file');
+    if (!is_string($file)) {
+      throw new NotFoundHttpException();
+    }
+
     // This is normally the URI of the source image.
-    $uri = $scheme . '://' . $request->query->get('file');
+    $uri = $scheme . '://' . trim($file);
 
     // Retrieve the base directory in which the previews are stored.
     $preview_directory = $this->config->get('preview_directory') ?? 'previews';

--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldWidget/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldWidget/ReliefWebFile.php
@@ -1322,7 +1322,8 @@ class ReliefWebFile extends WidgetBase {
    */
   public static function rebuildWidgetForm(array &$form, FormStateInterface &$form_state, Request $request) {
     // Retrieve the updated widget.
-    $parents = explode('/', $request->query->get('field_parents'));
+    $parameter = $request->query->get('field_parents');
+    $parents = explode('/', is_string($parameter) ? trim($parameter) : '');
     $field_name = array_pop($parents);
     $field_state = static::getWidgetState($parents, $field_name, $form_state);
 

--- a/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
+++ b/html/modules/custom/reliefweb_guidelines/src/Form/GuidelineForm.php
@@ -94,7 +94,8 @@ class GuidelineForm extends ContentEntityForm {
     // Attempt to load from preview when the uuid is present unless we are
     // rebuilding the form.
     $request_uuid = $this->getRequest()->query->get('uuid');
-    if (!$form_state->isRebuilding() && $request_uuid && $preview = $store->get($request_uuid)) {
+    $request_uuid = is_string($request_uuid) ? trim($request_uuid) : '';
+    if (!$form_state->isRebuilding() && !empty($request_uuid) && $preview = $store->get($request_uuid)) {
       /** @var \Drupal\Core\Form\FormStateInterface $preview */
 
       $form_state->setStorage($preview->getStorage());
@@ -243,7 +244,11 @@ class GuidelineForm extends ContentEntityForm {
     $options = [];
     $query = $this->getRequest()->query;
     if ($query->has('destination')) {
-      $options['query']['destination'] = $query->get('destination');
+      $destination = $query->get('destination');
+      $destination = is_string($destination) ? trim($destination) : '';
+      if (!empty($destination)) {
+        $options['query']['destination'] = $query->get('destination');
+      }
       $query->remove('destination');
     }
     $form_state->setRedirect('entity.guideline.preview', $route_parameters, $options);

--- a/html/modules/custom/reliefweb_key_figures/src/Services/KeyFiguresClient.php
+++ b/html/modules/custom/reliefweb_key_figures/src/Services/KeyFiguresClient.php
@@ -138,6 +138,7 @@ class KeyFiguresClient {
 
     // Limit the number of figures based on the "figures" query parameter.
     $figures_parameter = $this->requestStack->getCurrentRequest()->query->get('figures');
+    $figures_parameter = is_string($figures_parameter) ? trim($figures_parameter) : '';
     $count = count($data['figures']);
     $limit = $figures_parameter === 'all' ? $count : 6;
     $data['figures'] = array_slice($data['figures'], 0, $limit);

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -563,6 +563,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
    */
   public function getAutocompleteSuggestions($filter) {
     $query = $this->getCurrentRequest()->query->get('query', '');
+    $query = is_string($query) ? trim($query) : '';
 
     if (empty($query) || !$this->hasFilterDefinition($filter)) {
       return [];
@@ -1274,9 +1275,11 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
   protected function getOrderInformation() {
     $headers = $this->getHeaders();
     $order = $this->getCurrentRequest()->query->get('order', '');
+    $order = is_string($order) ? trim($order) : '';
     // We assume the date header is present and sortable.
     $order = !empty($headers[$order]['sortable']) ? $order : 'date';
-    $sort = strtolower($this->getCurrentRequest()->query->get('sort', ''));
+    $sort = $this->getCurrentRequest()->query->get('sort', '');
+    $sort = strtolower(is_string($sort) ? trim($sort) : '');
     $sort = in_array($sort, ['asc', 'desc']) ? $sort : 'desc';
     $headers[$order]['sort'] = $sort;
 

--- a/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
+++ b/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
@@ -164,7 +164,7 @@ class AdvancedSearch {
     // "WITH legacy-facets AND WITH legacy-river AND with advanced-search".
     $components[] = $this->parseLegacyFacetParameters();
     $components[] = $this->parseLegacyRiverParameter();
-    $components[] = $this->parameters->get('advanced-search');
+    $components[] = $this->parameters->getString('advanced-search');
 
     // Update the advanced search parameter.
     $this->parameters->set('advanced-search', implode('_', array_filter($components)));
@@ -513,7 +513,7 @@ class AdvancedSearch {
       if (isset($info['shortcut'], $this->filters[$info['shortcut']])) {
         $code = $info['shortcut'];
         $operator = isset($info['operator']) && $info['operator'] === 'OR' ? '.' : '_';
-        $values = $this->parameters->get($field);
+        $values = $this->parameters->getString($field);
         if (!empty($values)) {
           $filters[] = '(' . $code . str_replace('.', $operator . $code, $values) . ')';
         }
@@ -542,7 +542,7 @@ class AdvancedSearch {
       return '';
     }
     // Get and remove the parameter.
-    $path = $this->parameters->get('legacy-river');
+    $path = $this->parameters->getString('legacy-river');
     $this->parameters->remove('legacy-river');
 
     // Check if the path is using the alias form and, if so, find the term path.
@@ -574,7 +574,7 @@ class AdvancedSearch {
    *   the sense that we just ignore invalid values.
    */
   public function getAdvancedSearchFilterSelection() {
-    return $this->parseAdvancedSearchParameter($this->parameters->get('advanced-search'));
+    return $this->parseAdvancedSearchParameter($this->parameters->getString('advanced-search'));
   }
 
   /**

--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
@@ -199,6 +199,7 @@ class SearchConverter extends ControllerBase {
    */
   protected function getAppname() {
     $appname = $this->requestStack->getCurrentRequest()->query->get('appname', '');
+    $appname = is_string($appname) ? trim($appname) : '';
     return $appname ?: 'rw-user-' . $this->currentUser->id();
   }
 
@@ -209,7 +210,8 @@ class SearchConverter extends ControllerBase {
    *   The search URL parameter.
    */
   protected function getSearchUrl() {
-    return $this->requestStack->getCurrentRequest()->query->get('search-url', '');
+    $search_url = $this->requestStack->getCurrentRequest()->query->get('search-url', '');
+    return is_string($search_url) ? trim($search_url) : '';
   }
 
   /**

--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchResults.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchResults.php
@@ -215,7 +215,7 @@ class SearchResults extends ControllerBase {
   public function getSearchQuery() {
     if (!isset($this->searchQuery)) {
       $parameters = Parameters::getParameters();
-      if (isset($parameters['search'])) {
+      if (isset($parameters['search']) && is_string($parameters['search'])) {
         $this->searchQuery = trim($parameters['search']);
       }
       else {

--- a/html/modules/custom/reliefweb_rivers/src/Parameters.php
+++ b/html/modules/custom/reliefweb_rivers/src/Parameters.php
@@ -543,6 +543,29 @@ class Parameters {
   }
 
   /**
+   * Get a query parameter as a string.
+   *
+   * @param string $name
+   *   Parameter name. NULL returns all parameters.
+   * @param string $default
+   *   Default value in case the parameter is not defined.
+   * @param bool $trim
+   *   Whether to trim the parameter value or not.
+   *
+   * @return string
+   *   The query parameter or an empty string.
+   */
+  public function getString($name, $default = '', $trim = TRUE) {
+    if (isset($this->parameters[$name]) && is_scalar($this->parameters[$name])) {
+      $parameter = (string) $this->parameters[$name];
+    }
+    else {
+      $parameter = $default;
+    }
+    return $trim ? trim($parameter) : $parameter;
+  }
+
+  /**
    * Set a parameter value.
    *
    * @param string $name
@@ -581,7 +604,7 @@ class Parameters {
    * Parse and convert the Sphinx search parameter.
    */
   protected function parseSphinxsearch() {
-    $parameter = $this->get('search');
+    $parameter = $this->getString('search');
 
     if (!empty($parameter)) {
       $mapping = $this->mapping['sphinxsearch'];
@@ -600,7 +623,7 @@ class Parameters {
    * Parse and convert the Searchlight parameters.
    */
   protected function parseSearchlight() {
-    $parameter = $this->get('sl');
+    $parameter = $this->getString('sl');
 
     // Remove Searchlight parameters.
     $this->remove('sl');
@@ -715,7 +738,7 @@ class Parameters {
    * Convert the extended search parameter to the new advanced search one.
    */
   protected function parseExtendedSearch() {
-    $parameter = $this->get('extended_search');
+    $parameter = $this->getString('extended_search');
 
     // Remove extended search parameter.
     $this->remove('extended_search');
@@ -723,7 +746,7 @@ class Parameters {
     if (!empty($parameter) && ($parameters = json_decode($parameter, TRUE)) !== NULL) {
       // Full text search.
       if (!empty($parameters['text'])) {
-        $search_query = [$this->get('search')];
+        $search_query = [$this->getString('search')];
         if (!empty($parameters['text']['all'])) {
           $search_query[] = '"' . implode('" AND "', $parameters['text']['all']) . '"';
         }
@@ -748,7 +771,7 @@ class Parameters {
 
       // Filters.
       if (!empty($parameters['filters'])) {
-        $filters = [$this->get('advanced-search')];
+        $filters = [$this->getString('advanced-search')];
 
         $operators = [
           '|' => '(',

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -299,7 +299,7 @@ abstract class RiverServiceBase implements RiverServiceInterface {
    * {@inheritdoc}
    */
   public function getSelectedView() {
-    $view = $this->getParameters()->get('view');
+    $view = $this->getParameters()->getString('view');
     $views = $this->getViews();
     return isset($views[$view]) ? $view : $this->getDefaultView();
   }
@@ -308,8 +308,7 @@ abstract class RiverServiceBase implements RiverServiceInterface {
    * {@inheritdoc}
    */
   public function getSearch() {
-    $search = $this->getParameters()->get('search', '');
-    return trim($search);
+    return $this->getParameters()->getString('search');
   }
 
   /**
@@ -880,14 +879,16 @@ abstract class RiverServiceBase implements RiverServiceInterface {
    *   entity bundle and view.
    */
   public static function getRiverServiceFromUrl($url) {
-    $mapping = static::getRiverMapping();
-    $path = trim(parse_url($url, PHP_URL_PATH), '/');
+    if (is_string($url)) {
+      $mapping = static::getRiverMapping();
+      $path = trim(parse_url($url, PHP_URL_PATH), '/');
 
-    if (isset($mapping[$path]['bundle'])) {
-      $data = $mapping[$path];
-      $service = static::getRiverService($data['bundle']);
-      if (isset($service)) {
-        return $data + ['service' => $service];
+      if (isset($mapping[$path]['bundle'])) {
+        $data = $mapping[$path];
+        $service = static::getRiverService($data['bundle']);
+        if (isset($service)) {
+          return $data + ['service' => $service];
+        }
       }
     }
     return [];

--- a/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
@@ -54,7 +54,7 @@ class SourceRiver extends RiverServiceBase {
 
     // Get the currently selected letter filter and mark the corresponding
     // letter as active.
-    $letter = $this->getParameters()->get('group', 'all');
+    $letter = $this->getParameters()->getString('group', 'all');
     if (isset($letters[$letter])) {
       $letters[$letter]['active'] = TRUE;
     }
@@ -120,7 +120,7 @@ class SourceRiver extends RiverServiceBase {
 
     // Add a filter on the selected letter.
     $letters = static::getFirstLetters();
-    $letter = $this->getParameters()->get('group', 'all');
+    $letter = $this->getParameters()->getString('group', 'all');
     if (!empty($letters[$letter]['ids'])) {
       $payload['filter'] = [
         'conditions' => [


### PR DESCRIPTION
Refs: RW-710

This adds some validation to all the places where we retrieve query parameters to avoid unexpected behaviors (like uncaught exception) when the parameter is invalid (ex `search[]=whatever` instead of `search=whatever`).

### Tests

Compare with prod where the pages should show a "The website encountered an unexpected error. Please try again later.".

1. `/updates?search[]=whatever` (expected: parameter ignored)
2. `/updates?view[]=whatever` (expected: parameter ignored)
3. `/updates?advanced-search[]=whatever` (expected: parameter ignored)
4. `/updates?legacy-river[]=country/afg`  (expected: parameter ignored)
5. `/search/results?search[]=whatever` (expected: parameter ignored)
6. `/country/afg?figures[]=all` (expected: parameter ignored; it's already also ignored on prod)
7. `/organizations?group[]=whatever` (expected: parameter ignored)