### PR TITLE
[RW-878] Mutool options

### DIFF
--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
@@ -877,8 +877,8 @@ class ReliefWebFile extends FieldItemBase {
 
     $mutool = \Drupal::state()->get('mutool', '/usr/bin/mutool');
     if (is_executable($mutool)) {
-      // @todo add max dimensions.
-      $command = "{$mutool} draw -R {$rotation} -o {$destination} {$source} {$page}";
+      $options = \Drupal::state()->get('mutool_options', '');
+      $command = "{$mutool} draw {$options} -R {$rotation} -o {$destination} {$source} {$page}";
       exec($command, $output, $return_val);
       // @todo log error?
       return empty($return_val) && @file_exists($destination_uri);


### PR DESCRIPTION
 Refs: RW-878

This allows to pass additional parameters to the mutool command used to extract thumbnails from PDFs. Notably

- `-D` to fix issues with some PDFs like https://reliefweb.int/attachments/1fd03f18-18f8-44c5-8b36-18671f711a38/ar.pdf for which the thumbnail for the first page cannot be generated due to the way the PDF was created.
- `-w 1400` to generate a large enough image to have a less burry thumbnail, for example for https://reliefweb.int/sites/reliefweb.int/files/resources/ukr_ocha.pdf (PDF with vector map without proper dimensions)

These options can be set via drush for example (ex: `drush sset mutool_options -- "-D -w 1400"`).

## Tests.

1. Checkout the branch, clear the cache
2. Download https://reliefweb.int/attachments/1fd03f18-18f8-44c5-8b36-18671f711a38/ar.pdf
3. Create a report (`/node/add/report`), fill in title, language, source, origin, country, primary country and select "Situation report" as content format
4. Upload the PDF as attachment, confirm that the thumbnail is not generated for the first PDF.
5. Save
6. Repeat (2) to (5) with the second PDF: https://reliefweb.int/sites/reliefweb.int/files/resources/ukr_ocha.pdf, select **Map** as content format
7. Confirm that the preview for the PDF is really blurry
8. Set the extra mutool options with `drush sset mutool_options -- "-D -w 1400"`
9. Edit report from (3), select "none" as page for the preview then select "1" to force the regeneration
10. Confirm that the thumbnail is generated this time
11. Edit report from (6), select "none" as page for the preview then select "1" to force the regeneration
12. Save and confirm that the preview looks less blurry now