### PR TITLE
[RW-705] se selected filters and search for river page description

### DIFF
--- a/html/modules/custom/reliefweb_meta/reliefweb_meta.module
+++ b/html/modules/custom/reliefweb_meta/reliefweb_meta.module
@@ -52,6 +52,15 @@ function reliefweb_meta_metatags_alter(array &$metatags, array &$context) {
     'image' => reliefweb_meta_get_image_url(),
   ];
 
+  if (strpos($route_name, 'reliefweb_rivers.') === 0) {
+    try {
+      $description = \Drupal::service($route_name)->getRiverDescription();
+    }
+    catch (Exception $exception) {
+      // Nothing to do.
+    }
+  }
+
   switch ($route_name) {
     case 'entity.node.canonical':
       $data = reliefweb_meta_get_node_metatags($context['entity']);
@@ -74,42 +83,42 @@ function reliefweb_meta_metatags_alter(array &$metatags, array &$context) {
 
     case 'reliefweb_rivers.blog_post.river':
       $data['title'] = t('Blog');
-      $data['description'] = t("A look at the ideas and projects we're working on as we strive to grow and improve ReliefWeb.");
+      $data['description'] = $description ?? t("A look at the ideas and projects we're working on as we strive to grow and improve ReliefWeb.");
       break;
 
     case 'reliefweb_rivers.country.river':
       $data['title'] = t('Countries');
-      $data['description'] = t('ReliefWeb country pages provide a comprehensive overview of the humanitarian situation and feature situation reports, news and press releases, assessments, evaluations, infographics, maps and more.');
+      $data['description'] = $description ?? t('ReliefWeb country pages provide a comprehensive overview of the humanitarian situation and feature situation reports, news and press releases, assessments, evaluations, infographics, maps and more.');
       break;
 
     case 'reliefweb_rivers.disaster.river':
       $data['title'] = t('Disasters');
-      $data['description'] = t('ReliefWeb disaster pages provide an overview of the situation and situation reports, news and press releases, assessments, evaluations, infographics and maps. Browse our list of natural disasters with humanitarian impact from 1981 until today.');
+      $data['description'] = $description ?? t('ReliefWeb disaster pages provide an overview of the situation and situation reports, news and press releases, assessments, evaluations, infographics and maps. Browse our list of natural disasters with humanitarian impact from 1981 until today.');
       break;
 
     case 'reliefweb_rivers.job.river':
       $data['title'] = t('Jobs');
-      $data['description'] = t('Your gateway for humanitarian and development jobs. Search and/or drill down with filters to narrow down the listings.');
+      $data['description'] = $description ?? t('Your gateway for humanitarian and development jobs. Search and/or drill down with filters to narrow down the listings.');
       break;
 
     case 'reliefweb_rivers.report.river':
       $data['title'] = t('Updates');
-      $data['description'] = t('Your gateway to all content to date. Search and/or drill down with filters to narrow down the content.');
+      $data['description'] = $description ?? t('Your gateway to all content to date. Search and/or drill down with filters to narrow down the content.');
       break;
 
     case 'reliefweb_rivers.source.river':
       $data['title'] = t('Organizations');
-      $data['description'] = t('A list of organizations that are actively providing ReliefWeb with content (reports, jobs and training).');
+      $data['description'] = $description ?? t('A list of organizations that are actively providing ReliefWeb with content (reports, jobs and training).');
       break;
 
     case 'reliefweb_rivers.topic.river':
       $data['title'] = t('Topics');
-      $data['description'] = t('Curated pages dedicated to humanitarian themes and specific humanitarian crises.');
+      $data['description'] = $description ?? t('Curated pages dedicated to humanitarian themes and specific humanitarian crises.');
       break;
 
     case 'reliefweb_rivers.training.river':
       $data['title'] = t('Training');
-      $data['description'] = t('Your gateway for humanitarian training opportunities. Search and/or drill down with filters to narrow down the listings.');
+      $data['description'] = $description ?? t('Your gateway for humanitarian training opportunities. Search and/or drill down with filters to narrow down the listings.');
       break;
 
     default:

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -719,6 +719,48 @@ abstract class RiverServiceBase implements RiverServiceInterface {
   /**
    * {@inheritdoc}
    */
+  public function getRiverDescription() {
+    $title = $this->getPageTitle();
+    $search = $this->getSearch();
+    $filters = $this->getAdvancedSearch()->getHumanReadableSelection();
+
+    $view = $this->getSelectedView();
+    if ($view !== $this->getDefaultView()) {
+      $title = $this->t('@title (@view)', [
+        '@title' => $title,
+        '@view' => $this->getViews()[$view],
+      ]);
+    }
+
+    if (!empty($search) && !empty($filters)) {
+      return $this->t('@title containing @search and @filters', [
+        '@title' => $title,
+        '@search' => $search,
+        '@filters' => $filters,
+      ]);
+    }
+    elseif (!empty($search)) {
+      return $this->t('@title containing @search', [
+        '@title' => $title,
+        '@search' => $search,
+      ]);
+    }
+    elseif (!empty($filters)) {
+      return $this->t('@title @filters', [
+        '@title' => $title,
+        '@filters' => $filters,
+      ]);
+    }
+    elseif ($view !== $this->getDefaultView()) {
+      return $title;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function getLanguageCode(array &$data = NULL) {
     if (isset($data['langcode'])) {
       $langcode = $data['langcode'];

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceInterface.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceInterface.php
@@ -294,6 +294,14 @@ interface RiverServiceInterface {
   public function parseApiDataForRss(array $data, $view = '');
 
   /**
+   * Get the river description based on the filters and search query.
+   *
+   * @return \Drupal\Component\Render\MarkupInterface|null
+   *   River page description or empty if there is no search or filters.
+   */
+  public function getRiverDescription();
+
+  /**
    * Get the ISO 639-1 language code for the entity.
    *
    * Defaults to English if not defined.

--- a/html/modules/custom/reliefweb_rivers/src/Services/DisasterRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/DisasterRiver.php
@@ -76,6 +76,7 @@ class DisasterRiver extends RiverServiceBase {
     return [
       'C' => [
         'name' => $this->t('Country'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'country',
         'field' => 'country.id',

--- a/html/modules/custom/reliefweb_rivers/src/Services/JobRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/JobRiver.php
@@ -106,6 +106,7 @@ class JobRiver extends RiverServiceBase {
       ],
       'C' => [
         'name' => $this->t('Country'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'country',
         'field' => 'country.id',
@@ -121,6 +122,7 @@ class JobRiver extends RiverServiceBase {
       ],
       'S' => [
         'name' => $this->t('Organization'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'source',
         'field' => 'source.id',

--- a/html/modules/custom/reliefweb_rivers/src/Services/ReportRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/ReportRiver.php
@@ -58,6 +58,7 @@ class ReportRiver extends RiverServiceBase {
     return [
       'PC' => [
         'name' => $this->t('Primary country'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'country',
         'field' => 'primary_country.id',
@@ -70,6 +71,7 @@ class ReportRiver extends RiverServiceBase {
       ],
       'C' => [
         'name' => $this->t('Country'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'country',
         'field' => 'country.id',
@@ -82,6 +84,7 @@ class ReportRiver extends RiverServiceBase {
       ],
       'S' => [
         'name' => $this->t('Organization'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'source',
         'field' => 'source.id',

--- a/html/modules/custom/reliefweb_rivers/src/Services/TrainingRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/TrainingRiver.php
@@ -120,6 +120,7 @@ class TrainingRiver extends RiverServiceBase {
       ],
       'C' => [
         'name' => $this->t('Country'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'country',
         'field' => 'country.id',
@@ -131,6 +132,7 @@ class TrainingRiver extends RiverServiceBase {
       ],
       'S' => [
         'name' => $this->t('Organization'),
+        'shortname' => TRUE,
         'type' => 'reference',
         'vocabulary' => 'source',
         'field' => 'source.id',


### PR DESCRIPTION
Refs: RW-705

This changes the generic page description of the rivers when there are selected filters to help search engines notably differentiate between those pages.

So for example [this search query](https://reliefweb.int/updates?advanced-search=%28S1275%29.%28DT4642_T4595%29_%28DA20200301-%29_%21%28OT273%29) will have the description:

> Updates with organization: World Health Organization (WHO) or with disaster type: Epidemic and theme: Health and with posting date on reliefweb: after 2020/02/29 and without organization type: Media

instead of the generic when there is no filter or search query:

> Your gateway to all content to date. Search and/or drill down with filters to narrow down the content.

### Tests.

1. Checkout this branch
2. Go to a river (ex: /updates), select some filters and apply
3. Check that the description in the `<head>` matches the selected filters
4. Do a full text search as well and check that it also appears in the description
5. Select a view (ex:  headlines) and check that it also appears in the description (ex: `Updates  (Headlines) ...`)