### PR TITLE
[OPS-9523] Fix missing logger channel complaint

### DIFF
--- a/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.info.yml
+++ b/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.info.yml
@@ -4,6 +4,7 @@ description: 'Allow users to subscribe to content changes.'
 package: reliefweb
 core_version_requirement: ^9 || ^10
 dependencies:
+  - amazon_ses:amazon_ses
   - drupal:reliefweb_api
   - drupal:reliefweb_form
   - drupal:reliefweb_utility

--- a/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.services.yml
+++ b/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.services.yml
@@ -2,8 +2,15 @@ services:
   reliefweb_subscriptions.mailer:
     class: \Drupal\reliefweb_subscriptions\ReliefwebSubscriptionsMailer
     arguments: ['@config.factory', '@database', '@entity_field.manager', '@entity.repository', '@entity_type.manager', '@state', '@datetime.time', '@reliefweb_api.client', '@private_key', '@renderer', '@plugin.manager.mail', '@language.default', '@logger.factory', '@theme.initialization', '@theme.manager',  '@theme_handler']
+
   # Override the amazon_ses message builder so we can add extra headers and
   # override the text version of the email.
   amazon_ses.message_builder:
     class: Drupal\reliefweb_subscriptions\AmazonSesMessageBuilder
     arguments: ['@logger.channel.amazon_ses', '@config.factory', '@file_system', '@file.mime_type.guesser']
+
+  # We need to override the logger channel as well so Drupal stops complaining.
+  logger.channel.amazon_ses:
+    class: Drupal\Core\Logger\LoggerChannel
+    factory: logger.factory:get
+    arguments: ['amazon_ses']


### PR DESCRIPTION
Refs: OPS-9523

Make Drupal happy and stop complaining about a missing service because it loads things out of order.