### PR TITLE
CD-519 Remove missing UNOCHA logo from base theme via patch

### DIFF
--- a/PATCHES/common_design--default-logo-remove.patch
+++ b/PATCHES/common_design--default-logo-remove.patch
@@ -1,0 +1,14 @@
+diff --git a/components/cd/cd-header/cd-logo.css b/components/cd/cd-header/cd-logo.css
+index b8e7821..c7b7d96 100644
+--- a/components/cd/cd-header/cd-logo.css
++++ b/components/cd/cd-header/cd-logo.css
+@@ -14,9 +14,6 @@
+   float: left;
+   width: var(--brand-logo-mobile-width, 52px);
+   height: var(--cd-site-header-height);
+-  background:
+-    linear-gradient(transparent, transparent),
+-    url(../../../img/logos/ocha-logo-blue.svg) center no-repeat;
+ }
+
+ /* Mobile: Hides logo set in info.yml in favour of background image. */

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,5 +1,8 @@
 {
     "patches": {
+        "unocha/common_design": {
+            "https://humanitarian.atlassian.net/browse/CD-519": "PATCHES/common_design--default-logo-remove.patch"
+        },
         "drupal/core" : {
             "https://www.drupal.org/project/drupal/issues/3047110": "PATCHES/core--drupal--3047110-taxonomy-term-moderation-class.patch",
             "https://www.drupal.org/project/drupal/issues/3008292": "PATCHES/core--drupal--3008292-image-upload-validators.patch",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,8 +1,5 @@
 {
     "patches": {
-        "unocha/common_design": {
-            "https://humanitarian.atlassian.net/browse/CD-519": "PATCHES/common_design--default-logo-remove.patch"
-        },
         "drupal/core" : {
             "https://www.drupal.org/project/drupal/issues/3047110": "PATCHES/core--drupal--3047110-taxonomy-term-moderation-class.patch",
             "https://www.drupal.org/project/drupal/issues/3008292": "PATCHES/core--drupal--3008292-image-upload-validators.patch",
@@ -26,6 +23,9 @@
         },
         "drush/drush": {
             "https://humanitarian.atlassian.net/browse/OPS-8026": "PATCHES/drush--timeout-override.patch"
+        },
+        "unocha/common_design": {
+            "https://humanitarian.atlassian.net/browse/CD-519": "PATCHES/common_design--default-logo-remove.patch"
         }
     }
 }


### PR DESCRIPTION
chore: create patch that removes logo from common_design base theme, add to patches file

See CD-519 for screenshots and details.

Once this patch is applied, the declaration in the common_design base theme rule that sets the UNOCHA logo as a background `  background:
    linear-gradient(transparent, transparent),
    url(../../../img/logos/ocha-logo-blue.svg) center no-repeat;`  is no longer present, which means we no longer have a reference to a missing image.

This will be tested after its deployed. If it has a positive impact on SEO, we will implement this properly in the base theme as described on CD-519