### PR TITLE
[RW-717] Fix query performance on moderation pages

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -1209,8 +1209,13 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
     // Filter the query with the form filters.
     $this->filterQuery($query, $filters);
 
-    // Ensure there are no duplicates (ex: when joining revision tables).
-    $query->distinct();
+    // Ensure there are no duplicates when joining revision tables.
+    foreach ($query->getTables() as $table) {
+      if (isset($table['table']) && strpos($table['table'], 'revision') !== FALSE) {
+        $query->distinct();
+        break;
+      }
+    }
 
     // Wrap the query in a parent query to which the ordering and limiting is
     // applied.


### PR DESCRIPTION
Refs: RW-717

This restricts the fix from RW-701 (`distinct()`) to only apply when there is a filter on a revision table as it's the source of the duplication. This improves the performances for queries which already return unique results.

Note: previous PR with the fix from RW-701: https://github.com/UN-OCHA/rwint9-site/pull/502

### Tests.

**Before checking out this branch**

1. Check out the latest develop
2. Go to `/moderation/content/report`, check how long it takes to load
3. Add a review date filter for example, apply and take note of the totals

**After checking out this branch**

1. Go to `/moderation/content/report`, check how long it takes to load => it should be faster than (2) above
2. Add the same date filter as (2) above, apply and check that the totals are the same.