### PR TITLE
[RW-746] Use event date for sorting disasters

### DIFF
--- a/html/modules/custom/reliefweb_homepage/src/Controller/Homepage.php
+++ b/html/modules/custom/reliefweb_homepage/src/Controller/Homepage.php
@@ -337,7 +337,6 @@ class Homepage extends ControllerBase {
     $payload['fields']['exclude'][] = 'country';
     $payload['fields']['exclude'][] = 'type';
     $payload['fields']['exclude'][] = 'date';
-    $payload['sort'] = ['date.created:desc'];
     $payload['limit'] = $limit;
 
     return [

--- a/html/modules/custom/reliefweb_rivers/src/Services/DisasterRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/DisasterRiver.php
@@ -116,7 +116,7 @@ class DisasterRiver extends RiverServiceBase {
       'DA' => [
         'name' => $this->t('Date'),
         'type' => 'date',
-        'field' => 'date.created',
+        'field' => 'date.event',
         'widget' => [
           'type' => 'date',
           'label' => $this->t('Select disaster date'),
@@ -163,10 +163,12 @@ class DisasterRiver extends RiverServiceBase {
           'type.code',
           'type.primary',
           'primary_type.code',
-          'date.created',
+          'date.event',
         ],
       ],
-      'sort' => ['date.created:desc'],
+      // To ensure consistent order for disaster with the same event day,
+      // we also sort those by ID to have the most recents first.
+      'sort' => ['date.event:desc', 'id:desc'],
     ];
 
     // Handle the filtered selection (view).
@@ -310,7 +312,7 @@ class DisasterRiver extends RiverServiceBase {
       }
 
       // Dates.
-      $data['date'] = static::createDate($fields['date']['created']);
+      $data['date'] = static::createDate($fields['date']['event']);
 
       // Body and how to apply.
       $data['body'] = $fields['profile']['overview-html'] ?? '';


### PR DESCRIPTION
Refs: RW-746

This uses the `event` date to sort disasters to match the changes in the API from RW-594.

The disasters are now sorted by event date first and then ID (to have most recently created one first) for those with the same event date.

### Tests

1. Update the most recent disaster (latest ID), set the event date to yesterday and save
2. Update the second most disaster (second lastest ID), set the event date to today and save
3. Confirm that the homepage and /disasters page have the same order with (2) first and (1) second
4. Update (1), set the event date to today and save
5. Confirm that the homepage and /disasters page have the same order with (1) first and (2) second