### PR TITLE
[RW-760] save changes to user posting rights notes when nothing else changes

### DIFF
--- a/html/modules/custom/reliefweb_fields/components/reliefweb-user-posting-rights/reliefweb-user-posting-rights.js
+++ b/html/modules/custom/reliefweb_fields/components/reliefweb-user-posting-rights/reliefweb-user-posting-rights.js
@@ -256,6 +256,9 @@
       // Handle change events on the different select elements in the form.
       container.addEventListener('change', this.handleChange.bind(this));
 
+      // Handle focus out events from notes fields.
+      container.addEventListener('focusout', this.handleFocusOut.bind(this));
+
       // Save the container.
       return container;
     },
@@ -518,6 +521,22 @@
 
           // Set the attribute to the value of the select element.
           parent.setAttribute('data-' + name, target.value);
+          parent.setAttribute('data-modified', '');
+          this.updateData();
+        }
+      }
+    },
+
+    /**
+     * Handle focus out events from notes fields.
+     */
+    handleFocusOut: function (event) {
+      var target = event.target;
+
+      if (target && target.tagName === 'TEXTAREA') {
+        // Update the data if the notes have changed.
+        if (target.value !== target.defaultValue) {
+          var parent = this.getParentElement(target, 'LI');
           parent.setAttribute('data-modified', '');
           this.updateData();
         }


### PR DESCRIPTION
Refs: RW-760

This PR ensures changes to the notes field are saved when nothing else changes.

## Tests

1. Checkout the branch and clear the cache
2. Find a source, click the "User posting rights" tab to edit the posting rights, add an entry with some comment. Save.
3. Edit again the rights, this time only change the notes and click save and confirm that the notes are showing the modifications.