### PR TITLE
[RW-708] Set proper max length for the import feed info fields

### DIFF
--- a/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebImportInfo.php
+++ b/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebImportInfo.php
@@ -33,6 +33,7 @@ class ReliefWebImportInfo extends WidgetBase {
       '#title' => $this->t('Feed Url'),
       '#default_value' => $items[$delta]->feed_url ?? NULL,
       '#description' => $this->t('For automatic job imports. This URL is a feed url of an updated list of the job offers for the organization. It must start with "https://" or "http://".'),
+      '#maxlength' => 2048,
     ];
 
     $element['base_url'] = [
@@ -40,6 +41,7 @@ class ReliefWebImportInfo extends WidgetBase {
       '#title' => $this->t('Base Url'),
       '#default_value' => $items[$delta]->base_url ?? NULL,
       '#description' => $this->t('Job postings published by this organization must match this URL. It must start with "https://" or "http://".'),
+      '#maxlength' => 2048,
     ];
 
     $element['uid'] = [


### PR DESCRIPTION
Refs: RW-708

This set the maxlength for the import feed info fields on the source form to a value compatible with the database storage size to avoid truncating a 128 characters.

### Tests

**Before checking out this branch**

1. Go to `/taxonomy/term/2865/edit` for example, and a URL with more than 128 characters in the `Feed URL` field at the bottom of the form
2. Save and check that the URL has been truncated to 128 characters

**After checking out this branch**

Repeat the above but this time the URL should not be truncated.