### PR TITLE
[RW-736] Add training language backend filter and restrict autocomplete suggestions

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -23,6 +23,7 @@ use Drupal\reliefweb_utility\Helpers\DateHelper;
 use Drupal\reliefweb_utility\Helpers\EntityHelper;
 use Drupal\reliefweb_utility\Helpers\MailHelper;
 use Drupal\reliefweb_utility\Helpers\MediaHelper;
+use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\taxonomy\TermInterface;
@@ -654,7 +655,7 @@ function reliefweb_entities_mail($key, array &$message, array $parameters) {
     $message['params']['plain'] = TRUE;
     // Use the submit mailbox as sender and add it also as CC to track the
     // notifications.
-    $submit = \Drupal::state()->get('reliefweb_submit_email');
+    $submit = ReliefWebStateHelper::getSubmitEmail();
     if (!empty($submit)) {
       $message['headers']['From'] = $submit;
       $message['headers']['CC'] = $submit;

--- a/html/modules/custom/reliefweb_entities/src/Entity/Job.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Job.php
@@ -15,6 +15,7 @@ use Drupal\reliefweb_moderation\EntityModeratedTrait;
 use Drupal\reliefweb_revisions\EntityRevisionedInterface;
 use Drupal\reliefweb_revisions\EntityRevisionedTrait;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
+use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
 
 /**
  * Bundle class for job nodes.
@@ -163,10 +164,7 @@ class Job extends Node implements BundleEntityInterface, EntityModeratedInterfac
    *   List of theme term ids.
    */
   public static function getJobIrrelevantCountries() {
-    // Irrelevant countries (Trello #DI9bxljg):
-    // - World (254).
-    $default = [254];
-    return \Drupal::state()->get('reliefweb_job_irrelevant_countries', $default);
+    return ReliefWebStateHelper::getJobIrrelevantCountries();
   }
 
   /**
@@ -176,12 +174,7 @@ class Job extends Node implements BundleEntityInterface, EntityModeratedInterfac
    *   List of theme term ids.
    */
   public static function getJobIrrelevantThemes() {
-    // Irrelevant themes (Trello #RfWgIdwA):
-    // - Contributions (4589) (Collab #2327).
-    // - Humanitarian Financing (4597) (Trello #OnXq5cCC).
-    // - Logistics and Telecommunications (4598) (Trello #G3YgNUF6).
-    $default = [4589, 4597, 4598];
-    return \Drupal::state()->get('reliefweb_job_irrelevant_themes', $default);
+    return ReliefWebStateHelper::getJobIrrelevantThemes();
   }
 
   /**
@@ -191,13 +184,7 @@ class Job extends Node implements BundleEntityInterface, EntityModeratedInterfac
    *   List of theme term ids.
    */
   public static function getJobThemelessCategories() {
-    // Disable the themes for some career categories (Trello #RfWgIdwA):
-    // - Human Resources (6863).
-    // - Administration/Finance (6864).
-    // - Information and Communications Technology (6866).
-    // - Donor Relations/Grants Management (20966).
-    $default = [6863, 6864, 6866, 20966];
-    return \Drupal::state()->get('reliefweb_job_themeless_categories', $default);
+    return ReliefWebStateHelper::getJobThemelessCategories();
   }
 
 }

--- a/html/modules/custom/reliefweb_entities/src/Entity/Report.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Report.php
@@ -16,6 +16,7 @@ use Drupal\reliefweb_moderation\EntityModeratedTrait;
 use Drupal\reliefweb_revisions\EntityRevisionedInterface;
 use Drupal\reliefweb_revisions\EntityRevisionedTrait;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
+use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
 use Drupal\reliefweb_utility\Helpers\UrlHelper;
 
 /**
@@ -314,7 +315,7 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
 
     // Recipients and sender.
     $to = implode(', ', $emails);
-    $from = \Drupal::state()->get('reliefweb_submit_email');
+    $from = ReliefWebStateHelper::getSubmitEmail();
     if (empty($from)) {
       return;
     }

--- a/html/modules/custom/reliefweb_entities/src/Entity/Training.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Training.php
@@ -16,6 +16,7 @@ use Drupal\reliefweb_revisions\EntityRevisionedInterface;
 use Drupal\reliefweb_revisions\EntityRevisionedTrait;
 use Drupal\reliefweb_rivers\RiverServiceBase;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
+use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
 use Drupal\reliefweb_utility\Helpers\UrlHelper;
 
 /**
@@ -156,12 +157,7 @@ class Training extends Node implements BundleEntityInterface, EntityModeratedInt
    *   List of term ids.
    */
   public static function getTrainingIrrelevantThemes() {
-    // Irrelevant themes (Trello #RfWgIdwA):
-    // - Contributions (4589) (Collab #2327).
-    // - Logistics and Telecommunications (4598) (Trello #G3YgNUF6).
-    // - Camp Coordination and Camp Management (49458).
-    $default = [4589, 4598, 49458];
-    return \Drupal::state()->get('reliefweb_training_irrelevant_themes', $default);
+    return ReliefWebStateHelper::getTrainingIrrelevantThemes();
   }
 
   /**
@@ -171,11 +167,7 @@ class Training extends Node implements BundleEntityInterface, EntityModeratedInt
    *   List of term ids.
    */
   public static function getTrainingIrrelevantLanguages() {
-    // Irrelevant languages (Collab #4452001), due to limited capacity.
-    // - Russian (10906) and Arabic (6876).
-    // - Other (31996).
-    $default = [6876, 10906, 31996];
-    return \Drupal::state()->get('reliefweb_training_irrelevant_languages', $default);
+    return ReliefWebStateHelper::getTrainingIrrelevantLanguages();
   }
 
   /**
@@ -185,10 +177,7 @@ class Training extends Node implements BundleEntityInterface, EntityModeratedInt
    *   List of term ids.
    */
   public static function getTrainingIrrelevantTrainingLanguages() {
-    // Irrelevant languages (Collab #4452001), due to limited capacity.
-    // - Other (31996).
-    $default = [31996];
-    return \Drupal::state()->get('reliefweb_training_irrelevant_training_languages', $default);
+    return ReliefWebStateHelper::getTrainingIrrelevantTrainingLanguages();
   }
 
 }

--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -2086,6 +2086,11 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
     $conditions = $this->buildFilterConditions($conditions, $fields);
     $query->where($conditions, $replacements);
 
+    // Exclude some terms.
+    if (!empty($filter_definition['exclude'])) {
+      $query->condition($alias . '.' . $id_field, $filter_definition['exclude'], 'NOT IN');
+    }
+
     // Sort by name.
     $query->orderBy($alias . '.' . $label_field, 'ASC');
 

--- a/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/JobModeration.php
@@ -7,6 +7,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
+use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
 use Drupal\reliefweb_utility\Helpers\UserHelper;
 
 /**
@@ -272,6 +273,8 @@ class JobModeration extends ModerationServiceBase {
       'body',
       'how_to_apply',
     ]);
+    $definitions['country']['exclude'] = ReliefWebStateHelper::getJobIrrelevantCountries();
+    $definitions['theme']['exclude'] = ReliefWebStateHelper::getJobIrrelevantThemes();
     return $definitions;
   }
 

--- a/html/modules/custom/reliefweb_moderation/src/Services/TrainingModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/TrainingModeration.php
@@ -7,6 +7,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
 use Drupal\reliefweb_moderation\ModerationServiceBase;
+use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
 use Drupal\reliefweb_utility\Helpers\UserHelper;
 
 /**
@@ -302,6 +303,15 @@ class TrainingModeration extends ModerationServiceBase {
     $definitions['career_categories']['label'] = $this->t('Professional function');
     $definitions['training_type']['label'] = $this->t('Category');
     $definitions['training_format']['label'] = $this->t('Format');
+    $definitions['theme']['exclude'] = ReliefWebStateHelper::getTrainingIrrelevantThemes();
+    $definitions['language']['label'] = $this->t('Advertisment language');
+    $definitions['language']['exclude'] = ReliefWebStateHelper::getTrainingIrrelevantLanguages();
+    $definitions['training_language'] = [
+      'field' => 'field_training_language',
+      'label' => $this->t('Course/Event language'),
+      'shortcut' => 'tl',
+      'exclude' => ReliefWebStateHelper::getTrainingIrrelevantTrainingLanguages(),
+    ] + $definitions['language'];
     return $definitions;
   }
 

--- a/html/modules/custom/reliefweb_utility/src/Helpers/ReliefWebStateHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/ReliefWebStateHelper.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\reliefweb_utility\Helpers;
+
+/**
+ * Helper to get state values specific to ReliefWeb.
+ */
+class ReliefWebStateHelper {
+
+  /**
+   * Get the ReliefWeb submit email address.
+   *
+   * @return string
+   *   The submit email address.
+   */
+  public static function getSubmitEmail() {
+    return \Drupal::state()->get('reliefweb_submit_email');
+  }
+
+  /**
+   * Get the list of countries that are irrelevant for jobs.
+   *
+   * @return array
+   *   List of theme term ids.
+   */
+  public static function getJobIrrelevantCountries() {
+    // Irrelevant countries (Trello #DI9bxljg):
+    // - World (254).
+    $default = [254];
+    return \Drupal::state()->get('reliefweb_job_irrelevant_countries', $default);
+  }
+
+  /**
+   * Get the list of themes that are irrelevant for jobs.
+   *
+   * @return array
+   *   List of theme term ids.
+   */
+  public static function getJobIrrelevantThemes() {
+    // Irrelevant themes (Trello #RfWgIdwA):
+    // - Contributions (4589) (Collab #2327).
+    // - Humanitarian Financing (4597) (Trello #OnXq5cCC).
+    // - Logistics and Telecommunications (4598) (Trello #G3YgNUF6).
+    $default = [4589, 4597, 4598];
+    return \Drupal::state()->get('reliefweb_job_irrelevant_themes', $default);
+  }
+
+  /**
+   * Get the list of job categories for which themes are irrelevant.
+   *
+   * @return array
+   *   List of theme term ids.
+   */
+  public static function getJobThemelessCategories() {
+    // Disable the themes for some career categories (Trello #RfWgIdwA):
+    // - Human Resources (6863).
+    // - Administration/Finance (6864).
+    // - Information and Communications Technology (6866).
+    // - Donor Relations/Grants Management (20966).
+    $default = [6863, 6864, 6866, 20966];
+    return \Drupal::state()->get('reliefweb_job_themeless_categories', $default);
+  }
+
+  /**
+   * Get the list of themes that are irrelevant for training ads.
+   *
+   * @return array
+   *   List of term ids.
+   */
+  public static function getTrainingIrrelevantThemes() {
+    // Irrelevant themes (Trello #RfWgIdwA):
+    // - Contributions (4589) (Collab #2327).
+    // - Logistics and Telecommunications (4598) (Trello #G3YgNUF6).
+    // - Camp Coordination and Camp Management (49458).
+    $default = [4589, 4598, 49458];
+    return \Drupal::state()->get('reliefweb_training_irrelevant_themes', $default);
+  }
+
+  /**
+   * Get the list of languages that are irrelevant for training ads.
+   *
+   * @return array
+   *   List of term ids.
+   */
+  public static function getTrainingIrrelevantLanguages() {
+    // Irrelevant languages (Collab #4452001), due to limited capacity.
+    // - Russian (10906) and Arabic (6876).
+    // - Other (31996).
+    $default = [6876, 10906, 31996];
+    return \Drupal::state()->get('reliefweb_training_irrelevant_languages', $default);
+  }
+
+  /**
+   * Get the list of training languages that are irrelevant for training ads.
+   *
+   * @return array
+   *   List of term ids.
+   */
+  public static function getTrainingIrrelevantTrainingLanguages() {
+    // Irrelevant languages (Collab #4452001), due to limited capacity.
+    // - Other (31996).
+    $default = [31996];
+    return \Drupal::state()->get('reliefweb_training_irrelevant_training_languages', $default);
+  }
+
+}


### PR DESCRIPTION
Refs: RW-736

This adds a "Course/Event language" filter to the training moderation backend form, renames "Language" to "Advertisement Language" and limits the languages and themes returned by the autocomplete, to be consistent with the training form.

Excluding irrelevant values from the autocomplete suggestions is also applied to the theme and country filters for jobs to be consistent with the job form.

### Tests.

*Note:  make sure you have a recent enough DB so the `state` has the correct values*

1. Check out this branch
2. Clear the cache
3. Open `/moderation/content/training`
4. Check that the "Advertisement Language" and "Course/Event Language" filters are present in the dropdown
5. Select "Advertisement Language", type "Other", there should be no suggestion, type "Spanish", it should appear
6. Select "Course/Event Language", type "Other", it should appear, type "Spanish", it should also appear