### PR TITLE
[RW-907] Ensure contact form sender alias is prefixed with the site name

### DIFF
--- a/html/modules/custom/reliefweb_contact/reliefweb_contact.module
+++ b/html/modules/custom/reliefweb_contact/reliefweb_contact.module
@@ -15,6 +15,8 @@ function reliefweb_contact_mail_alter(&$message) {
     return;
   }
 
+  $sitename = \Drupal::config('system.site')->get('name');
+
   /** @var Drupal\contact\Entity\Message $contact_message */
   $contact_message = $message['params']['contact_message'];
   $sender = $contact_message->field_sender->value;
@@ -23,13 +25,17 @@ function reliefweb_contact_mail_alter(&$message) {
   /** @var \Drupal\Core\Field\FieldStorageDefinitionInterface $field_definition */
   $field_definition = $contact_message->field_sender->getFieldDefinition()->getFieldStorageDefinition();
   $field_allowed_options = options_allowed_values($field_definition, $contact_message);
-  $sender_name = $field_allowed_options[$sender];
+  $category = $field_allowed_options[$sender];
+
+  $sender_alias = t('@sitename @category', [
+    '@sitename' => $sitename,
+    '@category' => $category,
+  ]);
 
   // Clean subject.
-  $config = \Drupal::config('system.site');
-  $message['subject'] = t('[@site-name - @category] @subject', [
-    '@site-name' => $config->get('name'),
-    '@category' => $sender_name,
+  $message['subject'] = t('[@sitename - @category] @subject', [
+    '@sitename' => $sitename,
+    '@category' => $category,
     '@subject' => $contact_message->subject->value,
   ]);
 
@@ -43,6 +49,6 @@ function reliefweb_contact_mail_alter(&$message) {
   // Set sender headers.
   $message['from'] = $sender;
   $message['headers']['Bcc'] = $sender;
-  $message['headers']['From'] = $sender_name . ' <' . $sender . '>';
+  $message['headers']['From'] = $sender_alias . ' <' . $sender . '>';
   $message['headers']['Reply-to'] = $sender;
 }


### PR DESCRIPTION
Refs: RW-907

Prefix the sender alias with the site name for the emails sent via the contact form.

<img width="632" alt="Screenshot 2024-03-12 at 10 56 00" src="https://github.com/UN-OCHA/rwint9-site/assets/696348/177842cb-176c-499b-b5f2-4b15b29fcce5">

### Tests

1. Check out the branch, clear the cache
2. Log in as editor
3. Go to a different's user **contact** page
4. Select a category, enter a subject and body and send the email
5. Visit `https://mail.rwint-loca.test` to verify that something like the screenshot above appears with "ReliefWeb XXX" as sender and "[ReliefWeb - XXX] subject" as subject.

Note: make sure to have `https://mail.rwint-local.test` in your /etc/hosts if not already.
