### PR TITLE
[OPS-9699] Remove mapbox token from mabox responses

### DIFF
--- a/docker/etc/nginx/custom/03_mapbox.conf
+++ b/docker/etc/nginx/custom/03_mapbox.conf
@@ -20,13 +20,25 @@ location /mapbox/ {
   ## Remove cookies.
   more_clear_input_headers Cookie;
 
+  ## Ensure the proxy host is in a variable, so nginx will not cache the IP
+  ## indefinitely and cause 502 errors if the IPs change.
+  set $mapbox_host "api.mapbox.com";
+
   ## Proxy the request to the mapbox API.
   proxy_ssl_server_name on;
-  proxy_set_header Host "api.mapbox.com";
-  proxy_pass https://api.mapbox.com$mapbox_request_uri;
+  # Disable compression so we can substitute the token in the response body.
+  proxy_set_header Accept-Encoding "";
+  proxy_set_header Host $mapbox_host;
+  proxy_pass https://$mapbox_host$mapbox_request_uri;
   proxy_http_version 1.1;
   proxy_redirect off;
   proxy_intercept_errors on;
+
+  # Substitute the token in the response body.
+  # That doesn't seem to have any ill effect.
+  sub_filter_types application/json;
+  sub_filter_once off;
+  sub_filter "$mapbox_token" 'token';
 
   ## Remove the sku parameter as it's always different.
   set $cache_uri $mapbox_request_uri;


### PR DESCRIPTION
Refs: OPS-9699

This substitutes the mapbox token in the proxied mapbox responses.

## Tests

1. Checkout the branch
2. Recreate the drupal container
3. Visit `/disasters`
4. Check the network tab (refresh if necessary), filter by `mapbox`
5. Check the content of any json file, the mapbox token should not be present (instead there should be `access_token=token`)