### PR TITLE
[RW-725] User routes

### DIFF
--- a/html/modules/custom/reliefweb_bookmarks/reliefweb_bookmarks.routing.yml
+++ b/html/modules/custom/reliefweb_bookmarks/reliefweb_bookmarks.routing.yml
@@ -16,6 +16,13 @@ reliefweb_bookmarks.user:
     _custom_access: '\Drupal\reliefweb_bookmarks\Controller\UserBookmarksController::checkUserAccess'
     user: \d+
 
+reliefweb_bookmarks.user.current_user:
+  path: '/user/bookmarks'
+  defaults:
+    _controller: '\Drupal\reliefweb_bookmarks\Controller\UserBookmarksController::currentUserBookmarksPage'
+  requirements:
+    _user_is_logged_in: 'TRUE'
+
 reliefweb_bookmarks.user.type:
   path: '/user/{user}/bookmarks/{entity_type}/{bundle}'
   defaults:

--- a/html/modules/custom/reliefweb_bookmarks/src/Controller/UserBookmarksController.php
+++ b/html/modules/custom/reliefweb_bookmarks/src/Controller/UserBookmarksController.php
@@ -481,4 +481,16 @@ class UserBookmarksController extends ControllerBase implements ContainerInjecti
     return AccessResult::allowedIf($account->hasPermission('see other bookmarks'));
   }
 
+  /**
+   * Redirect the current user to the its bookmarks page.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirection response.
+   */
+  public function currentUserBookmarksPage() {
+    return $this->redirect('reliefweb_bookmarks.user', [
+      'user' => $this->currentUser()->id(),
+    ], [], 301);
+  }
+
 }

--- a/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.routing.yml
+++ b/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.routing.yml
@@ -11,6 +11,12 @@ reliefweb_subscriptions.subscription_form:
     _user_is_logged_in: 'TRUE'
     _custom_access: '\Drupal\reliefweb_subscriptions\Controller\UnsubscribeController::checkUserAccess'
     user: \d+
+reliefweb_subscriptions.subscription_form.current_user:
+  path: '/user/notifications'
+  defaults:
+    _controller: '\Drupal\reliefweb_subscriptions\Controller\SubscriptionController::currentUserSubscriptionsPage'
+  requirements:
+    _user_is_logged_in: 'TRUE'
 reliefweb_subscriptions.unsubscribe:
   path: '/notifications/unsubscribe/user/{user}'
   defaults:

--- a/html/modules/custom/reliefweb_subscriptions/src/Controller/SubscriptionController.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/Controller/SubscriptionController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\reliefweb_subscriptions\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Handle subscription routes.
+ */
+class SubscriptionController extends ControllerBase {
+
+  /**
+   * Redirect the current user to the its subscriptions page.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirection response.
+   */
+  public function currentUserSubscriptionsPage() {
+    return $this->redirect('reliefweb_subscriptions.subscription_form', [
+      'user' => $this->currentUser()->id(),
+    ], [], 301);
+  }
+
+}

--- a/html/modules/custom/reliefweb_user_posts/reliefweb_user_posts.routing.yml
+++ b/html/modules/custom/reliefweb_user_posts/reliefweb_user_posts.routing.yml
@@ -15,7 +15,12 @@ reliefweb_user_posts.content:
     _user_is_logged_in: 'TRUE'
     _custom_access: '\Drupal\reliefweb_user_posts\Controller\UserPostsPage::checkUserPostsPageAccess'
     user: \d+
-
+reliefweb_user_posts.content.current_user:
+  path: '/user/posts'
+  defaults:
+    _controller: '\Drupal\reliefweb_user_posts\Controller\UserPostsPage::currentUserPostsPage'
+  requirements:
+    _user_is_logged_in: 'TRUE'
 reliefweb_user_posts.autocomplete:
   path: '/user/{user}/posts/autocomplete/{filter}'
   defaults:

--- a/html/modules/custom/reliefweb_user_posts/src/Controller/UserPostsPage.php
+++ b/html/modules/custom/reliefweb_user_posts/src/Controller/UserPostsPage.php
@@ -165,4 +165,16 @@ class UserPostsPage extends ModerationPage {
     return AccessResult::allowedIf($account->hasPermission('view other user posts'));
   }
 
+  /**
+   * Redirect the current user to the its posts page.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirection response.
+   */
+  public function currentUserPostsPage() {
+    return $this->redirect('reliefweb_user_posts.content', [
+      'user' => $this->currentUser()->id(),
+    ], [], 301);
+  }
+
 }


### PR DESCRIPTION
Refs: RW-725

This adds `/user/*` routes and associated controllers/methods for the bookmarks, posts and subscriptions user pages for the current user so we can add menu items under the new "my account" dropdown added in CD 7.4.

### Tests

1. Checkout this branch and clear the cache (`drush cr`)
2. Log in with a user.
3. Confirm that the `/user/bookmarks`, `/user/notifications` and `/user/posts` redirect to the corresponding `/user/{uid}/*` pages.