### PR TITLE
[RW-755] Fix access to taxonomy term pages

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/Access/EntityAccessCheck.php
+++ b/html/modules/custom/reliefweb_entities/src/Access/EntityAccessCheck.php
@@ -7,8 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\reliefweb_moderation\EntityModeratedInterface;
-use Drupal\taxonomy\TermInterface;
+use Drupal\reliefweb_entities\Entity\TaxonomyTermBase;
 
 /**
  * Check access to an entity page.
@@ -45,10 +44,9 @@ class EntityAccessCheck implements AccessInterface {
     if ($route_match->getRouteName() === 'entity.taxonomy_term.canonical') {
       $entity = $this->getEntityFromRouteMatch($route_match, 'taxonomy_term');
 
-      if (!empty($entity) && $entity instanceof TermInterface) {
-        if (!($entity instanceof EntityModeratedInterface) && !$this->currentUser->hasPermission('edit terms in ' . $entity->bundle())) {
-          return AccessResult::forbidden();
-        }
+      // Deny access to basic taxonomy terms unless the user can edit them.
+      if (!empty($entity) && $entity instanceof TaxonomyTermBase && !$this->currentUser->hasPermission('edit terms in ' . $entity->bundle())) {
+        return AccessResult::forbidden();
       }
     }
     // Let other modules decide.


### PR DESCRIPTION
Refs: RW-755

This fixes the access to taxonomy term pages (all but countries, disasters and sources) that are supposed to be only accessible to people who can edit them.

## Tests

1. Checkout the branch
2. Try to access term pages (ex: /career-categories/administrationfinance, /country/afg) as an anonymous user --> should get a 404 for all pages except for countries, disasters and sources.
3. Do the same as a normal authenticated user -> same results
4. Do the same as a user with the Editor role -> same results
5. Do the same as a user with the Webmaster role -> should be able to access the term pages