### PR TITLE
[Rw-879] Allow upload of webp images

### DIFF
--- a/config/field.field.media.image_announcement.field_media_image.yml
+++ b/config/field.field.media.image_announcement.field_media_image.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: images/announcements
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png gif jpg jpeg webp'
   max_filesize: ''
   max_resolution: 1200x400
   min_resolution: 1200x400

--- a/config/field.field.media.image_blog_post.field_media_image.yml
+++ b/config/field.field.media.image_blog_post.field_media_image.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: images/blog-posts
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png gif jpg jpeg webp'
   max_filesize: ''
   max_resolution: ''
   min_resolution: 700x200

--- a/config/field.field.media.image_book.field_media_image.yml
+++ b/config/field.field.media.image_book.field_media_image.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: images/book-pages
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png gif jpg jpeg webp'
   max_filesize: ''
   max_resolution: ''
   min_resolution: 700x200

--- a/config/field.field.media.image_report.field_media_image.yml
+++ b/config/field.field.media.image_report.field_media_image.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: images/reports
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png gif jpg jpeg webp'
   max_filesize: ''
   max_resolution: ''
   min_resolution: 700x400

--- a/config/field.field.media.image_source.field_media_image.yml
+++ b/config/field.field.media.image_source.field_media_image.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: images/sources
-  file_extensions: 'png gif jpg jpeg svg'
+  file_extensions: 'png gif jpg jpeg svg webp'
   max_filesize: ''
   max_resolution: ''
   min_resolution: 64x64

--- a/config/field.field.media.image_topic.field_media_image.yml
+++ b/config/field.field.media.image_topic.field_media_image.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: images/topics
-  file_extensions: 'png gif jpg jpeg svg'
+  file_extensions: 'png gif jpg jpeg svg webp'
   max_filesize: ''
   max_resolution: ''
   min_resolution: 64x64


### PR DESCRIPTION
Refs: RW-879

This allows to upload `webp` images.

## Tests

1. Checkout the branch, clear the cache and import the config
2. Create a report for example, upload a `webp` image via the image field and fill in the rest of the form
3. Save and confirm that the image is displayed
4. Inspect the image and verify all the links to the different derivative images are working