### PR TITLE
[RW-751] Allow original extension in download file name validation pattern

### DIFF
--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
@@ -1280,19 +1280,40 @@ class ReliefWebFile extends FieldItemBase {
   }
 
   /**
-   * Extract the extension of the file.
+   * Extract the basename of the file.
    *
    * @param string $file_name
    *   File name.
    *
    * @return string
-   *   File extension in lower case.
+   *   File base name.
    */
-  public static function extractFileExtension($file_name) {
+  public static function extractFileBasename($file_name) {
     if (empty($file_name)) {
       return '';
     }
-    return mb_strtolower(pathinfo($file_name, PATHINFO_EXTENSION));
+    $position = mb_strrpos($file_name, '.');
+    return $position > 0 ? mb_substr($file_name, 0, $position) : '';
+  }
+
+  /**
+   * Extract the extension of the file.
+   *
+   * @param string $file_name
+   *   File name.
+   * @param bool $normalize
+   *   If TRUE the extension will be returned lower case.
+   *
+   * @return string
+   *   File extension in lower case.
+   */
+  public static function extractFileExtension($file_name, $normalize = TRUE) {
+    if (empty($file_name)) {
+      return '';
+    }
+    $position = mb_strrpos($file_name, '.');
+    $extension = $position > 0 ? mb_substr($file_name, $position + 1) : '';
+    return $normalize ? mb_strtolower($extension) : $extension;
   }
 
   /**
@@ -1338,7 +1359,7 @@ class ReliefWebFile extends FieldItemBase {
       ]);
     }
     elseif ($file_name_length < $minlength) {
-      return t('File name too short. Maximum: @length characters.', [
+      return t('File name too short. Minimum: @length characters.', [
         '@length' => $minlength,
       ]);
     }
@@ -1518,6 +1539,16 @@ class ReliefWebFile extends FieldItemBase {
   public function getUploadedFileName() {
     $file = $this->loadFile();
     return !empty($file) ? $file->getFileName() : '';
+  }
+
+  /**
+   * Get the file basename.
+   *
+   * @return string
+   *   File extension.
+   */
+  public function getFileBasename() {
+    return static::extractFileBasename($this->getFileName());
   }
 
   /**

--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldWidget/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldWidget/ReliefWebFile.php
@@ -328,7 +328,10 @@ class ReliefWebFile extends WidgetBase {
     }
 
     // Add a field to allow changing the file name.
+    $file_name = $item->getFileName();
     $extension = $item->getFileExtension();
+    $original_extension = ReliefWebFileType::extractFileExtension($file_name, FALSE);
+    $extension_pattern = '(' . $extension . '|' . $original_extension . ')';
     $element['_new_file_name'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Download file name'),
@@ -336,7 +339,7 @@ class ReliefWebFile extends WidgetBase {
       '#size' => 60,
       '#not_required' => FALSE,
       '#attributes' => [
-        'pattern' => '^[^' . ReliefWebFileType::getFileNameInvalidCharacters() . ']+\.' . $extension . '$',
+        'pattern' => '^[^' . ReliefWebFileType::getFileNameInvalidCharacters() . ']+\.' . $extension_pattern . '$',
         'placeholder' => 'filename.' . $extension,
         'data-file-new-name' => '',
         'minlength' => strlen($extension) + 2,
@@ -346,7 +349,7 @@ class ReliefWebFile extends WidgetBase {
         '@extension' => $extension,
         '@characters' => ReliefWebFileType::getFileNameInvalidCharacters(TRUE),
       ]),
-      '#default_value' => $item->_new_file_name ?: $item->getFileName(),
+      '#default_value' => $item->_new_file_name ?: $file_name,
       '#attached' => [
         'library' => ['reliefweb_files/file.rename'],
       ],


### PR DESCRIPTION
Refs: RW-751

This fixes an issue with the download file name of report attachments when the extension is not lower case.

### Tests

1. Checkout the branch and clear the cache
2. Edit or create a report and fill in the mandatory fields
3. Upload an attachment with the extension in **upper case** (ex: .PDF)
4. Check that the download file name (under "view file name details") is fine with either `PDF` or `pdf` as extension.
5. Leave it as `PDF` (upper case) and save the report and download the file to confirm it has the `PDF` extension
6. Edit the report again, change the extension to `pdf` (lower case) and save and download and check the extension is `pdf`
7. Edit the report again, this time, check that `PDF` (upper case) is not allowed (expected behavior because the download file name's original extension is now `pdf`).