### PR TITLE
[RW-772] Date filters

### DIFF
--- a/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
+++ b/html/modules/custom/reliefweb_moderation/src/ModerationServiceBase.php
@@ -845,6 +845,14 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
           'form' => 'omnibox',
           'widget' => 'datepicker',
         ],
+        'changed' => [
+          'type' => 'property',
+          'field' => 'changed',
+          'label' => $this->t('Change date'),
+          'shortcut' => 'cgd',
+          'form' => 'omnibox',
+          'widget' => 'datepicker',
+        ],
         'reviewed' => [
           'type' => 'property',
           'field' => 'revision_created',
@@ -878,7 +886,7 @@ abstract class ModerationServiceBase implements ModerationServiceInterface {
           'type' => 'field',
           'field' => 'field_disaster_date',
           'column' => 'value',
-          'label' => $this->t('Creation date'),
+          'label' => $this->t('Disaster date'),
           'shortcut' => 'cd',
           'form' => 'omnibox',
           'widget' => 'datepicker',

--- a/html/modules/custom/reliefweb_moderation/src/Services/CountryModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/CountryModeration.php
@@ -136,6 +136,7 @@ class CountryModeration extends ModerationServiceBase {
       'name',
       'shortname',
       'profile',
+      'changed',
     ]);
     return $definitions;
   }

--- a/html/modules/custom/reliefweb_moderation/src/Services/DisasterModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/DisasterModeration.php
@@ -306,9 +306,11 @@ class DisasterModeration extends ModerationServiceBase {
       'name',
       'profile',
       'author',
+      'created',
     ]);
 
     $definitions['author']['join_callback'] = 'joinTaxonomyAuthor';
+    $definitions['created']['label'] = $this->t('Creation date');
     return $definitions;
   }
 

--- a/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
+++ b/html/modules/custom/reliefweb_moderation/src/Services/SourceModeration.php
@@ -256,8 +256,10 @@ class SourceModeration extends ModerationServiceBase {
       'organization_type',
       'country',
       'content_type',
+      'created',
     ]);
     unset($definitions['organization_type']['join_callback']);
+    $definitions['created']['label'] = $this->t('Creation date');
     return $definitions;
   }
 


### PR DESCRIPTION
Refs: RW-772

This adds and renames date filters on the country, disaster and source moderation backends.

### Tests.

1. Checkout the branch, clear the cache
2. Go to `/moderation/content/country`, check that there is a "Change date" filter. Select a date, filter and confirm that it matches the "updated" column
3. Go to `/moderation/content/disaster`, check that there is a "Disaster date" "change date" filter. Select a date, filter and confirm that it matches the "disaster date" column
4. Go to `/moderation/content/disaster`, check that there is a "Creation date" "change date" filter. Select a date, filter and open a disaster in the results, check the revision history at the bottom and confirm the disaster was indeed created on the selected date
5. Go to `/moderation/content/source`, check that there is a "Creation date" "change date" filter. Select a date, filter and open a source in the results, check the revision history at the bottom and confirm the source was indeed created on the selected date