### PR TITLE
[RW-712] Fixes for translated forms.

### DIFF
--- a/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSanitizer.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/HtmlSanitizer.php
@@ -170,6 +170,8 @@ class HtmlSanitizer {
       'tr' => FALSE,
       'sup' => FALSE,
       'sub' => FALSE,
+      'small' => FALSE,
+      'font' => FALSE,
       // No children.
       'img' => TRUE,
     ];
@@ -253,6 +255,10 @@ class HtmlSanitizer {
       // Process list items.
       elseif ($tag === 'li') {
         $this->handleListItem($node);
+      }
+      // Process tables.
+      elseif ($tag === 'font') {
+        $this->stripTag($node);
       }
       // Process the node, converting if necessary and removing attributes.
       else {
@@ -597,6 +603,22 @@ class HtmlSanitizer {
         $this->removeChild($parent);
       }
     }
+  }
+
+  /**
+   * Strip a tag.
+   *
+   * @param \DOMNode $node
+   *   Heading node.
+   */
+  protected function stripTag(\DOMNode $node) {
+    $parent = $node->parentNode;
+    // Move the content to the parent.
+    while ($node->firstChild !== NULL) {
+      $parent->insertBefore($node->firstChild, $node);
+    }
+    // Remove the node.
+    $this->removeChild($node);
   }
 
   /**

--- a/html/modules/custom/reliefweb_utility/tests/src/Unit/HtmlSanitizerTest.php
+++ b/html/modules/custom/reliefweb_utility/tests/src/Unit/HtmlSanitizerTest.php
@@ -184,6 +184,16 @@ class HtmlSanitizerTest extends UnitTestCase {
     $iframe = FALSE;
     $this->assertEquals(HtmlSanitizer::sanitize($html, $iframe), $expected);
 
+    $html = '<p><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">Text</font></font></p>';
+    $expected = '<p>Text</p>';
+    $iframe = FALSE;
+    $this->assertEquals(HtmlSanitizer::sanitize($html, $iframe), $expected);
+
+    $html = '<p><font style="vertical-align: inherit;"><strong>Text</strong> <small>With</small> Parts</font</p>';
+    $expected = '<p><strong>Text</strong> <small>With</small> Parts</p>';
+    $iframe = FALSE;
+    $this->assertEquals(HtmlSanitizer::sanitize($html, $iframe), $expected);
+
     $markdown = 'a **strong** word';
     $expected = '<p>a <strong>strong</strong> word</p>';
     $this->assertEquals(HtmlSanitizer::sanitizeFromMarkdown($markdown), $expected);

--- a/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-form/rw-form.css
@@ -15,7 +15,7 @@ form textarea {
 form button,
 /* Apply styles to field UI buttons
   with some exceptions (Notably "Save" buttons) */
-form:not(.subscription-form):not(.community-topics-form) .form-item .cd-button {
+form:not(.subscription-form, .community-topics-form) .form-item .cd-button {
   margin: 0 12px 0 0;
   padding: 12px;
   color: white;
@@ -28,18 +28,18 @@ form:not(.subscription-form):not(.community-topics-form) .form-item .cd-button {
 form button:hover,
 form button:focus,
 form button:active,
-form:not(.subscription-form):not(.community-topics-form) .form-item .cd-button:hover,
-form:not(.subscription-form):not(.community-topics-form) .form-item .cd-button:focus,
-form:not(.subscription-form):not(.community-topics-form) .form-item .cd-button:active {
+form:not(.subscription-form, .community-topics-form) .form-item .cd-button:hover,
+form:not(.subscription-form, .community-topics-form) .form-item .cd-button:focus,
+form:not(.subscription-form, .community-topics-form) .form-item .cd-button:active {
   text-decoration: underline;
   background: var(--cd-reliefweb-brand-red--dark);
 }
 form button:focus,
-form:not(.subscription-form):not(.community-topics-form) .form-item .cd-button:focus {
+form:not(.subscription-form, .community-topics-form) .form-item .cd-button:focus {
   text-decoration: underline;
   border: 2px solid var(--cd-reliefweb-brand-grey--dark);
 }
-form:not('.subscription-form'):not('community-topics-form') .form-item .cd-button {
+form:not(.subscription-form, .community-topics-form) .form-item .cd-button {
   transition: none;
   border-radius: 0;
 }
@@ -286,7 +286,8 @@ form #actions {
   background: rgba(230, 236, 239, 0.4);
 }
 form #actions .cd-button {
-  margin-top: 12px;
+  margin: 12px 2px 0 2px;
+  font-weight: normal;
 }
 form #actions + * {
   border-top: none;
@@ -520,14 +521,14 @@ form button[value="edit"] {
 }
 
 /* Preview button */
-input[data-drupal-selector="edit-preview"] {
+button[data-drupal-selector="edit-preview"] {
   background-color: var(--cd-grey--dark);
 }
-input[data-drupal-selector="edit-preview"]:hover,
-input[data-drupal-selector="edit-preview"]:focus {
+button[data-drupal-selector="edit-preview"]:hover,
+button[data-drupal-selector="edit-preview"]:focus {
   background-color: var(--cd-grey--mid);
 }
-input[data-drupal-selector="edit-preview"]:focus {
+button[data-drupal-selector="edit-preview"]:focus {
   border: 2px solid var(--cd-black);
 }
 

--- a/html/themes/custom/common_design_subtheme/templates/form/input--submit.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/form/input--submit.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+<button{{ attributes.addClass('cd-button') }}>{{ attributes.offsetGet('value') }}</button>{{ children }}


### PR DESCRIPTION
Refs: RW-712

This includes 2 fixes to improve compatibility of the forms with translation tools (like Chrome's page translation):

1. Use `<button>` instead of `<input>` for submit buttons in order to preserve the `value` attribute that Drupal uses to identify the clicked button. (For buttons, the text inside `<button>LABEL</button>` is translated while for input of type submit, the value is translated.)
2. Strip the `<font>` elements in the sanitizer, keeping the relevant children instead of removing the elements completely. Chrome page translation for example wraps all the translated text inside `<font style="vertical-align: inherit;">...</font>` for whatever reason.

### Tests

(2) above is already checked by the unit tests so only (1) needs testing:

**Before checking out this branch**

1. Using Chrome, go to settings > languages > add a language other than English and select it as language to use for the translation (may have to remove English (USA) which is the default one first):
2. Log in local RW site
3. Create a new job (link from dashboard)
4. Right click to show the contextual menu and select “Translate to …”
fill in the form
5. Click “submit” → you should be redirected to the preview

Note: alternatively, just edit the `value` of one of the submit buttons in the job form to some gibberish so simulate the translation of the button text.

**After checking out this branch**

Repeat the above but this time (5) should properly submit the job.
