### PR TITLE
[RW-753] Use proper value for filter for source publications API queries

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/SourceRiver.php
@@ -233,7 +233,7 @@ class SourceRiver extends RiverServiceBase {
       'limit' => 0,
       'filter' => [
         'field' => $field . '.id',
-        'value' => $ids,
+        'value' => array_keys($ids),
       ],
       // We'll extract the number of documents for the sources from the
       // the facets data.


### PR DESCRIPTION
Refs: RW-753

This fixes the filter to get the list of publications for the sources.

<img width="595" alt="Screenshot 2023-03-17 at 11 36 10" src="https://user-images.githubusercontent.com/696348/225798073-084cef02-79f4-42f3-b4a8-c1678b1a06a5.png">

## Tests

1. Checkout this branch and clear the cache
2. Go to /organizations, and check that some organization show something like the screenshot above (may need to use letter filter or pagination to find a source with content when using the slim DB)