### PR TITLE
[RW-931] Job tagging adjustments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "reliefweb/simple-datepicker": "^v1.3",
         "symfony/uid": "^6.2",
         "unocha/common_design": "^9.4",
-        "unocha/ocha_ai": "^1.0.8",
+        "unocha/ocha_ai": "dev-RW-931-tagger-settings",
         "unocha/ocha_monitoring": "^1.0",
         "webflo/drupal-finder": "^1.2.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c73583c1b6a85d03777ff408d4fc915e",
+    "content-hash": "5cf0eed11a737ef9f6be6792f523d26a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -15810,16 +15810,16 @@
         },
         {
             "name": "unocha/ocha_ai",
-            "version": "v1.0.8",
+            "version": "dev-RW-931-tagger-settings",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/ocha_ai.git",
-                "reference": "15711ef743b512fa0468dacb7d479de3bc67e925"
+                "reference": "096a40d5c4a2d9d8c4ab7d7b9531cde840a232d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/ocha_ai/zipball/15711ef743b512fa0468dacb7d479de3bc67e925",
-                "reference": "15711ef743b512fa0468dacb7d479de3bc67e925",
+                "url": "https://api.github.com/repos/UN-OCHA/ocha_ai/zipball/096a40d5c4a2d9d8c4ab7d7b9531cde840a232d5",
+                "reference": "096a40d5c4a2d9d8c4ab7d7b9531cde840a232d5",
                 "shasum": ""
             },
             "require": {
@@ -15837,7 +15837,6 @@
                 "drupal/coder": "^8.3",
                 "phpcompatibility/php-compatibility": "^9.3"
             },
-            "default-branch": true,
             "type": "drupal-module",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -15851,9 +15850,9 @@
             "description": "OCHA AI module",
             "support": {
                 "issues": "https://github.com/UN-OCHA/ocha_ai/issues",
-                "source": "https://github.com/UN-OCHA/ocha_ai/tree/v1.0.8"
+                "source": "https://github.com/UN-OCHA/ocha_ai/tree/RW-931-tagger-settings"
             },
-            "time": "2024-03-26T14:05:46+00:00"
+            "time": "2024-04-04T01:58:43+00:00"
         },
         {
             "name": "unocha/ocha_monitoring",

--- a/config/ocha_ai_tag.settings.yml
+++ b/config/ocha_ai_tag.settings.yml
@@ -1,6 +1,10 @@
 _core:
   default_config_hash: r1hk7e31MjYWgy4AuBRXxwuhornPFBp0LDrncwSG38Q
 defaults:
+  form:
+    instructions:
+      value: 'The process of posting jobs via ReliefWeb is now even smoother. The form now includes an automated function for the "career" and "themes" categories; fewer fields for users to fill and higher efficiency overall.'
+      format: markdown_editor
   plugins:
     completion:
       plugin_id: aws_bedrock

--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -58,29 +58,33 @@ function reliefweb_job_tagger_form_node_form_alter(array &$form, FormStateInterf
     return;
   }
 
-  // Add message for job posters.
-  $form['ai_message'] = [
-    '#type' => 'fieldset',
-    '#attached' => [
-      'library' => [
-        'reliefweb_job_tagger/ai-message',
+  $settings = \Drupal::service('ocha_ai_tag.tagger')->getSettings();
+
+  if (!empty($settings['form']['instructions']['value'])) {
+    // Add message for job posters.
+    $form['ai_message'] = [
+      '#type' => 'fieldset',
+      '#attached' => [
+        'library' => [
+          'reliefweb_job_tagger/ai-message',
+        ],
       ],
-    ],
-    '#attributes' => [
-      'class' => [
-        'ai-message-wrapper',
+      '#attributes' => [
+        'class' => [
+          'ai-message-wrapper',
+        ],
       ],
-    ],
-    'message' => [
-      '#type' => 'processed_text',
-      '#text' => t('The process of posting jobs via ReliefWeb is now even smoother. The form now includes an automated function for the "career" and "themes" categories; fewer fields for users to fill and higher efficiency overall.'),
-      '#format' => 'html',
-      '#weight' => -90,
-      '#prefix' => '<div class="messages messages--warning cd-alert cd-alert--warning">',
-      '#suffix' => '</div>',
-      '#states' => [],
-    ],
-  ];
+      'message' => [
+        '#type' => 'processed_text',
+        '#text' => $settings['form']['instructions']['value'],
+        '#format' => $settings['form']['instructions']['format'] ?? 'html',
+        '#weight' => -90,
+        '#prefix' => '<div class="messages messages--warning cd-alert cd-alert--warning">',
+        '#suffix' => '</div>',
+        '#states' => [],
+      ],
+    ];
+  }
 
   $sources = reliefweb_job_tagger_get_trusted_organizations($user);
   if (empty($sources)) {

--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -208,8 +208,12 @@ function reliefweb_job_tagger_node_presave(EntityInterface $node) {
 
   // Queue node when status is empty.
   if ($node->reliefweb_job_tagger_status->isEmpty()) {
-    $node->setNewRevision(FALSE);
-    $node->set('reliefweb_job_tagger_status', 'queue');
+    // $node->setNewRevision(FALSE);
+    $node->set('reliefweb_job_tagger_status', 'queued');
+
+    $log_message = $node->getRevisionLogMessage();
+    $log_message .= (empty($log_message) ? '' : ' ') . 'Job has been queued for tagging.';
+    $node->setRevisionLogMessage($log_message);
   }
 }
 
@@ -231,12 +235,8 @@ function reliefweb_job_tagger_entity_after_save(EntityInterface $entity) {
   }
 
   /** @var \Drupal\node\Entity\Node $entity */
-  if ($entity->hasField('reliefweb_job_tagger_status') && $entity->get('reliefweb_job_tagger_status')->value == 'queue') {
+  if ($entity->hasField('reliefweb_job_tagger_status') && $entity->get('reliefweb_job_tagger_status')->value == 'queued') {
     reliefweb_job_tagger_queue_job($entity);
-
-    $entity->set('reliefweb_job_tagger_status', 'queued');
-    $entity->setRevisionLogMessage('Job has been queued for tagging');
-    $entity->save();
   }
 }
 

--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -251,7 +251,6 @@ function reliefweb_job_tagger_node_presave(EntityInterface $node) {
 
   // Queue node when status is empty.
   if ($node->reliefweb_job_tagger_status->isEmpty()) {
-    // $node->setNewRevision(FALSE);
     $node->set('reliefweb_job_tagger_status', 'queued');
 
     $log_message = $node->getRevisionLogMessage();

--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -70,6 +70,10 @@ function reliefweb_job_tagger_form_node_form_alter(array &$form, FormStateInterf
     return;
   }
 
+  // Add a validation callback so we can check if the career categories field
+  // is set for trusted users who selected a source they are trusted for.
+  $form['#validate'][] = 'reliefweb_job_tagger_validate_mandatory_fields';
+
   $settings = \Drupal::service('ocha_ai_tag.tagger')->getSettings();
 
   if (!empty($settings['form']['instructions']['value'])) {
@@ -160,6 +164,27 @@ function reliefweb_job_tagger_get_trusted_organizations($account = NULL) {
   $sources = array_keys($sources);
 
   return $sources;
+}
+
+/**
+ * Validate mandatory fields.
+ */
+function reliefweb_job_tagger_validate_mandatory_fields($form, FormStateInterface $form_state) {
+  $trusted_sources = reliefweb_job_tagger_get_trusted_organizations();
+  $source = $form_state->getValue(['field_source', 0, 'target_id']);
+
+  // If the selected source is a trusted source, then the career category field
+  // is mandatory since it will not be processed by the AI.
+  //
+  // @see reliefweb_job_tagger_form_node_form_alter().
+  if (!empty($trusted_sources) && !empty($source) && in_array($source, $trusted_sources)) {
+    // Check if a career category was selected.
+    if (!$form_state->hasValue(['field_career_categories', 0, 'target_id'])) {
+      $form_state->setError($form['field_career_categories']['widget'], t('@name field is required.', [
+        '@name' => $form['field_career_categories']['widget']['#title'],
+      ]));
+    }
+  }
 }
 
 /**

--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -24,6 +24,8 @@ function reliefweb_job_tagger_form_node_form_alter(array &$form, FormStateInterf
     return;
   }
 
+  $skip = FALSE;
+
   // Display AI info for editors.
   if ($form_id == 'node_job_edit_form') {
     $entity = $form_state->getFormObject()->getEntity();
@@ -40,19 +42,29 @@ function reliefweb_job_tagger_form_node_form_alter(array &$form, FormStateInterf
         ];
       }
     }
+
+    // Skip when editing a job that already has a career category that was not
+    // added via the AI.
+    // That includes all the jobs before the deployment of the AI tagging since
+    // the career category field is mandatory.
+    $skip = !$entity->get('field_career_categories')->isEmpty() &&
+            $entity->get('reliefweb_job_tagger_status')->isEmpty();
   }
 
   // Check permissions.
   $user = \Drupal::currentUser();
   if ($user->hasPermission('bypass ocha ai job tag')) {
-    // Make fields mandatory.
-    $form['field_career_categories']['widget']['#required'] = TRUE;
-
-    return;
+    $skip = TRUE;
   }
 
   if (!$user->hasPermission('enforce ocha ai job tag')) {
-    // Make fields mandatory.
+    $skip = TRUE;
+  }
+
+  if ($skip) {
+    // Ensure the field is mandatory because we cannot do that at the field
+    // definition level. It indeed needs to be optional so that it can be
+    // ignored when it is to be filled by the AI.
     $form['field_career_categories']['widget']['#required'] = TRUE;
 
     return;

--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -218,6 +218,13 @@ function reliefweb_job_tagger_node_presave(EntityInterface $node) {
     return;
   }
 
+  // Skip queued and processed nodes.
+  if ($node->hasField('reliefweb_job_tagger_status')) {
+    if ($node->reliefweb_job_tagger_status->value == 'queued' || $node->reliefweb_job_tagger_status->value == 'processed') {
+      return;
+    }
+  }
+
   if ($node->moderation_status->value != 'pending') {
     $node->set('reliefweb_job_tagger_status', '');
     return;

--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -26,11 +26,7 @@ function reliefweb_job_tagger_form_node_form_alter(array &$form, FormStateInterf
 
   // Display AI info for editors.
   if ($form_id == 'node_job_edit_form') {
-    // Bail out if post is created before deployment.
     $entity = $form_state->getFormObject()->getEntity();
-    if ($entity->created->value < strtotime('2024-04-18')) {
-      return;
-    }
 
     if (UserHelper::userHasRoles(['editor'])) {
       if ($entity->hasField('reliefweb_job_tagger_info') && !$entity->reliefweb_job_tagger_info->IsEmpty()) {
@@ -43,7 +39,6 @@ function reliefweb_job_tagger_form_node_form_alter(array &$form, FormStateInterf
           '#weight' => -90,
         ];
       }
-
     }
   }
 

--- a/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
+++ b/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
@@ -184,28 +184,14 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
   protected function getRelevantTerm($vocabulary, $data, $limit) {
     $storage = $this->entityTypeManager->getStorage('taxonomy_term');
 
-    if ($limit == 1) {
-      $first = array_keys($data);
-      $first = reset($first);
-      $terms = $storage->loadByProperties([
-        'name' => $first,
-        'vid' => $vocabulary,
-      ]);
-      return reset($terms);
-    }
-
     $items = $this->getTopNumTerms($data, $limit);
-    $result = [];
 
-    foreach ($items as $item) {
-      $terms = $storage->loadByProperties([
-        'name' => $item,
-        'vid' => $vocabulary,
-      ]);
-      $result[] = reset($terms);
-    }
+    $terms = $storage->loadByProperties([
+      'name' => $items,
+      'vid' => $vocabulary,
+    ]);
 
-    return $result;
+    return $limit === 1 ? reset($terms) : $terms;
   }
 
   /**

--- a/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
+++ b/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
@@ -147,7 +147,7 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
           'format' => 'markdown',
         ]);
       }
-      $node->revision_log = 'Job has been updated by AI.';
+      $node->setRevisionLogMessage('Job has been updated by AI.');
       $node->set('reliefweb_job_tagger_status', 'processed');
       $node->setNewRevision(TRUE);
       $node->save();

--- a/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
+++ b/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
@@ -3,6 +3,8 @@
 namespace Drupal\reliefweb_job_tagger\Plugin\QueueWorker;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\ocha_ai_tag\Services\OchaAiTagTagger;
@@ -36,9 +38,9 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
   /**
    * The logger service.
    *
-   * @var \Psr\Log\LoggerInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
-  protected LoggerInterface $logger;
+  protected LoggerChannelInterface $logger;
 
   /**
    * {@inheritdoc}

--- a/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
+++ b/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
@@ -62,7 +62,6 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
     $nid = $data->nid;
 
     if (empty($nid)) {
-      \Drupal::logger('debug')->notice('no nid');
       return;
     }
 
@@ -70,12 +69,10 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
     $node = $this->entityTypeManager->getStorage('node')->load($nid);
 
     if (!$node || $node->bundle() !== 'job') {
-      \Drupal::logger('debug')->notice('no bundle');
       return;
     }
 
     if ($node->body->isEmpty()) {
-      \Drupal::logger('debug')->notice('no body');
       return;
     }
 

--- a/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
+++ b/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
@@ -62,7 +62,7 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
     $nid = $data->nid;
 
     if (empty($nid)) {
-      \Drupal::logger('deubg')->notice('no nid');
+      \Drupal::logger('debug')->notice('no nid');
       return;
     }
 
@@ -70,12 +70,12 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
     $node = $this->entityTypeManager->getStorage('node')->load($nid);
 
     if (!$node || $node->bundle() !== 'job') {
-      \Drupal::logger('deubg')->notice('no bundle');
+      \Drupal::logger('debug')->notice('no bundle');
       return;
     }
 
     if ($node->body->isEmpty()) {
-      \Drupal::logger('deubg')->notice('no body');
+      \Drupal::logger('debug')->notice('no body');
       return;
     }
 


### PR DESCRIPTION
Refs: RW-931

**Note**: the ocha_ai module is set to branch from https://github.com/UN-OCHA/ocha_ai/pull/23. That will need to be changed to a tagged release after the current ocha_ai open PRs are merged.

This adjusts a few things from https://github.com/UN-OCHA/rwint9-site/pull/734.

Each commit can picked up separately in case some of the changes in that PR are not welcomed.

Some of the main changes are:

1. Removal of the `entity->save()` in the `hook_entity_after_update` because it results in unnecessary double DB writes. Setting the tagging status to "queued" in the `presave` hook and queueing the entity in the `after_save` hook is enough.
2. The use of the `instructions` field of the ai tagger config form for the message displayed on the job form. This is to be able to adjust or remove the message without a deployment. (This should be reviewed if at one point we add tagging of other content types with different "instruction" messages.)
3. The cutoff date is replaced by a check on the career category field and the tagger status field. This is more robust I think and importantly allows to test properly before the deployment.
4. There is a new form validation callback to ensure that a career category is selected when a user selects a source they are trusted for. The form `states` only affects the UI and doesn't enforce the requirement.


This was tested with several use cases:

**Existing jobs created before AI tagging introduced**

All the AI stuff is always skipped, regardless of who edits the job --> same behavior as before with career categories and themes fields visible and career categories mandatory.

**Editors**

All the AI stuff is always skipped.

**Trusted users**

Trusted source selected --> AI stuff skipped --> same behavior as before with career categories and themes fields visible and career categories mandatory --> submitting saves as published with no queueing.

Non trusted source selected --> see normal user below.

**Normal user/non trusted source**

Career categories and themes fields are not visible, message at top of form is visible.
- Saving as draft --> document not queued
- Submitting --> saves as pending and queues document for AI processing.

**New source**

Career categories and themes fields are not visible, message at top of form is visible --> saved as on-hold as expected and document is not queued for AI tagging.

