### PR TITLE
[RW-912] Permissions and admin pages access

### DIFF
--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -41,6 +41,7 @@ dependencies:
     - reliefweb_topics
     - reliefweb_user_posts
     - reliefweb_users
+    - system
     - taxonomy
     - taxonomy_term_revision
 id: editor
@@ -48,6 +49,7 @@ label: Editor
 weight: 2
 is_admin: null
 permissions:
+  - 'access administration pages'
   - 'access content moderation backend'
   - 'access content moderation features'
   - 'access editorial guidelines'
@@ -174,6 +176,7 @@ permissions:
   - 'view report revisions'
   - 'view term revision data'
   - 'view term revision list'
+  - 'view the administration theme'
   - 'view topic revisions'
   - 'view training revisions'
   - 'view user email addresses'

--- a/config/user.role.user_manager.yml
+++ b/config/user.role.user_manager.yml
@@ -5,11 +5,13 @@ dependencies:
   module:
     - reliefweb_subscriptions
     - reliefweb_users
+    - system
 id: user_manager
 label: 'User manager'
 weight: 3
 is_admin: null
 permissions:
+  - 'access administration pages'
   - 'access user profiles'
   - 'administer subscriptions'
   - 'administer users'
@@ -22,4 +24,5 @@ permissions:
   - 'change own username'
   - 'manage user roles'
   - 'view reliefweb admin menu'
+  - 'view the administration theme'
   - 'view user email addresses'

--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -24,11 +24,13 @@ dependencies:
   module:
     - book
     - filter
-    - google_tag
     - guidelines
+    - ocha_ai
+    - ocha_ai_chat
     - reliefweb_bookmarks
     - reliefweb_guidelines
     - reliefweb_users
+    - system
     - taxonomy
     - taxonomy_term_revision
 id: webmaster
@@ -36,11 +38,12 @@ label: Webmaster
 weight: 4
 is_admin: null
 permissions:
+  - 'access administration pages'
   - 'access editorial guidelines'
+  - 'access ocha ai chat'
   - 'access taxonomy overview'
   - 'add content to books'
   - 'add guideline entities'
-  - 'administer google tag manager'
   - 'create new books'
   - 'create terms in career_category'
   - 'create terms in content_format'
@@ -113,6 +116,7 @@ permissions:
   - 'guideline_list edit own entities'
   - 'guideline_list revert revisions'
   - 'guideline_list view revisions'
+  - 'manage ocha ai chat config'
   - 'revert all guideline revisions'
   - 'revert term revision'
   - 'see other bookmarks'
@@ -120,8 +124,11 @@ permissions:
   - 'sort editorial guidelines'
   - 'use text format guideline'
   - 'view all guideline revisions'
+  - 'view ocha ai admin config menu'
+  - 'view ocha ai chat logs'
   - 'view published guideline entities'
   - 'view reliefweb admin menu'
   - 'view term revision data'
   - 'view term revision list'
+  - 'view the administration theme'
   - 'view unpublished guideline entities'

--- a/html/themes/custom/common_design_subtheme/templates/user/admin-menu.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/user/admin-menu.html.twig
@@ -44,7 +44,7 @@
           <li>
             <h3 id="admin-menu-manage">Manage</h3>
             <ul aria-labelledby="admin-menu-manage">
-              <li><a href="/admin/index">Administration</a></li>
+              <li><a href="/admin">Administration</a></li>
               <li><a href="/admin/people">People</a></li>
               <li><a href="/admin/structure/taxonomy">Taxonomy</a></li>
               <li><a href="/admin/community-topics">Community topics</a></li>


### PR DESCRIPTION
Refs: RW-912

Save permissions and ensure roles which have access to some admin pages can view the admin menu with the relevant links.

### Tests

1. Check out the branch, clear the cache, import the config
2. Log in as a webmaster
3. Click the "Admin menu" in the top header
4. Click the "Administration" link in the menu
5. Confirm that the admin page shown uses the Drupal default admin theme
6. Click the "Configuration" link in this admin page
7. Check that there is a "OCHA AI" section with a link to the logs and one to the chat config
8. Click those links to confirm they are accessible