### PR TITLE
[RW-747] pecify revision creation time when manually creating revisions

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -694,6 +694,7 @@ function reliefweb_entities_cron() {
       $report->field_embargo_date->setValue([]);
       $report->setNewRevision(TRUE);
       $report->setRevisionUserId(2);
+      $report->setRevisionCreationTime(time());
       $report->setRevisionLogMessage(strtr('Embargoed document automatically published on @date.', [
         '@date' => DateHelper::format($timestamp, 'custom', 'd M Y H:i e'),
       ]));
@@ -728,6 +729,7 @@ function reliefweb_entities_cron() {
       $node->setModerationStatus('expired');
       $node->setNewRevision(TRUE);
       $node->setRevisionUserId(2);
+      $node->setRevisionCreationTime(time());
       $node->setRevisionLogMessage(strtr('@type automatically expired on @date.', [
         '@type' => ucfirst($node->bundle()),
         '@date' => DateHelper::format($time, 'custom', 'd M Y H:i e'),

--- a/html/modules/custom/reliefweb_entities/src/OpportunityDocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/OpportunityDocumentTrait.php
@@ -194,6 +194,7 @@ trait OpportunityDocumentTrait {
         $source->setNewRevision(TRUE);
         $source->setRevisionLogMessage('Automatic status update due to publication of node ' . $this->id());
         $source->setRevisionUserId(2);
+        $source->setRevisionCreationTime(time());
         $source->save();
       }
     }

--- a/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebLinks.php
+++ b/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebLinks.php
@@ -574,6 +574,7 @@ class ReliefWebLinks extends WidgetBase implements ContainerFactoryPluginInterfa
 
         // Force a new revision.
         $entity->setNewRevision(TRUE);
+        $entity->setRevisionCreationTime(time());
 
         // Save as the System user.
         $entity->setRevisionUserId(2);

--- a/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebUserPostingRights.php
+++ b/html/modules/custom/reliefweb_fields/src/Plugin/Field/FieldWidget/ReliefWebUserPostingRights.php
@@ -486,6 +486,7 @@ class ReliefWebUserPostingRights extends WidgetBase implements ContainerFactoryP
 
         // Force a new revision.
         $entity->setNewRevision(TRUE);
+        $entity->setRevisionCreationTime(time());
 
         // Save as the System user.
         $entity->setRevisionUserId(2);

--- a/html/modules/custom/reliefweb_import/src/Command/ReliefwebImportCommand.php
+++ b/html/modules/custom/reliefweb_import/src/Command/ReliefwebImportCommand.php
@@ -649,6 +649,7 @@ class ReliefwebImportCommand extends DrushCommands implements SiteAliasManagerAw
     // Revision user is always 'System'.
     $job->setRevisionUserId($job->getOwnerId());
     $job->setNewRevision(TRUE);
+    $job->setRevisionCreationTime(time());
 
     // Revision message.
     if ($job->isNew()) {

--- a/html/modules/custom/reliefweb_moderation/src/Commands/ReliefWebModerationCommands.php
+++ b/html/modules/custom/reliefweb_moderation/src/Commands/ReliefWebModerationCommands.php
@@ -134,6 +134,7 @@ class ReliefWebModerationCommands extends DrushCommands {
           $source->setNewRevision(TRUE);
           $source->setRevisionLogMessage('Automatic status update due to inactivity.');
           $source->setRevisionUserId(2);
+          $source->setRevisionCreationTime(time());
           $source->save();
         }
         $count++;

--- a/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
@@ -236,6 +236,7 @@ class SourceModeration extends ModerationServiceBase {
       // Add a message if something changed.
       if ($changed) {
         $entity->setNewRevision(TRUE);
+        $entity->setRevisionCreationTime(time());
         $entity->setRevisionLogMessage(trim(implode(' ', [
           'Posting rights changed to blocked due to source being blocked.',
           $entity->getRevisionLogMessage() ?? '',


### PR DESCRIPTION
Refs: RW-747

This explicitly sets the revision creation time when creating a revision manually. Without that the previous revision timestamp is used.

### Tests

**Before checking out this branch**

1. Edit a job source (allowed content format = job), save it as inactive, there should be revision entry with "inactive"
2. Create a job with that source, publish it
3. Check the source history, there should be a new revision entry with the "active" status, the date for this revision should be the same as the inactive one

**After checking out this branch**

Repeat the above but this time, the latest "active" revision should have a different timestamp than the "inactive" revision before it.