### PR TITLE
[RW-726] Upgrade to CD 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "reliefweb/simple-datepicker": "^v1.3",
         "symfony/flex": "^2.0",
         "symfony/uid": "^6.0",
-        "unocha/common_design": "^7.0.0",
+        "unocha/common_design": "^7.4",
         "webflo/drupal-finder": "^1.2.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6513373623cb704e10807005a835013e",
+    "content-hash": "708f8745d78cfcfcff7519b69f55f29c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -13751,16 +13751,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v7.2.0",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "3b3d0069d6132870b0dcb166ea2839b8ce5c7560"
+                "reference": "c349f709576eda763ddce2f7578457dd8508b8cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/3b3d0069d6132870b0dcb166ea2839b8ce5c7560",
-                "reference": "3b3d0069d6132870b0dcb166ea2839b8ce5c7560",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/c349f709576eda763ddce2f7578457dd8508b8cb",
+                "reference": "c349f709576eda763ddce2f7578457dd8508b8cb",
                 "shasum": ""
             },
             "require": {
@@ -13774,9 +13774,9 @@
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v7.2.0"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v7.4.0"
             },
-            "time": "2022-07-04T09:49:44+00:00"
+            "time": "2022-12-21T10:16:39+00:00"
         },
         {
             "name": "webflo/drupal-finder",

--- a/composer.lock
+++ b/composer.lock
@@ -13751,16 +13751,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v7.4.0",
+            "version": "v7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "c349f709576eda763ddce2f7578457dd8508b8cb"
+                "reference": "b803f6b303bfcc2a46b5d2d531189832679d820a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/c349f709576eda763ddce2f7578457dd8508b8cb",
-                "reference": "c349f709576eda763ddce2f7578457dd8508b8cb",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/b803f6b303bfcc2a46b5d2d531189832679d820a",
+                "reference": "b803f6b303bfcc2a46b5d2d531189832679d820a",
                 "shasum": ""
             },
             "require": {
@@ -13774,9 +13774,9 @@
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
                 "issues": "https://github.com/UN-OCHA/common_design/issues",
-                "source": "https://github.com/UN-OCHA/common_design/tree/v7.4.0"
+                "source": "https://github.com/UN-OCHA/common_design/tree/v7.4.1"
             },
-            "time": "2022-12-21T10:16:39+00:00"
+            "time": "2023-01-10T14:13:58+00:00"
         },
         {
             "name": "webflo/drupal-finder",

--- a/html/themes/custom/common_design_subtheme/components/rw-admin-menu/admin-menu.js
+++ b/html/themes/custom/common_design_subtheme/components/rw-admin-menu/admin-menu.js
@@ -16,7 +16,7 @@
       if (section && sibling) {
         // Ensure the element is hidden before moving it to avoid flickering.
         this.toggleVisibility(section, true);
-        sibling.parentNode.insertBefore(section, sibling.nextSibling);
+        sibling.parentNode.insertBefore(section, sibling);
       }
     },
 

--- a/html/themes/custom/common_design_subtheme/components/rw-admin-menu/rw-admin-menu.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-admin-menu/rw-admin-menu.css
@@ -21,6 +21,9 @@
   background: transparent;
   font-size: var(--cd-font-size--tiny);
 }
+.admin-menu__btn:hover {
+  text-decoration: underline;
+}
 
 @media screen and (max-width: 767px) {
   .admin-menu__btn span {
@@ -35,15 +38,19 @@
   }
 }
 
-.admin-menu__btn::after {
+.admin-menu__btn::after,
+/* Guidelines / Help separator. Not the best place to add but this avoids adding
+ * a duplicate rule somewhere else and the guidelines and admin menu are both
+ * only displayed to Editors. */
+.admin-menu + * .navigation > .menu > .menu-item:not(:last-child) > a::after {
   position: absolute;
   top: 50%;
   right: -1px;
-  width: 2px;
+  width: 1.5px;
   height: calc(35px / 3);
   content: "";
   transform: translateY(-50%);
-  background: var(--brand-grey);
+  background: var(--cd-white);
 }
 
 .admin-menu-dropdown__inner {
@@ -108,15 +115,15 @@
  */
 
 .js .admin-menu {
-  float: right;
+  /* Compensate for the `gap` property on the `.cd-global-header__inner` so
+   * that the menu is evenly spaced with the other menus in the header. */
+  margin-right: -8px;
+  margin-left: auto;
   padding: 0;
 }
 
 /* Print. */
 @media print {
-  .admin-menu-button {
-    display: none !important;
-  }
   .admin-menu {
     display: none !important;
   }


### PR DESCRIPTION
Refs: RW-726

This upgrades to the CD 7.4 and adjusts some css/js for the admin menu.

After upgrading,  and logged in as an Editor, the site's top header will look like (A):

<img width="1212" alt="Screen Shot 2022-12-27 at 14 19 41" src="https://user-images.githubusercontent.com/696348/209615238-deb3af71-db5a-4499-a174-ad56139d1e19.png">

Or, if https://github.com/UN-OCHA/common_design/pull/362 was merged, like (B):

<img width="1190" alt="Screen Shot 2022-12-27 at 14 26 11" src="https://user-images.githubusercontent.com/696348/209615742-e9798686-e699-4d66-8e75-b65494410f0a.png">

As a normal user, it will look like that (C):

<img width="1168" alt="Screen Shot 2022-12-27 at 14 31 55" src="https://user-images.githubusercontent.com/696348/209616176-3ca05e4b-904a-424d-b830-aa833e68d941.png">

Or, if https://github.com/UN-OCHA/common_design/pull/362 was merged, like (D):

<img width="1191" alt="Screen Shot 2022-12-27 at 14 33 09" src="https://user-images.githubusercontent.com/696348/209616286-c9c7f2a7-0ac0-458c-92cf-998e768a4071.png">

**Note:** (B) and (D) are also the expected result **after modifying the menu structure** as per CD 7.4's release notes with or without https://github.com/UN-OCHA/common_design/pull/362. 

**Extra**

If https://github.com/UN-OCHA/rwint9-site/pull/533 was merged and after adding the `user/*` sub menu items, like (E):

<img width="1193" alt="Screen Shot 2022-12-27 at 14 39 40" src="https://user-images.githubusercontent.com/696348/209616860-c30e3164-b1ad-4825-b18c-2d6af657283f.png">

Or as an Editor (F):

<img width="1172" alt="Screen Shot 2022-12-27 at 14 20 19" src="https://user-images.githubusercontent.com/696348/209615306-ff83a776-3031-4432-80c9-940101b5f8d8.png">

### Tests.

1. Run `composer install` to upgrade to the CD 7.4
2. Run `drush cr` to clear the cache
3. Log in as an editor and check that the top header looks like (A)
4. Log in as a normal user and check that the top header looks like (C)
5. Apply the instructions from the CD 7.4 to change the menu structure
6. Log in as an editor and check that the top header looks like (B)
7. Log in as a normal user and check that the top header looks like (D)

