### PR TITLE
[RW-932] Fix admin menu position

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-admin-menu/admin-menu.js
+++ b/html/themes/custom/common_design_subtheme/components/rw-admin-menu/admin-menu.js
@@ -8,8 +8,8 @@
     },
 
     /**
-     * Hide and move OCHA Services to the top of the header after the target.
-   */
+     * Hide and move admin menu to the top of the header after the target.
+     */
     moveToHeader: function (id, target) {
       var section = document.getElementById(id);
       var sibling = document.getElementById(target);
@@ -24,4 +24,5 @@
       element.setAttribute('cd-data-hidden', hide === true);
     }
   };
+
 })(Drupal);

--- a/html/themes/custom/common_design_subtheme/components/rw-admin-menu/rw-admin-menu.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-admin-menu/rw-admin-menu.css
@@ -53,6 +53,11 @@
   background: var(--cd-white);
 }
 
+.admin-menu-dropdown {
+  width: 100%;
+  padding: 22px 0;
+}
+
 .admin-menu-dropdown__inner {
   max-width: var(--cd-max-width);
   padding: 0 var(--cd-container-padding);

--- a/html/themes/custom/common_design_subtheme/templates/user/admin-menu.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/user/admin-menu.html.twig
@@ -6,7 +6,7 @@
 
   <h2 id="admin-menu-title">{% trans %}Admin menu{% endtrans %}</h2>
 
-  <div class="cd-global-header__dropdown cd-ocha-dropdown cd-dropdown" id="admin-menu-dropdown" aria-labelledby="admin-menu-title" data-cd-toggable="{{ 'Admin menu'|t }}" data-cd-component="admin-menu" data-cd-icon="arrow-down" data-cd-replace="admin-menu-title" data-cd-logo="admin">
+  <div class="cd-global-header__dropdown cd-dropdown admin-menu-dropdown" id="admin-menu-dropdown" aria-labelledby="admin-menu-title" data-cd-toggable="{{ 'Admin menu'|t }}" data-cd-component="admin-menu" data-cd-icon="arrow-down" data-cd-replace="admin-menu-title" data-cd-logo="admin">
 
     <div class="admin-menu-dropdown__inner">
       <nav>


### PR DESCRIPTION
Refs: RW-932

This fixes a regression from the upgrade to the latest CD for the RW admin menu.

<img width="1437" alt="Screenshot 2024-04-02 at 10 35 12" src="https://github.com/UN-OCHA/rwint9-site/assets/696348/80ac07c8-6565-4cea-8f43-d60536209c33">

## Tests.

1. Checkout the branch, clear the cache
2. Log in as an editor
3. Click the "admin menu" in the global header and check that the menu background stretches to the left and right borders (see screenshot).
4. Optionally, checkout v2.4.2 to confirm it's the same behavior.