### PR TITLE
[RW-724] Fix posted filter on people page

### DIFF
--- a/html/modules/custom/reliefweb_users/src/Form/UserPageFilterForm.php
+++ b/html/modules/custom/reliefweb_users/src/Form/UserPageFilterForm.php
@@ -96,7 +96,7 @@ class UserPageFilterForm extends FormBase {
       '#title' => $this->t('Posted'),
       '#type' => 'checkboxes',
       '#options' => $content_types,
-      '#default_value' => $filters['posted'] ?? [],
+      '#default_value' => array_keys($filters['posted']) ?? [],
     ];
 
     $form['filters']['job_rights'] = [

--- a/html/modules/custom/reliefweb_users/src/Form/UserPageFilterForm.php
+++ b/html/modules/custom/reliefweb_users/src/Form/UserPageFilterForm.php
@@ -96,7 +96,7 @@ class UserPageFilterForm extends FormBase {
       '#title' => $this->t('Posted'),
       '#type' => 'checkboxes',
       '#options' => $content_types,
-      '#default_value' => array_keys($filters['posted']) ?? [],
+      '#default_value' => array_keys($filters['posted'] ?? []),
     ];
 
     $form['filters']['job_rights'] = [


### PR DESCRIPTION
Refs: RW-724

This fixes the exception thrown when using the "posted" filter on the people page.

### Tests

**Before checking out this branch**

1. Go to `/admin/people`
2. Check "Job" for example under "Posted"
3. Click "Filter"
4. Cry

**After checking out this branch**

Repeat the above but this time at (4), after a few seconds (because the query is slow with this filter), you should see the properly filtered list of users.