### PR TITLE
[RW-885] One-click unsubscribe links for notifications

### DIFF
--- a/config/reliefweb_subscriptions.settings.yml
+++ b/config/reliefweb_subscriptions.settings.yml
@@ -1,0 +1,2 @@
+encryption_method: 'aes-128-ctr'
+encryption_key:

--- a/docker/etc/nginx/custom/04_unsubscribe.conf
+++ b/docker/etc/nginx/custom/04_unsubscribe.conf
@@ -1,0 +1,32 @@
+## Handle unsubscribe links.
+location ^~ /notifications/unsubscribe/ {
+
+    ## One click unsubscribe links.
+    location ~ "^(?<unsubscribe_uri>/notifications/unsubscribe/[^/]+)$" {
+        error_page 418 = @one-click-unsubscribe-no-cookies;
+
+        ## Pass the request to Drupal but with the cookie header removed.
+        if ($request_method = POST) {
+            return 418;
+        }
+
+        ## Pass the request to Drupal.
+        try_files /dev/null @drupal;
+    }
+
+    ## Pass the request to Drupal.
+    try_files /dev/null @drupal;
+}
+
+## Similar to @drupal but with the cookie headers removed.
+location @one-click-unsubscribe-no-cookies {
+    ## Remove the Cookie header from the request.
+    more_clear_input_headers "Cookie";
+
+    ## Include the FastCGI config.
+    include apps/drupal/fastcgi_drupal.conf;
+    fastcgi_pass phpcgi;
+
+    ## Remove the Set-Cookie header from the response.
+    fastcgi_hide_header 'Set-Cookie';
+}

--- a/html/modules/custom/reliefweb_subscriptions/config/install/reliefweb_subscriptions.settings.yml
+++ b/html/modules/custom/reliefweb_subscriptions/config/install/reliefweb_subscriptions.settings.yml
@@ -1,0 +1,4 @@
+# Encryption method for the unsubscribe links.
+encryption_method: 'aes-128-ctr'
+# Encryption key for the unsubscribe links.
+encryption_key:

--- a/html/modules/custom/reliefweb_subscriptions/config/schema/reliefweb_subscriptions.schema.yml
+++ b/html/modules/custom/reliefweb_subscriptions/config/schema/reliefweb_subscriptions.schema.yml
@@ -1,0 +1,10 @@
+reliefweb_subscriptions.settings:
+  type: config_object
+  label: 'Reliefweb Subscriptions settings'
+  mapping:
+    encryption_method:
+      type: string
+      label: 'Encryption method for the unsubscribe links'
+    encryption_key:
+      type: string
+      label: 'Encryption key for the unsubscribe links'

--- a/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.routing.yml
+++ b/html/modules/custom/reliefweb_subscriptions/reliefweb_subscriptions.routing.yml
@@ -25,6 +25,17 @@ reliefweb_subscriptions.unsubscribe:
   requirements:
     _access: 'TRUE'
     user: \d+
+reliefweb_subscriptions.unsubscribe_one_click:
+  path: '/notifications/unsubscribe/{opaque}'
+  defaults:
+    _controller: '\Drupal\reliefweb_subscriptions\Controller\UnsubscribeController::unsubscribeOneClick'
+    _title: 'Unsubscribe'
+  methods: [POST, GET]
+  options:
+    no_cache: 'TRUE'
+  requirements:
+    _access: 'TRUE'
+    user: \d+
 reliefweb_subscriptions.unsubscription_form:
   path: '/user/{user}/notifications/unsubscribe/{timestamp}/{signature}'
   defaults:

--- a/html/modules/custom/reliefweb_subscriptions/src/Controller/UnsubscribeController.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/Controller/UnsubscribeController.php
@@ -200,7 +200,7 @@ class UnsubscribeController extends ControllerBase {
 
     return [
       '#type' => 'inline_template',
-      '#template' => '<p><strong>You have successfully unsubscribed.</strong></p><p>You will not longer receive <em>{{ subscription_label }}</em> notifications.</p><p>{{ message }}</p>',
+      '#template' => '<p><strong>You have successfully unsubscribed.</strong></p><p>You will no longer receive <em>{{ subscription_label }}</em> notifications.</p><p>{{ message }}</p>',
       '#context' => [
         'subscription_label' => $subscriptions[$sid]['name'],
         'message' => $message,

--- a/html/modules/custom/reliefweb_subscriptions/src/Controller/UnsubscribeController.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/Controller/UnsubscribeController.php
@@ -4,11 +4,17 @@ namespace Drupal\reliefweb_subscriptions\Controller;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\reliefweb_subscriptions\ReliefwebSubscriptionsMailer;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Unsubscribe controller.
@@ -25,16 +31,46 @@ class UnsubscribeController extends ControllerBase {
   /**
    * Account.
    *
-   * @var \Symfony\Component\HttpFoundation\Request
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
-  protected $request;
+  protected $requestStack;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The actual mailer.
+   *
+   * @var \Drupal\reliefweb_subscriptions\ReliefwebSubscriptionsMailer
+   */
+  protected $mailer;
 
   /**
    * {@inheritdoc}
    */
-  public function __construct(AccountInterface $account, RequestStack $request_stack) {
+  public function __construct(
+    AccountInterface $account,
+    RequestStack $request_stack,
+    Connection $database,
+    EntityTypeManagerInterface $entity_type_manager,
+    ReliefwebSubscriptionsMailer $mailer
+  ) {
     $this->account = $account;
-    $this->request = $request_stack->getCurrentRequest();
+    $this->requestStack = $request_stack;
+    $this->database = $database;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->mailer = $mailer;
   }
 
   /**
@@ -43,8 +79,41 @@ class UnsubscribeController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('current_user'),
-      $container->get('request_stack')
+      $container->get('request_stack'),
+      $container->get('database'),
+      $container->get('entity_type.manager'),
+      $container->get('reliefweb_subscriptions.mailer')
     );
+  }
+
+  /**
+   * Get the current request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   Current request.
+   */
+  public function getRequest(): Request {
+    return $this->requestStack->getCurrentRequest();
+  }
+
+  /**
+   * Get the current user.
+   *
+   * @return \Drupal\Core\Session\AccountInterface
+   *   Current user.
+   */
+  public function getCurrentUser(): AccountInterface {
+    return $this->account;
+  }
+
+  /**
+   * Get the entity type manger.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   Entity type manager.
+   */
+  public function getEntityTypeManager(): EntityTypeManagerInterface {
+    return $this->entityTypeManager;
   }
 
   /**
@@ -52,8 +121,10 @@ class UnsubscribeController extends ControllerBase {
    */
   public function unsubscribe(AccountInterface $user) {
     if ($this->account->isAnonymous()) {
-      $timestamp = $this->request->get('timestamp');
-      $signature = $this->request->get('signature');
+      $request = $this->getRequest();
+      $timestamp = $request->get('timestamp');
+      $signature = $request->get('signature');
+
       if (empty($timestamp) || empty($signature)) {
         throw new AccessDeniedHttpException();
       }
@@ -65,13 +136,76 @@ class UnsubscribeController extends ControllerBase {
       ]);
     }
 
-    if ($this->account->id() === $user->id()) {
+    if ($user->id() === $this->getCurrentUser()->id()) {
       return $this->redirect('reliefweb_subscriptions.subscription_form', [
         'user' => $user->id(),
       ]);
     }
 
     throw new AccessDeniedHttpException();
+  }
+
+  /**
+   * Unsubscribe a user (one click).
+   *
+   * @param string $opaque
+   *   Opaque data from the unsubscribe link.
+   *
+   * @return array
+   *   Render array for the page.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+   *   Bad request if the link is invalid.
+   */
+  public function unsubscribeOneClick(string $opaque): array {
+    $data = $this->mailer->decryptOneClickUnsubscribeLink($opaque);
+    if ($data === FALSE) {
+      throw new BadRequestHttpException();
+    }
+
+    [$uid, $sid] = $data;
+
+    $subscriptions = reliefweb_subscriptions_subscriptions();
+    if (!isset($subscriptions[$sid])) {
+      throw new BadRequestHttpException();
+    }
+
+    $user = $this->getEntityTypeManager()->getStorage('user')->load($uid);
+    if (is_null($user)) {
+      throw new BadRequestHttpException();
+    }
+
+    // Remove the subscription.
+    $this->database->delete('reliefweb_subscriptions_subscriptions')
+      ->condition('sid', $sid)
+      ->condition('uid', $user->id())
+      ->execute();
+
+    $subscription_page = '/user/' . $user->id() . '/notifications';
+
+    if ($user->id() === $this->getCurrentUser()->id()) {
+      $message = $this->t('To add new subscriptions or manage your list, please go to your <a href=":subscription_page">subscriptions</a> page.', [
+        ':subscription_page' => $subscription_page,
+      ]);
+    }
+    else {
+      $login_link = Url::fromRoute('user.login', [], [
+        'query' => ['destination' => $subscription_page],
+      ]);
+
+      $message = $this->t('To add new subscriptions or manage your list, please <a href=":login_link">log in</a>.', [
+        ':login_link' => $login_link->toString(),
+      ]);
+    }
+
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<p><strong>You have successfully unsubscribed.</strong></p><p>You will not longer receive <em>{{ subscription_label }}</em> notifications.</p><p>{{ message }}</p>',
+      '#context' => [
+        'subscription_label' => $subscriptions[$sid]['name'],
+        'message' => $message,
+      ],
+    ];
   }
 
   /**


### PR DESCRIPTION
Refs: RW-885

This replaces the current unsubscribe links with one-click unsubscribe links.

It also adds the proper List-Unsubscribe* headers and removes cookie headers for the POST requests.

## Tests

**Notes** 

- Make sure you have the local stack with mailpit or another tool the RW drupal site can send emails to.
- Make sure you have an instance of the RW API and that the RW local site can index content in it.

**Steps**

1. Checkout the branch, clear the cache, import the config
2. Truncate the subscriptions table: `drush sql-query "TRUNCATE reliefweb_subscriptions_subscriptions"`, `drush sql-query "TRUNCATE reliefweb_subscriptions_queue"`, `drush sql-query "TRUNCATE reliefweb_subscriptions_logs"`
3. Log in, go to your subscriptions page `/user/notifications`, subscribe to the headlines.
4. Create a new headline report, save
5. Run `drush reliefweb_subscriptions:queue -v headlines` then `drush reliefweb_subscriptions:send -d -v`
6. Open the RW mailpit instance, check the email, there should be `Unsubscribe` at the end of the `From` line at the top when opening the email, check there is no red icon (which means it's working). Click on it to reveal the unsubscribe info.
7. Copy the unsubscribe url (without the surrounding `<>`).
8. Run `curl -XPOST "unsubcribe-url-from-above"`
9. Check your subscriptions tab and confirm you are not subscribed to the headlines anymore