### PR TITLE
[RW-837] Date filter fix

### DIFF
--- a/html/modules/custom/reliefweb_rivers/js/advanced-search.js
+++ b/html/modules/custom/reliefweb_rivers/js/advanced-search.js
@@ -418,6 +418,7 @@
     parent.setAttribute('data-datepicker', '');
     parent.classList.add(advancedSearch.widgetClassPrefix + 'datepicker');
     input.classList.add(advancedSearch.widgetClassPrefix + 'datepicker-input');
+    input.setAttribute('pattern', '^\\d{4}([\\/-]\\d{2}){0,2}$');
 
     // Create the button to show the datepicker.
     var toggleLabel = createElement('span', {
@@ -506,9 +507,22 @@
     });
 
     // Update the toggle label.
-    addEventListener(input, 'keyup', function (event) {
+    addEventListener(input, 'input', function (event) {
       var date = updateDatepicker(datepicker, input.value);
       updateToggleLabel(date);
+      if (date) {
+        input.setAttribute('data-value', date.format('YYYYMMDD'));
+      }
+      else {
+        input.removeAttribute('data-value');
+      }
+      if (!date && input.value.length > 0) {
+        input.setCustomValidity(advancedSearch.labels.dates.invalid);
+      }
+      else {
+        input.setCustomValidity('');
+      }
+      input.reportValidity();
     });
 
     // Logic to keep the focus inside the dialog when it's open.

--- a/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
+++ b/html/modules/custom/reliefweb_rivers/src/AdvancedSearch.php
@@ -260,6 +260,7 @@ class AdvancedSearch {
             'before' => $this->t('before _end_'),
             'after' => $this->t('after _start_'),
             'range' => $this->t('_start_ to _end_'),
+            'invalid' => $this->t('Invalid date. It will not be added'),
           ],
           'operators' => [
             'all' => $this->t('ALL OF'),

--- a/html/themes/custom/common_design_subtheme/components/rw-advanced-search/rw-advanced-search.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-advanced-search/rw-advanced-search.css
@@ -393,6 +393,10 @@
   padding: 8px;
   border: 1px solid var(--cd-reliefweb-brand-grey--light);
 }
+.rw-advanced-search__filter-selector [data-datepicker] > input:invalid {
+  border: 2px solid var(--cd-reliefweb-brand-red--dark);
+  background: ;
+}
 
 /**
  * Advanced search operator selector.


### PR DESCRIPTION
Refs: RW-837

This allows adding date filter in river without showing the datepicker and warns when the date is invalid.

<img width="329" alt="Screenshot 2023-12-07 at 15 51 59" src="https://github.com/UN-OCHA/rwint9-site/assets/696348/d99d4a73-dae9-494e-a5c6-815029e6b64b">

### Tests

1. Checkout the branch, clear the cache
2. Go to  `/updates` for example
3. Click on `Original publication date`
4. Enter a date in the `From` input, check that there is some indication that the date is not valid when it's not in the `YYYY`, `YYYY/MM` or `YYYY/MM/DD` format.
5. Check that the date is added only if it's valid after clicking the `Add` button.
6. Repeat (4) and (5) with the datepicker open
