### PR TITLE
[OPS-10242] Add new hostname setting for google tag

### DIFF
--- a/config/google_tag.container.default.yml
+++ b/config/google_tag.container.default.yml
@@ -10,6 +10,7 @@ id: default
 label: Default
 weight: 0
 container_id: GTM-xxxxxx
+hostname: www.googletagmanager.com
 data_layer: dataLayer
 include_classes: false
 whitelist_classes: |-


### PR DESCRIPTION
Refs: OPS-10242

This adds the new `hostname` setting added in google_tag v1.7.0.

## Tests

1. Checkout the branch, clear the cache, import the config (ex: `local/install.sh -d`)
2. Visit `/admin/config/system/google-tag` and check the `hostname` column is `www.googletagmanager.com`