### PR TITLE
chore: add and configure environment indicator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-dev": "^9.3",
         "drupal/core-recommended": "^9.3",
+        "drupal/environment_indicator": "^4.0",
         "drupal/geofield": "^1.39",
         "drupal/google_tag": "^1.4",
         "drupal/guidelines": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8a661243305cd3b8c8b8ff33747f09a",
+    "content-hash": "1387962142ca97291e5113058201b141",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2825,6 +2825,54 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/ctools",
                 "issues": "https://www.drupal.org/project/issues/ctools"
+            }
+        },
+        {
+            "name": "drupal/environment_indicator",
+            "version": "4.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/environment_indicator.git",
+                "reference": "4.0.14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/environment_indicator-4.0.14.zip",
+                "reference": "4.0.14",
+                "shasum": "ff4fe11fcd5fa08b7ba7a451302cf93e5f68449c"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.14",
+                    "datestamp": "1674120945",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "e0ipso",
+                    "homepage": "https://www.drupal.org/user/550110"
+                },
+                {
+                    "name": "mrfelton",
+                    "homepage": "https://www.drupal.org/user/305669"
+                }
+            ],
+            "description": "Adds a color indicator for the different environments.",
+            "homepage": "https://www.drupal.org/project/environment_indicator",
+            "support": {
+                "source": "https://git.drupalcode.org/project/environment_indicator"
             }
         },
         {

--- a/config/config_split.config_split.config_dev.yml
+++ b/config/config_split.config_split.config_dev.yml
@@ -6,14 +6,21 @@ id: config_dev
 label: config_dev
 description: 'Dev modules and settings not suitable for production.'
 weight: 0
+stackable: false
 storage: folder
 folder: ../config_dev
 module:
   config_filter: 0
   dblog: 0
   devel: 0
+  environment_indicator: 0
   stage_file_proxy: 0
   views_ui: 0
 theme: {  }
-complete_list: {  }
+complete_list:
+  - dblog.settings
+  - devel.settings
+  - devel.toolbar.settings
+  - environment_indicator.indicator
+  - stage_file_proxy.settings
 partial_list: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -17,6 +17,7 @@ module:
   datetime_range: 0
   dynamic_page_cache: 0
   editor: 0
+  environment_indicator: 0
   field: 0
   field_ui: 0
   file: 0

--- a/config/environment_indicator.settings.yml
+++ b/config/environment_indicator.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: Bi0EyyiH6m5wpHRfxlKhqTIhAZayhRQudheDzAcrotU
+toolbar_integration:
+  - toolbar
+favicon: true

--- a/config/environment_indicator.switcher.dev.yml
+++ b/config/environment_indicator.switcher.dev.yml
@@ -1,0 +1,11 @@
+uuid: e9ca1728-97c6-4a54-bd56-f0d2c6958331
+langcode: en
+status: true
+dependencies: {  }
+machine: dev
+description: null
+name: Dev
+weight: ''
+url: 'https://dev.reliefweb-int.ahconu.org/'
+fg_color: '#000000'
+bg_color: '#34ccc1'

--- a/config/environment_indicator.switcher.local.yml
+++ b/config/environment_indicator.switcher.local.yml
@@ -1,0 +1,11 @@
+uuid: 358d16b5-802e-43ea-bfd3-9b733e3ae744
+langcode: en
+status: true
+dependencies: {  }
+machine: local
+description: null
+name: Local
+weight: ''
+url: 'https://rwint.test/'
+fg_color: '#ffffff'
+bg_color: '#0d0d0d'

--- a/config/environment_indicator.switcher.prod.yml
+++ b/config/environment_indicator.switcher.prod.yml
@@ -1,0 +1,11 @@
+uuid: a32853f9-840f-4dfa-ab58-26a2aed68c42
+langcode: en
+status: true
+dependencies: {  }
+machine: prod
+description: null
+name: Prod
+weight: ''
+url: 'https://reliefweb.int/'
+fg_color: '#ffffff'
+bg_color: '#6937ac'

--- a/config_dev/environment_indicator.indicator.yml
+++ b/config_dev/environment_indicator.indicator.yml
@@ -1,0 +1,3 @@
+name: Local
+fg_color: '#ffffff'
+bg_color: '#000000'


### PR DESCRIPTION
Refs: OPS-8939

Should be consistent with the changes to all the other repos. No permissions included to see the environment switchers and requires ansible changes to see the indicators on the dev and prod sites.