### PR TITLE
[RW-917] Add missing name property to schema

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/layout/html--home.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/html--home.html.twig
@@ -60,6 +60,7 @@
 		{
 			"@context": "https://schema.org",
 			"@type": "WebSite",
+			"name": "ReliefWeb",
 			"url": "https://reliefweb.int/",
 			"potentialAction": {
 				"@type": "SearchAction",


### PR DESCRIPTION
Refs: RW-917

Add the `name` property to the JSON LD schema on the homepage.