### PR TITLE
[RW-918] Add disallow rules for RSS and API converter

### DIFF
--- a/assets/robots.txt.append
+++ b/assets/robots.txt.append
@@ -1,5 +1,11 @@
 # River crawling control.
 Disallow: /*&page=*
 
+# RSS feeds.
+Disallow: /*/rss.xml
+
+# API converter.
+Disallow: /search/converter
+
 # Sitemap
 Sitemap: https://reliefweb.int/sitemap.xml


### PR DESCRIPTION
Refs: RW-918

Add disallow rules for RSS and API search converter.

## Tests

1. Checkout the branch
2. Recreate the image/container with `./local/install.sh -m -d`
3. Check the rules appear in `/robots.txt`