### PR TITLE
[RW-754] Better ordering of suggestions in river filters

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
+++ b/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
@@ -1113,6 +1113,7 @@ class AdvancedSearch {
    *   API suggest URL.
    */
   public static function getApiSuggestUrl($resource, array $parameters = []) {
+    $parameters['sort'] = ['score:desc', 'name.collation_en:asc'];
     return \Drupal::service('reliefweb_api.client')
       ->buildApiUrl($resource, $parameters);
   }


### PR DESCRIPTION
Refs: RW-754

Sort suggestions with the same score alphabetically to improve ordering.

## Tests

1. Before checking out this branch, take a screenshot or note the results of using `af` as query for the `organizations` filter on the `/updates` page.
2. After checking out this branch and clearing the cache, search for `af` as well, and confirm that the results look a bit more ordered.

See reference ticket for some example to confirm.