### PR TITLE
[RW-740] Extended text trimming

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
@@ -6,6 +6,7 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\reliefweb_rivers\AdvancedSearch;
 use Drupal\reliefweb_rivers\RiverServiceBase;
 use Drupal\reliefweb_utility\Helpers\LocalizationHelper;
+use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\reliefweb_utility\Helpers\UrlHelper;
 
 /**
@@ -347,7 +348,8 @@ class SourceRiver extends RiverServiceBase {
 
     $letters = [];
     foreach ($terms as $term) {
-      $letter = mb_strtoupper(mb_substr($term['name'], 0, 1));
+      $name = TextHelper::trimText($term['name']);
+      $letter = mb_strtoupper(mb_substr($name, 0, 1));
       $letter = $transliterator->transliterate($letter);
       if (is_numeric($letter)) {
         $letter = '#';

--- a/html/modules/custom/reliefweb_utility/src/Helpers/TextHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/TextHelper.php
@@ -16,7 +16,7 @@ class TextHelper {
    * 2. Replace non breaking spaces with normal spaces.
    * 3. Remove control characters (except line feed).
    * 4. Optionally, replace line breaks and consecutive whitespaces.
-   * 4. Trim the text.
+   * 5. Trim the text.
    *
    * @param string $text
    *   Text to clean.
@@ -42,7 +42,20 @@ class TextHelper {
       $patterns[] = '/\s{2,}/u';
       $replacements[] = ' ';
     }
-    return trim(preg_replace($patterns, $replacements, $text));
+    return static::trimText(preg_replace($patterns, $replacements, $text));
+  }
+
+  /**
+   * Trim a text (extended version, removing Z and C unicode categories).
+   *
+   * @param string $text
+   *   Text to trim.
+   *
+   * @return string
+   *   Trimmed text.
+   */
+  public static function trimText($text) {
+    return preg_replace('/^[\pZ\pC]+|[\pZ\pC]+$/u', '', $text);
   }
 
   /**

--- a/html/modules/custom/reliefweb_utility/tests/src/Unit/TextHelperTest.php
+++ b/html/modules/custom/reliefweb_utility/tests/src/Unit/TextHelperTest.php
@@ -52,6 +52,32 @@ class TextHelperTest extends UnitTestCase {
     $expected = 'trim around';
     $options = [];
     $this->assertEquals(TextHelper::cleanText($text, $options), $expected);
+
+    // This string contains `\u200b` (zero width space) characters at the start,
+    // end and middle. The start and end ones should be removed.
+    $text = '​自然​環境​​';
+    $expected = '自然​環境';
+    $options = [];
+    $this->assertEquals(TextHelper::cleanText($text, $options), $expected);
+  }
+
+  /**
+   * Test trim text.
+   *
+   * @covers \Drupal\reliefweb_utility\Helpers\TextHelper::trimText
+   */
+  public function testTrimText() {
+    $text = '   trim around ';
+    $expected = 'trim around';
+    $options = [];
+    $this->assertEquals(TextHelper::trimText($text, $options), $expected);
+
+    // This string contains `\u200b` (zero width space) characters at the start,
+    // end and middle. The start and end ones should be removed.
+    $text = '​自然​環境​​';
+    $expected = '自然​環境';
+    $options = [];
+    $this->assertEquals(TextHelper::trimText($text, $options), $expected);
   }
 
   /**


### PR DESCRIPTION
Refs: RW-740

This updates the text helper to trim all Z and C unicode categories (notably to remove \u200b (zero width space) and trim the taxonomy term names when building the letter navigation on the /organizations page.

### Tests

**Before checking out this branch**

1. Check if you have the "CorpsAfrica" source (/organization/corpsafrica), if not grab a recent light DB dump
2. Clear the cache
3. Check the `/organizations` page, there should be a blank space in the letter navigation between C and D

<img width="1226" alt="Screen Shot 2023-02-03 at 11 31 44" src="https://user-images.githubusercontent.com/696348/216499385-4504a0c1-3cc2-4211-8f2a-e51ba14bd032.png">

**After checking out this branch**

1. Clear the cache
2. Go to `/organizations`, the blank "letter" should be gone
3. Edit the `/organization/corpsafrica` source, copy the name in your text editor (or something that can show invisible characters like your terminal), it should show that the name starts with `\u200b` (ex: `<200b>CorpsAfrica`).
5. Do not change anything in the form and save it as "active".
6. Repeat (3) but this time, the name should be simply `​CorpsAfrica` without the starting `\u200b`.