### PR TITLE
[RW-718] Fix cache control of RSS feeds and JSON output

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
+++ b/html/modules/custom/reliefweb_rivers/src/Controller/SearchConverter.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\reliefweb_rivers\Controller;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormState;
@@ -20,6 +21,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * Controller for the reliefweb_rivers.search.converter route.
  */
 class SearchConverter extends ControllerBase {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
 
   /**
    * The current user.
@@ -52,6 +60,8 @@ class SearchConverter extends ControllerBase {
   /**
    * Constructor.
    *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\Core\Session\AccountProxyInterface $current_user
    *   The current user.
    * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
@@ -62,11 +72,13 @@ class SearchConverter extends ControllerBase {
    *   The reliefweb api client service.
    */
   public function __construct(
+    ConfigFactoryInterface $config_factory,
     AccountProxyInterface $current_user,
     FormBuilderInterface $form_builder,
     RequestStack $request_stack,
     ReliefWebApiClient $reliefweb_api_client
   ) {
+    $this->configFactory = $config_factory;
     $this->currentUser = $current_user;
     $this->formBuilder = $form_builder;
     $this->requestStack = $request_stack;
@@ -78,6 +90,7 @@ class SearchConverter extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('config.factory'),
       $container->get('current_user'),
       $container->get('form_builder'),
       $container->get('request_stack'),
@@ -180,14 +193,27 @@ class SearchConverter extends ControllerBase {
       ];
     }
 
+    $headers = [
+      'Content-Type' => 'application/json; charset=utf-8',
+    ];
+
+    // Add the cache control header.
+    $cache_settings = $this->configFactory->get('system.performance')?->get('cache');
+    if (!empty($cache_settings['page']['max_age']) && $cache_settings['page']['max_age'] > 0) {
+      $headers['Cache-Control'] = 'max-age=' . $cache_settings['page']['max_age'] . ', public';
+    }
+    else {
+      $headers['Cache-Control'] = 'private';
+    }
+
     try {
-      return new JsonResponse($result);
+      return new JsonResponse($result, 200, $headers);
     }
     catch (\Exception $exception) {
       $this->getLogger('reliefweb_river')->error('Unable to generate search conversion JSON result: @error', [
         '@error' => $exception->getMessage(),
       ]);
-      return new JsonResponse(['error' => $this->t('Invalid input')], 400);
+      return new JsonResponse(['error' => $this->t('Invalid input')], 400, $headers);
     }
   }
 

--- a/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
+++ b/html/modules/custom/reliefweb_rivers/src/RiverServiceBase.php
@@ -647,8 +647,16 @@ abstract class RiverServiceBase implements RiverServiceInterface {
 
     $headers = [
       'Content-Type' => 'application/rss+xml; charset=utf-8',
-      'Cache-Control' => 'private',
     ];
+
+    // Add the cache control header.
+    $cache_settings = $this->configFactory->get('system.performance')?->get('cache');
+    if (!empty($cache_settings['page']['max_age']) && $cache_settings['page']['max_age'] > 0) {
+      $headers['Cache-Control'] = 'max-age=' . $cache_settings['page']['max_age'] . ', public';
+    }
+    else {
+      $headers['Cache-Control'] = 'private';
+    }
 
     return new Response($this->renderer->render($content), 200, $headers);
   }


### PR DESCRIPTION
Refs: RW-718

This ensures the Cache-Control header for the RSS feeds (ex: /updates/rss.xml) and the json output of the search converter is properly set so that varnish can cache the pages.

### Tests

Note: this requires that `$config['system.performance']['cache']['page']['max_age']` is properly set in the `settings.local.yml` file.

**Before checking out this branch**

1. Check the cache control header of `/updates/rss.xml`, it should be  `private`
2. Check the cache control header of `/search/converter?appname=test&search-url=https%3A//rw9.test/updates`, it should be private

**After checking out this branch**

Repeat the above but this time the cache-control header should be `max-age=XX, public` where `XX` is the value of `$config['system.performance']['cache']['page']['max_age']` or `60` if using varnish.