### PR TITLE
[OPS-8834] Refuse to pass weird index.php<something> URLs to Drupal.

### DIFF
--- a/docker/etc/nginx/apps/drupal/drupal.conf
+++ b/docker/etc/nginx/apps/drupal/drupal.conf
@@ -386,6 +386,11 @@ location ~* ^.+\.php$ {
     return 404;
 }
 
+## Avoid a Drupal error when requesting index.phpfoobar.
+location ~ "^/index\.php.+" {
+    return 404;
+}
+
 if ( $args ~* "/autocomplete/" ) {
   return 406;
   ### error_page 406 = @drupal; ### error_page directive is not allowed within pseudo-location


### PR DESCRIPTION
Refs: OPS-8834

This adds the rule from https://github.com/UN-OCHA/docker-images/pull/320 to the `drupal.conf` to refuse to pass weird index.php<something> URLs to Drupal.

This is sadly needed because RW uses a custom `drupal.conf` file for the xmlsitemap handling.

### Tests

*Before checking out this branch*

1. Go to `https://LOCAL.test/index.phppouet` (change LOCAL with your local site domain obviously)
2. Check that you get an error

*After checking out this branch*

1. Rebuild the site image (`make`) and container to take into account the change
2. Go to `https://LOCAL.test/index.phppouet`
3. Check that you get a 404 from nginx
