### PR TITLE
[RW-733] Enable 'other' language in training language filter

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/Services/TrainingRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/TrainingRiver.php
@@ -162,10 +162,7 @@ class TrainingRiver extends RiverServiceBase {
         'name' => $this->t('Training language'),
         'type' => 'reference',
         'vocabulary' => 'language',
-        'exclude' => [
-          // Other.
-          31996,
-        ],
+        'exclude' => [],
         'field' => 'training_language.id',
         'widget' => [
           'type' => 'options',


### PR DESCRIPTION
Refs: RW-733

This simply removes the exclusion of the "other" language for the training language field in the training river.