### PR TITLE
chore: store the configuration for the user menu account

### DIFF
--- a/config/core.menu.static_menu_link_overrides.yml
+++ b/config/core.menu.static_menu_link_overrides.yml
@@ -1,3 +1,9 @@
 _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM
-definitions: {  }
+definitions:
+  user__page:
+    menu_name: account
+    parent: ''
+    weight: -10
+    expanded: true
+    enabled: true


### PR DESCRIPTION
Refs: RW-738

This makes sure that the "expanded" property of the user menu is preserved after a deployment so that the "View dashboard", "View my posts" links etc. appear in the user menu dropdown.

## Tests

1. Get a new light DB, restore it etc.
2. Checkout this branch
3. Import the config (drush cim) and clear the cache
4. Confirm that the "View dashboard" and other user links appear in the dropdown user menu (My account)