### PR TITLE
[RW-772] Fix date range filter in moderation backend

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -1675,6 +1675,11 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
       return;
     }
 
+    // Handle date range.
+    if (is_array($value)) {
+      $value = $value[0] . ' AND ' . $value[1];
+    }
+
     if (is_array($fields)) {
       if (count($fields) > 1) {
         $condition = new Condition('OR');


### PR DESCRIPTION
Refs: RW-772

This PR fixes an issue when using a date range for some date field in the moderation backend, like the "registration deadline" for training.

### Tests

1. Go to /moderation/content/disaster, select "creation date" as filter and enter a start and end dates.
2. Filter and check there is no error and the "disaster date" column reflects the selected filter.