### PR TITLE
CD-519 Take 2 - Remove missing UNOCHA logo from base theme via patch

### DIFF
--- a/PATCHES/common_design--default-logo-remove.patch
+++ b/PATCHES/common_design--default-logo-remove.patch
@@ -1,0 +1,14 @@
+diff --git a/libraries/cd/cd-header/cd-logo.css b/libraries/cd/cd-header/cd-logo.css
+index b8e7821..c7b7d96 100644
+--- a/libraries/cd/cd-header/cd-logo.css
++++ b/libraries/cd/cd-header/cd-logo.css
+@@ -14,9 +14,6 @@
+   float: left;
+   width: var(--brand-logo-mobile-width, 52px);
+   height: var(--cd-site-header-height);
+-  background:
+-    linear-gradient(transparent, transparent),
+-    url(../../../img/logos/ocha-logo-blue.svg) center no-repeat;
+ }
+
+ /* Mobile: Hides logo set in info.yml in favour of background image. */

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -20,6 +20,9 @@
         },
         "drush/drush": {
             "https://humanitarian.atlassian.net/browse/OPS-8026": "PATCHES/drush--timeout-override.patch"
+        },
+        "unocha/common_design": {
+            "https://humanitarian.atlassian.net/browse/CD-519": "PATCHES/common_design--default-logo-remove.patch"
         }
     }
 }


### PR DESCRIPTION
chore: base theme patch to remove ocha logo bg img

Refs: CD-519

See https://github.com/UN-OCHA/rwint9-site/pull/683