### PR TITLE
[RW-920] 410 for expired jobs/training and remove title on 404

### DIFF
--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -21,13 +21,13 @@ use Drupal\reliefweb_entities\Entity\Report;
 use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
 use Drupal\reliefweb_utility\Helpers\ClassHelper;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
-use Drupal\reliefweb_utility\Helpers\EntityHelper;
 use Drupal\reliefweb_utility\Helpers\MailHelper;
 use Drupal\reliefweb_utility\Helpers\MediaHelper;
 use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\taxonomy\TermInterface;
+use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 
 /**
  * Implements hook_entity_base_field_info().
@@ -755,27 +755,19 @@ function reliefweb_entities_menu_local_tasks_alter(&$data, $route_name, Refinabl
 }
 
 /**
- * Implements hook_preprocess_page__404().
+ * Implements hook_preprocess_page__410().
  *
  * Add a user friendly message on inaccessible entity pages to indicate it's
  * no longer available (we assume the URL was previously accessible, which is
  * probably true in most cases).
  */
-function reliefweb_entities_preprocess_page__404(array &$variables) {
-  // Get the entity from the original request.
-  $entity = EntityHelper::getEntityFromRequest(\Drupal::requestStack()->getMainRequest());
-  if (isset($entity) && $entity instanceof BundleEntityInterface) {
-    $type = mb_strtolower(EntityHelper::getBundleLabelFromEntity($entity));
-    $title = $entity->label();
-
-    $message = t('The @type %title is no longer available.', [
-      '@type' => $type,
-      '%title' => $title,
-    ]);
-
+function reliefweb_entities_preprocess_page__410(array &$variables) {
+  // @see \Drupal\reliefweb_entities\EventSubscriber\AccessDeniedToNotFound::on403().
+  $exception = \Drupal::requestStack()->getCurrentRequest()->attributes->get('exception');
+  if (isset($exception) && $exception instanceof GoneHttpException) {
     $variables['page']['content']['message'] = [
       '#type' => 'markup',
-      '#markup' => $message,
+      '#markup' => $exception->getMessage(),
     ];
   }
 
@@ -784,6 +776,17 @@ function reliefweb_entities_preprocess_page__404(array &$variables) {
   // and this preprocess hook implementation will not be called when visiting
   // an inaccessible entity page afterwards.
   $variables['#cache']['contexts'][] = 'url.path';
+}
+
+/**
+ * Implements hook_preprocess_page_title().
+ */
+function reliefweb_entities_4xx_title() {
+  $exception = \Drupal::requestStack()->getCurrentRequest()->attributes->get('exception');
+  if (isset($exception) && $exception instanceof GoneHttpException) {
+    return t('Gone');
+  }
+  return 'Client error';
 }
 
 /**

--- a/html/modules/custom/reliefweb_entities/src/EventSubscriber/AccessDeniedToNotFound.php
+++ b/html/modules/custom/reliefweb_entities/src/EventSubscriber/AccessDeniedToNotFound.php
@@ -2,16 +2,22 @@
 
 namespace Drupal\reliefweb_entities\EventSubscriber;
 
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase;
-use Drupal\reliefweb_entities\BundleEntityInterface;
+use Drupal\Core\Http\Exception\CacheableGoneHttpException;
+use Drupal\Core\Http\Exception\CacheableNotFoundHttpException;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\reliefweb_moderation\EntityModeratedInterface;
 use Drupal\reliefweb_utility\Helpers\EntityHelper;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Redirects 403 page error responses to 404 page for bundle entities.
  */
 class AccessDeniedToNotFound extends HttpExceptionSubscriberBase {
+
+  use StringTranslationTrait;
 
   /**
    * {@inheritdoc}
@@ -35,8 +41,31 @@ class AccessDeniedToNotFound extends HttpExceptionSubscriberBase {
    */
   public function on403(ExceptionEvent $event) {
     $entity = EntityHelper::getEntityFromRequest($event->getRequest());
-    if (isset($entity) && $entity instanceof BundleEntityInterface) {
-      $event->setThrowable(new NotFoundHttpException());
+    if (isset($entity) && $entity instanceof EntityModeratedInterface) {
+      $cacheable_metadata = new CacheableMetadata();
+
+      if ($entity instanceof CacheableDependencyInterface) {
+        $cacheable_metadata->addCacheableDependency($entity);
+      }
+
+      $throwable = $event->getThrowable();
+      if (isset($throwable) && $throwable instanceof CacheableDependencyInterface) {
+        $cacheable_metadata->addCacheableDependency($throwable);
+      }
+
+      if ($entity->getModerationStatus() === 'expired') {
+        $message = $this->t('The @bundle %title is no longer available.', [
+          '@bundle' => $entity->bundle(),
+          '%title' => $entity->label(),
+        ]);
+
+        $exception = new CacheableGoneHttpException($cacheable_metadata, $message);
+      }
+      else {
+        $exception = new CacheableNotFoundHttpException($cacheable_metadata);
+      }
+
+      $event->setThrowable($exception);
     }
   }
 

--- a/html/modules/custom/reliefweb_entities/src/Routing/RouteSubscriber.php
+++ b/html/modules/custom/reliefweb_entities/src/Routing/RouteSubscriber.php
@@ -29,6 +29,11 @@ class RouteSubscriber extends RouteSubscriberBase {
         $route->setOption('_admin_route', TRUE);
       }
     }
+
+    // Add a title callback for the 4xx errors so it's not always Client error.
+    if ($route = $collection->get('system.4xx')) {
+      $route->setDefault('_title_callback', 'reliefweb_entities_4xx_title');
+    }
   }
 
 }

--- a/html/themes/custom/common_design_subtheme/templates/layout/page--410.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/page--410.html.twig
@@ -1,0 +1,71 @@
+{% embed '@common_design/layout/page.html.twig' %}
+
+  {% block header %}
+    {% include '@common_design_subtheme/cd/cd-header/cd-header.html.twig' %}
+  {% endblock %}
+
+  {% block main %}
+
+    {{ attach_library('common_design_subtheme/rw-useful-links') }}
+
+    {# Link to skip to the main content is in html.html.twig #}
+    <main role="main" id="main-content" class="cd-container">
+
+      <div class="cd-layout">
+
+        <div class="cd-layout__content">
+
+          <section class="rw-410">
+            <header>
+              <h1 class="rw-page-title">{{ '410 - Gone'|t }}</h1>
+            </header>
+            {% if page.content.message is not empty %}
+            <p><strong>{{ page.content.message }}</strong></p>
+            {% endif %}
+            <p>{{ 'Sorry for any inconvenience.'|t }}</p>
+            <p>{{ 'Here are some useful pages to help you get back on track:'|t }}</p>
+            <div class="rw-entity-useful-links">
+              <ul>
+                <li>
+                  <a href="/">{{ 'Homepage'|t }}</a>
+                  <p>{{ 'View ongoing crises and latest headlines.'|t }}</p>
+                </li>
+                <li>
+                  <a href="/updates">{{ 'Updates'|t }}</a>
+                  <p>{{ 'Access the latest humanitarian reports, maps and infographics and an archive of more than 20 years of humanitarian information.'|t }}</p>
+                </li>
+                <li>
+                  <a href="/jobs">{{ 'Jobs'|t }}</a>
+                  <p>{{ 'Browse open job opportunities in the humanitarian field.'|t }}</p>
+                </li>
+                <li>
+                  <a href="/training">{{ 'Training'|t }}</a>
+                  <p>{{ 'Discover training opportunities in the humanitarian field.'|t }}</p>
+                </li>
+                <li>
+                  <a href="/help">{{ 'Help Section'|t }}</a>
+                  <p>{{ 'Find help on how to use the site, read terms and conditions, view the FAQs and API documentation.'|t }}</p>
+                </li>
+              </ul>
+            </div>
+          </section>
+
+        </div>{# /.cd-layout__content #}
+
+      </div>
+
+    </main>
+  {% endblock %}
+
+  {% block footer_soft %}
+    {% include '@common_design_subtheme/cd/cd-footer/cd-soft-footer.html.twig' %}
+  {% endblock %}
+
+  {% block footer %}
+    {% include '@common_design_subtheme/cd/cd-footer/cd-footer.html.twig' %}
+  {% endblock %}
+
+{% endembed %}
+
+
+


### PR DESCRIPTION
Refs: RW-920


Returns a 410 for expired jobs/training and removes the title on 404 pages.

## Tests

1. Checkout the branch, clear the cache.
2. Find an expired job in `/moderation/content/job` (or save on as expired)
3. Visit that job as anonymous user, confirm you get a 410 Gone **with** the `This job xxx is no longer available` message.
4. Find a draft or pending job
5. Visit it and confirm you get a 404  **without** the `This job xxx is no longer available` message