### PR TITLE
[OPS-9523][RW-935] Amazon SES compatibility fixes

### DIFF
--- a/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.services.yml
+++ b/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.services.yml
@@ -2,3 +2,8 @@ services:
   reliefweb_subscriptions.mailer:
     class: \Drupal\reliefweb_subscriptions\ReliefwebSubscriptionsMailer
     arguments: ['@config.factory', '@database', '@entity_field.manager', '@entity.repository', '@entity_type.manager', '@state', '@datetime.time', '@reliefweb_api.client', '@private_key', '@renderer', '@plugin.manager.mail', '@language.default', '@logger.factory', '@theme.initialization', '@theme.manager',  '@theme_handler']
+  # Override the amazon_ses message builder so we can add extra headers and
+  # override the text version of the email.
+  amazon_ses.message_builder:
+    class: Drupal\reliefweb_subscriptions\AmazonSesMessageBuilder
+    arguments: ['@logger.channel.amazon_ses', '@config.factory', '@file_system', '@file.mime_type.guesser']

--- a/html/modules/custom/reliefweb_subscriptions/src/AmazonSesMessageBuilder.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/AmazonSesMessageBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\reliefweb_subscriptions;
+
+use Drupal\amazon_ses\MessageBuilder;
+
+/**
+ * Extend the Amazon SES module's message builder.
+ */
+class AmazonSesMessageBuilder extends MessageBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildMessage(array $message) {
+    // Adjust headers and expected message properties to work with the base
+    // amazon_ses message builder.
+    if (isset($message['headers'])) {
+      foreach ($message['headers'] as $key => $value) {
+        switch (strtolower($key)) {
+          case 'from':
+            $message['from'] = $value;
+            unset($message['headers'][$key]);
+            $message['headers']['From'] = $value;
+            break;
+
+          case 'reply-to':
+            $message['reply-to'] = $value;
+            unset($message['headers'][$key]);
+            $message['headers']['Reply-to'] = $value;
+            break;
+
+          case 'cc':
+            unset($message['headers'][$key]);
+            $message['headers']['Cc'] = $value;
+            break;
+
+          case 'bcc':
+            unset($message['headers'][$key]);
+            $message['headers']['Bcc'] = $value;
+            break;
+        }
+      }
+    }
+
+    /** @var Symfony\Component\Mime\Email $email */
+    $email = parent::buildMessage($message);
+
+    // Add extra headers.
+    // @see \Drupal\reliefweb_subscriptions\ReliefWebSubscriptionsMailer::generateEmail().
+    if (isset($message['params']['headers'])) {
+      /** @var Symfony\Component\Mime\Headers $headers */
+      $headers = $email->getHeaders();
+      foreach ($message['params']['headers'] as $header => $value) {
+        $headers->addHeader($header, $value);
+      }
+    }
+
+    // Replace the plain text message if it exists.
+    //
+    // @see reliefweb_subscriptions_mail().
+    // @see reliefweb_entities_mail()
+    // @see reliefweb_contact_mail_alter().
+    if (isset($message['params']['plaintext'])) {
+      $email->text($message['params']['plaintext']);
+    }
+
+    // We replace the email with ours that preserves the BCC header so that
+    // AWS SES can send emails to the BCC addresses when parsing the raw email
+    // data sent by the AmazonSesHandler service.
+    //
+    // @see \Drupal\amazon_ses\MessageBuilder\AmazonSesHandler::send().
+    // @see \Symfony\Component\Mime\Message::getPreparedHeaders()
+    $data = $email->__serialize();
+    $email_with_bcc = new EmailWithBcc();
+    $email_with_bcc->__unserialize($data);
+
+    return $email_with_bcc;
+  }
+
+}

--- a/html/modules/custom/reliefweb_subscriptions/src/EmailWithBcc.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/EmailWithBcc.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\reliefweb_subscriptions;
+
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\Headers;
+
+/**
+ * Extend the Email class to avoid removing the Bcc header.
+ */
+class EmailWithBcc extends Email {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPreparedHeaders() : Headers {
+    // Add the BCC header since it's removed by the grandparent class.
+    // @see \Symfony\Component\Mime\Message::getPreparedHeaders()
+    $headers = parent::getPreparedHeaders();
+    if (!$headers->has('Bcc') && $this->getHeaders()->has('Bcc')) {
+      $headers->add($this->getHeaders()->get('Bcc'));
+    }
+    return $headers;
+  }
+
+}

--- a/html/modules/custom/reliefweb_subscriptions/src/ReliefwebSubscriptionsMailer.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/ReliefwebSubscriptionsMailer.php
@@ -538,7 +538,7 @@ class ReliefwebSubscriptionsMailer {
       // can help clear a back-log of 38,000 mails just a bit faster.
       $timer_elapsed = microtime(TRUE) - $timer_start;
       if ($timer_elapsed < 1) {
-        usleep((1 - $timer_elapsed) * 1e+6);
+        usleep((int) ((1 - $timer_elapsed) * 1e+6));
       }
     }
 

--- a/html/modules/custom/reliefweb_subscriptions/src/ReliefwebSubscriptionsMailer.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/ReliefwebSubscriptionsMailer.php
@@ -441,6 +441,7 @@ class ReliefwebSubscriptionsMailer {
     static $from;
     static $language;
     static $batch_size;
+    static $throttle;
 
     if (!isset($from)) {
       $from = $this->config('system.site')->get('mail') ?? ini_get('sendmail_from');
@@ -454,6 +455,10 @@ class ReliefwebSubscriptionsMailer {
       $language = $this->languageDefault->get()->getId();
       // Number of emails to send by second.
       $batch_size = $this->state->get('reliefweb_subscriptions_mail_batch_size', 40);
+
+      // Do not throttle if using the amazon_ses module since it does that by
+      // itself.
+      $throttle = $this->config('mailsystem.settings')?->get('defaults.sender') !== 'amazon_ses_mail';
     }
 
     $sid = $subscription['id'];
@@ -537,7 +542,7 @@ class ReliefwebSubscriptionsMailer {
       // batch. Probably not strictly necessary, but if we *do* go fast this
       // can help clear a back-log of 38,000 mails just a bit faster.
       $timer_elapsed = microtime(TRUE) - $timer_start;
-      if ($timer_elapsed < 1) {
+      if ($throttle && $timer_elapsed < 1) {
         usleep((int) ((1 - $timer_elapsed) * 1e+6));
       }
     }


### PR DESCRIPTION
Refs: OPS-9523, RW-935

_This is against the [cafuego/ops-9523-amazon-ses](https://github.com/UN-OCHA/rwint9-site/tree/cafuego/ops-9523-amazon-ses) branch._

This PR adjusts the way emails are sent by the `amazon_ses` module to handle proper HTML formatting, extra headers and BCC.

**Important:** to work properly this assumes that the formatting of the message is still done by MimeMail so the `mail.profile.formatter` will have to be set to `mime_mail` for RW: https://github.com/UN-OCHA/tools-ansible/blob/977a2cc13d56c2ed66ca5f57942d660a91432201/modules/drupal/templates/settings.10.php.j2#L1276

