### PR TITLE
[RW-857] Companion to OCHA AI Chat PR

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/layout/page--ai--chat--popup.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--ai--chat--popup.html.twig
@@ -47,6 +47,6 @@
   <main aria-label="{{ 'Chat'|t }}" id="main-content">
     <div class="ocha-ai-chat__content">
       {{ page.content }}
-    </div>{# /.cd-layout__content #}
+    </div>
   </main>
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--ai--chat--popup.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--ai--chat--popup.html.twig
@@ -45,8 +45,6 @@
 <div class="ocha-ai-chat">
   {# Link to skip to the main content is in html.html.twig #}
   <main aria-label="{{ 'Chat'|t }}" id="main-content">
-    {{ page.page_title }}
-
     <div class="ocha-ai-chat__content">
       {{ page.content }}
     </div>{# /.cd-layout__content #}

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--ai--chat--popup.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--ai--chat--popup.html.twig
@@ -1,0 +1,54 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+<div class="ocha-ai-chat">
+  {# Link to skip to the main content is in html.html.twig #}
+  <main aria-label="{{ 'Chat'|t }}" id="main-content">
+    {{ page.page_title }}
+
+    <div class="ocha-ai-chat__content">
+      {{ page.content }}
+    </div>{# /.cd-layout__content #}
+  </main>
+</div>


### PR DESCRIPTION
# RW-857

Main PR: https://github.com/UN-OCHA/ocha_ai_chat/pull/8

This provides a leaner template so that our chat window doesn't load as much stuff. The Chat module still tried to `display:none` all the elements it doesn't need, but this avoids printing those elements entirely.