### PR TITLE
[RW-741] allow unselecting the advanced mode checkbox in rivers

### DIFF
--- a/html/modules/custom/reliefweb_rivers/js/advanced-search.js
+++ b/html/modules/custom/reliefweb_rivers/js/advanced-search.js
@@ -1675,16 +1675,16 @@
 
       // Clear the selection when switching to simplified mode as it's not
       // compatible with the complex queries of the advanced mode.
-      if (!enabled) {
-        if (!advancedSearch.container.hasAttribute('data-empty') && window.confirm(advancedSearch.labels.changeMode)) {
+      if (!enabled && !advancedSearch.container.hasAttribute('data-empty')) {
+        if (window.confirm(advancedSearch.labels.changeMode)) {
           triggerEvent(advancedSearch.clear, 'click');
         }
         else {
           preventDefault(event);
         }
       }
-      // Update the operator selectors when switching to advanced mode.
       else {
+        // Update the operator selectors when switching to advanced mode.
         advancedSearch.container.setAttribute('data-advanced-mode', enabled);
         advancedSearch.advancedMode = enabled;
         createOperatorSwitchers(advancedSearch);


### PR DESCRIPTION
Refs: RW-741

This fixes the logic regarding the advanced search checkbox which was preventing it from being deselected.

### Tests

1. Check out this branch
2. Go to a river page
3. Check the "advanced search" checkbox at the bottom of the filters
4. Uncheck it
5. Add a filter (ex:  country)
6. Check the "advanced search" checkbox
7. Uncheck it -> there should be a popup asking for confirmation. Press cancel and confirm nothing changed and the checkbox is still checked.
8. Repeat (7) but this time press "ok", this should reload the page with the filter gone and "advanced search" should be unchecked