### PR TITLE
[RW-806] Prevent bots from crawling rivers excessively

### DIFF
--- a/assets/robots.txt.append
+++ b/assets/robots.txt.append
@@ -1,2 +1,5 @@
+# River crawling control.
+Disallow: /*&page=*
+
 # Sitemap
 Sitemap: https://reliefweb.int/sitemap.xml


### PR DESCRIPTION
Refs: RW-806

Simple robots.txt rule to disable crawling of paginated rivers when they are filtered (other query parameters).

## Tests

1. Checkout the branch
2. Run `./local/install.sh -m -d` to recreate the site image and container with the updated robots.txt
3. Visit `/robots.txt` and confirm that the rule is present