### PR TITLE
[RW-721] Show 404 instead of 403 for inaccessible entities

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -14,7 +14,6 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\Element;
-use Drupal\Core\Url;
 use Drupal\media\MediaInterface;
 use Drupal\reliefweb_entities\BundleEntityInterface;
 use Drupal\reliefweb_entities\BundleEntityStorageInterface;
@@ -748,54 +747,34 @@ function reliefweb_entities_menu_local_tasks_alter(&$data, $route_name, Refinabl
 }
 
 /**
- * Implements hook_preprocess_page__403().
+ * Implements hook_preprocess_page__404().
  *
- * Add a user friendly message on inaccessible node pages to indicate it's
+ * Add a user friendly message on inaccessible entity pages to indicate it's
  * no longer available (we assume the URL was previously accessible, which is
  * probably true in most cases).
  */
-function reliefweb_entities_preprocess_page__403(array &$variables) {
-  // The router may return a ResourceNotFoundException or
-  // MethodNotAllowedException so we skip the preprocessing in that case.
-  try {
-    $route_info = \Drupal::service('router.no_access_checks')
-      ->matchRequest(\Drupal::request());
+function reliefweb_entities_preprocess_page__404(array &$variables) {
+  // Get the entity from the original request.
+  $entity = EntityHelper::getEntityFromRequest(\Drupal::requestStack()->getMasterRequest());
+  if (isset($entity) && $entity instanceof BundleEntityInterface) {
+    $type = mb_strtolower(EntityHelper::getBundleLabelFromEntity($entity));
+    $title = $entity->label();
 
-    if (isset($route_info['node']) && $route_info['node'] instanceof BundleEntityInterface) {
-      $type = mb_strtolower(EntityHelper::getBundleLabelFromEntity($route_info['node']));
-      $title = $route_info['node']->label();
-      $anonymous = \Drupal::currentUser()->isAnonymous();
+    $message = t('The @type %title is no longer available.', [
+      '@type' => $type,
+      '%title' => $title,
+    ]);
 
-      if ($anonymous && in_array($type, ['job', 'training'])) {
-        $message = t('The @type %title is no longer available.<br>If you posted this @type, please <a href="@url">log in</a> to get access.', [
-          '@type' => $type,
-          '%title' => $title,
-          '@url' => Url::fromUserInput('/user/login', [
-            'query' => \Drupal::destination()->getAsArray(),
-          ])->toString(),
-        ]);
-      }
-      else {
-        $message = t('The @type %title is no longer available.', [
-          '@type' => $type,
-          '%title' => $title,
-        ]);
-      }
-
-      $variables['page']['content']['message'] = [
-        '#type' => 'markup',
-        '#markup' => $message,
-      ];
-    }
-  }
-  catch (\Exception $exception) {
-    // Nothing to do.
+    $variables['page']['content']['message'] = [
+      '#type' => 'markup',
+      '#markup' => $message,
+    ];
   }
 
-  // We need to vary the cache whether or not we are on a node page
-  // otherwise visiting a non node inaccessible page will cache the result
+  // We need to vary the cache whether or not we are on an entity page
+  // otherwise visiting a non entity inaccessible page will cache the result
   // and this preprocess hook implementation will not be called when visiting
-  // an inaccessible node page afterwards.
+  // an inaccessible entity page afterwards.
   $variables['#cache']['contexts'][] = 'url.path';
 }
 

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.services.yml
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.services.yml
@@ -8,6 +8,10 @@ services:
     arguments: ['@current_user']
     tags:
       - { name: access_check, applies_to: _reliefweb_entities_entity_access_check }
+  reliefweb_entities.access_denied_to_not_found:
+    class: Drupal\reliefweb_entities\EventSubscriber\AccessDeniedToNotFound
+    tags:
+      - { name: event_subscriber }
   # Form alteration services.
   reliefweb_entities.announcement.form_alter:
     class: Drupal\reliefweb_entities\Services\AnnouncementFormAlter

--- a/html/modules/custom/reliefweb_entities/src/EventSubscriber/AccessDeniedToNotFound.php
+++ b/html/modules/custom/reliefweb_entities/src/EventSubscriber/AccessDeniedToNotFound.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\reliefweb_entities\EventSubscriber;
+
+use Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase;
+use Drupal\reliefweb_entities\BundleEntityInterface;
+use Drupal\reliefweb_utility\Helpers\EntityHelper;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Redirects 403 page error responses to 404 page for bundle entities.
+ */
+class AccessDeniedToNotFound extends HttpExceptionSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static function getPriority() {
+    return 1000;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getHandledFormats() {
+    return ['html'];
+  }
+
+  /**
+   * Handles all 4xx errors for all serialization failures.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   *   The event to process.
+   */
+  public function on403(ExceptionEvent $event) {
+    $entity = EntityHelper::getEntityFromRequest($event->getRequest());
+    if (isset($entity) && $entity instanceof BundleEntityInterface) {
+      $event->setThrowable(new NotFoundHttpException());
+    }
+  }
+
+}

--- a/html/modules/custom/reliefweb_utility/src/Helpers/EntityHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/EntityHelper.php
@@ -4,6 +4,9 @@ namespace Drupal\reliefweb_utility\Helpers;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Helper to information about entities.
@@ -11,16 +14,21 @@ use Drupal\Core\Render\Markup;
 class EntityHelper {
 
   /**
-   * Attempt to get the entity for the current route.
+   * Attempt to get the entity for the given route or the current one.
    *
    * Note: this only works for routes using the "standard" way to declare
    * entity parameters: `entity:entity_type_id`.
    *
+   * @param \Drupal\Core\Routing\RouteMatchInterface|null $route_match
+   *   Optional route match.
+   *
    * @return \Drupal\Core\Entity\EntityInterface|null
    *   The entity for the route or NULL if none.
    */
-  public static function getEntityFromRoute() {
-    $route_match = \Drupal::routeMatch();
+  public static function getEntityFromRoute(?RouteMatchInterface $route_match = NULL) {
+    if (!isset($route_match)) {
+      $route_match = \Drupal::routeMatch();
+    }
 
     $route = $route_match->getRouteObject();
     if (empty($route)) {
@@ -43,6 +51,25 @@ class EntityHelper {
         }
       }
     }
+
+    return NULL;
+  }
+
+  /**
+   * Attempt to get the entity for a request.
+   *
+   * Note: this only works for routes using the "standard" way to declare
+   * entity parameters: `entity:entity_type_id`.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   Request.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The entity for the route or NULL if none.
+   */
+  public static function getEntityFromRequest(Request $request) {
+    $route_match = RouteMatch::createFromRequest($request);
+    return static::getEntityFromRoute($route_match);
   }
 
   /**

--- a/html/modules/custom/reliefweb_utility/tests/src/ExistingSite/EntityHelperTest.php
+++ b/html/modules/custom/reliefweb_utility/tests/src/ExistingSite/EntityHelperTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\Tests\reliefweb_utility\ExistingSite;
+
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\Core\Routing\RouteObjectInterface;
+use Drupal\reliefweb_utility\Helpers\EntityHelper;
+use Drupal\node\Entity\Node;
+use Symfony\Component\HttpFoundation\Request;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Tests entity helper.
+ *
+ * @covers \Drupal\reliefweb_utility\Helpers\EntityHelper
+ * @coversDefaultClass \Drupal\reliefweb_utility\Helpers\EntityHelper
+ */
+class EntityHelperTest extends ExistingSiteBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $nodes = [
+      [
+        'type' => 'blog_post',
+        'nid' => 9999901,
+        'status' => 1,
+        'moderation_status' => 'published',
+        'title' => 'test blog post 1',
+        'author' => 'test',
+        'body' => 'test body',
+      ],
+      [
+        'type' => 'blog_post',
+        'nid' => 9999902,
+        'status' => 1,
+        'moderation_status' => 'published',
+        'title' => 'test blog post 2',
+        'author' => 'test',
+        'body' => 'test body',
+      ],
+    ];
+
+    foreach ($nodes as $data) {
+      if (!Node::load($data['nid'])) {
+        $this->createNode($data);
+      }
+    }
+
+  }
+
+  /**
+   * @covers ::getEntityFromRequest
+   */
+  public function testGetEntityFromRequest() {
+    $request = $this->createRequestFromRoute('entity.node.canonical', [
+      'node' => Node::load(9999901),
+    ]);
+    $entity = EntityHelper::getEntityFromRequest($request);
+    $this->assertEquals($entity?->id(), 9999901);
+  }
+
+  /**
+   * @covers ::getEntityFromRoute
+   */
+  public function testGetEntityFromRoute() {
+    $request = $this->createRequestFromRoute('entity.node.canonical', [
+      'node' => Node::load(9999901),
+    ]);
+
+    $request_stack = \Drupal::requestStack();
+    while ($request_stack->pop() !== NULL) {
+      // Nothing to do.
+    }
+    $request_stack->push($request);
+
+    $entity = EntityHelper::getEntityFromRoute();
+    $this->assertEquals($entity?->id(), 9999901);
+
+    $request = $this->createRequestFromRoute('entity.node.canonical', [
+      'node' => Node::load(9999902),
+    ]);
+    $route_match = RouteMatch::createFromRequest($request);
+
+    $entity = EntityHelper::getEntityFromRoute($route_match);
+    $this->assertEquals($entity?->id(), 9999902);
+  }
+
+  /**
+   * Generate a request for the given route name and parameters.
+   *
+   * @param string $route_name
+   *   Route name.
+   * @param array $route_parameters
+   *   Route parameters.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   Request.
+   */
+  private function createRequestFromRoute($route_name, array $route_parameters = []) {
+    $route = \Drupal::service('router.route_provider')->getRouteByName($route_name);
+    $request = new Request();
+    $request->attributes->set(RouteObjectInterface::ROUTE_NAME, $route_name);
+    $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, $route);
+    foreach ($route_parameters as $name => $value) {
+      $request->attributes->set($name, $value);
+    }
+    return $request;
+  }
+
+}

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--404.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--404.html.twig
@@ -19,6 +19,9 @@
             <header>
               <h1 class="rw-page-title">{{ '404 - Page not found'|t }}</h1>
             </header>
+            {% if page.content.message is not empty %}
+            <p><strong>{{ page.content.message }}</strong></p>
+            {% endif %}
             <p>{{ 'Sorry for any inconvenience.'|t }}</p>
             <p>{{ 'Here are some useful pages to help you get back on track:'|t }}</p>
             <div class="rw-entity-useful-links">


### PR DESCRIPTION
Refs: RW-721

This returns a 404 instead of 403 for inaccessible bundle entities (jobs, countries etc.).

### Tests

1. Log in as an editor, look for an unpublished job, copy the URL
2. Log out or open another browser or private window
3. Go to the job URL on the production site and check that it's a 403
4. Go to the job URL on the local site and check that it's a 404 with "The job TITLE OF THE JOB is no longer available" message