### PR TITLE
chore: update actions as suggested

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout Code
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Extract PHP Version
         id: php
@@ -71,7 +71,7 @@ jobs:
 
       - name: Configure AWS Credentials
         id: aws
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         if: ${{ !env.ACT }}
         with:
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Login to Public ECR
         id: aws-login
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3
         if: ${{ !env.ACT }}
         with:
           registry: public.ecr.aws
@@ -192,7 +192,7 @@ jobs:
       - name: Slack Success Notification
         id: slack_success
         if: ${{ !env.ACT && failure() }}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: '${{ vars.SLACK_CHANNEL }}'
           payload: |
@@ -219,7 +219,7 @@ jobs:
       - name: Slack Failure Notification
         id: slack_failure
         if: ${{ !env.ACT && failure() }}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: '${{ vars.SLACK_CHANNEL }}'
           payload: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,9 @@ RUN mkdir -p /etc/nginx/custom && \
     cp lua-resty-jit-uuid/lib/resty/jit-uuid.lua /usr/share/lua/common/resty/ && \
     rm -rf /tmp/lua-resty-jit-uuid && \
     # Permit nginx access to the X_DOCSTORE_PROVIDER_UUID env variable.
-    sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;\n\n## Mapbox access token.\nenv MAPBOX_TOKEN;/' /etc/nginx/nginx.conf
+    sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;\n\n## Mapbox access token.\nenv MAPBOX_TOKEN;/' /etc/nginx/nginx.conf && \
+    # xdebug 3.3 makes drush DB connections error, so disable it.
+    mv -f /etc/php82/conf.d/90_xdebug.ini /etc/php82/conf.d/90_xdebug.ini.disabled
 
 COPY --from=builder /srv/www/assets /srv/www/assets/
 COPY --from=builder /srv/www/config /srv/www/config/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,9 +50,7 @@ RUN mkdir -p /etc/nginx/custom && \
     cp lua-resty-jit-uuid/lib/resty/jit-uuid.lua /usr/share/lua/common/resty/ && \
     rm -rf /tmp/lua-resty-jit-uuid && \
     # Permit nginx access to the X_DOCSTORE_PROVIDER_UUID env variable.
-    sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;\n\n## Mapbox access token.\nenv MAPBOX_TOKEN;/' /etc/nginx/nginx.conf && \
-    # xdebug 3.3 makes drush DB connections error, so disable it.
-    mv -f /etc/php82/conf.d/90_xdebug.ini /etc/php82/conf.d/90_xdebug.ini.disabled
+    sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;\n\n## Mapbox access token.\nenv MAPBOX_TOKEN;/' /etc/nginx/nginx.conf
 
 COPY --from=builder /srv/www/assets /srv/www/assets/
 COPY --from=builder /srv/www/config /srv/www/config/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,8 +37,7 @@ ENV  NGINX_SERVERNAME=reliefweb.int \
      GIT_BLAME=$GITHUB_ACTOR \
      GIT_REPO=$GITHUB_REPOSITORY \
      GIT_SHA=$GITHUB_SHA \
-     GIT_REF=$GITHUB_REF \
-     PHP_OPTIONS='-d display_errors="On"'
+     GIT_REF=$GITHUB_REF
 
 LABEL info.humanitarianresponse.build.date=$BUILD_DATE \
       info.humanitarianresponse.build.vcs-url=$VCS_URL \
@@ -53,7 +52,7 @@ RUN mkdir -p /etc/nginx/custom && \
     # Permit nginx access to the X_DOCSTORE_PROVIDER_UUID env variable.
     sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;\n\n## Mapbox access token.\nenv MAPBOX_TOKEN;/' /etc/nginx/nginx.conf && \
     # xdebug 3.3 makes drush DB connections error, so disable it.
-    rm -f /etc/php82/conf.d/90_xdebug.ini
+    mv -f /etc/php82/conf.d/90_xdebug.ini /etc/php82/conf.d/90_xdebug.ini.disabled
 
 COPY --from=builder /srv/www/assets /srv/www/assets/
 COPY --from=builder /srv/www/config /srv/www/config/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,8 @@ ENV  NGINX_SERVERNAME=reliefweb.int \
      GIT_BLAME=$GITHUB_ACTOR \
      GIT_REPO=$GITHUB_REPOSITORY \
      GIT_SHA=$GITHUB_SHA \
-     GIT_REF=$GITHUB_REF
+     GIT_REF=$GITHUB_REF \
+     PHP_OPTIONS='-d display_errors="On"'
 
 LABEL info.humanitarianresponse.build.date=$BUILD_DATE \
       info.humanitarianresponse.build.vcs-url=$VCS_URL \
@@ -52,7 +53,7 @@ RUN mkdir -p /etc/nginx/custom && \
     # Permit nginx access to the X_DOCSTORE_PROVIDER_UUID env variable.
     sed -i 's/env NGINX_OVERRIDE_PROTOCOL;/env NGINX_OVERRIDE_PROTOCOL;\n\n## Allow retrieval of a particular file version from the docstore.\nenv X_DOCSTORE_PROVIDER_UUID;\n\n## Mapbox access token.\nenv MAPBOX_TOKEN;/' /etc/nginx/nginx.conf && \
     # xdebug 3.3 makes drush DB connections error, so disable it.
-    mv -f /etc/php82/conf.d/90_xdebug.ini /etc/php82/conf.d/90_xdebug.ini.disabled
+    rm -f /etc/php82/conf.d/90_xdebug.ini
 
 COPY --from=builder /srv/www/assets /srv/www/assets/
 COPY --from=builder /srv/www/config /srv/www/config/


### PR DESCRIPTION
Refs: [OPS-10120](https://humanitarian.atlassian.net/browse/OPS-10120)

As suggested in test output on https://github.com/UN-OCHA/rwint9-site/actions/runs/8051258709 :
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, aws-actions/configure-aws-credentials@v3, docker/login-action@v2.1.0, slackapi/slack-github-action@v1.23.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

See:
https://github.com/docker/login-action
https://github.com/aws-actions/configure-aws-credentials
https://github.com/actions/checkout
https://github.com/slackapi/slack-github-action

[OPS-10120]: https://humanitarian.atlassian.net/browse/OPS-10120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ