### PR TITLE
[RW-745] nly publish embargoed documents if they have the embargoed status

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -681,6 +681,7 @@ function reliefweb_entities_cron() {
   $embargoed_ids = $storage
     ->getQuery()
     ->condition('type', 'report', '=')
+    ->condition('moderation_status', 'embargoed', '=')
     ->condition('field_embargo_date.value', gmdate("Y-m-d\TH:i:s"), '<')
     ->range(0, $cron_settings['embargoed_reports_limit'] ?? 20)
     ->execute();


### PR DESCRIPTION
Refs: RW-745

The cron code that published embargoed documents is missing a crucial condition to only publish reports with the `embargoed` status.

### Tests

Note: the embargo date is in UTC so add/substract your timezone's offset.

**Before checking out this branch**

1. Create or edit a report, set the embargo date to one/two minutes after your current time (+/- your timezone offset), save as `draft`
2. Wait until the time is passed and run `drush cron`
3. Check the draft document was published with the "Embargoed document automatically published..." message

**After checking out this branch**

1. Repeat the above but this time the `draft` report should not be published and stay as `draft`
2. Repeat the above but save as `on-hold` for example, this time the document should be published after running cron