### PR TITLE
[RW-938] Log manual changes to AI tagging

### DIFF
--- a/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
+++ b/html/modules/custom/reliefweb_job_tagger/reliefweb_job_tagger.module
@@ -220,6 +220,8 @@ function reliefweb_job_tagger_node_presave(EntityInterface $node) {
 
   // Skip queued and processed nodes.
   if ($node->hasField('reliefweb_job_tagger_status')) {
+    reliefweb_job_tagger_log_manual_changes_to_tagging($node);
+
     if ($node->reliefweb_job_tagger_status->value == 'queued' || $node->reliefweb_job_tagger_status->value == 'processed') {
       return;
     }
@@ -256,6 +258,51 @@ function reliefweb_job_tagger_node_presave(EntityInterface $node) {
     $log_message = $node->getRevisionLogMessage();
     $log_message .= (empty($log_message) ? '' : ' ') . 'Job has been queued for tagging.';
     $node->setRevisionLogMessage($log_message);
+  }
+}
+
+/**
+ * Check for manual changes to the AI tagging and log them.
+ *
+ * @param \Drupal\Entity\EntityInterface $entity
+ *   Changed entity.
+ */
+function reliefweb_job_tagger_log_manual_changes_to_tagging(EntityInterface $entity) {
+  if (!isset($entity->original) || !$entity->original->hasField('reliefweb_job_tagger_status')) {
+    return;
+  }
+  $original = $entity->original;
+
+  // Skip if the original was not processed by the AI.
+  if ($original->reliefweb_job_tagger_status->value !== 'processed') {
+    return;
+  }
+
+  $editor = UserHelper::userHasRoles(['editor']);
+  $logger = \Drupal::logger('reliefweb_job_tagger');
+
+  $fields = [
+    'field_theme',
+    'field_career_categories',
+  ];
+
+  foreach ($fields as $field) {
+    if ($entity->hasField($field) && !$entity->get($field)->equals($original->get($field))) {
+      $old = [];
+      $new = [];
+      foreach ($original->get($field) as $item) {
+        $old[] = $item->entity?->label() ?? $item->target_id;
+      }
+      foreach ($entity->get($field) as $item) {
+        $new[] = $item->entity?->label() ?? $item->target_id;
+      }
+      $logger->info(strtr('Manual change to the @field tagging by @user: @old --> @new', [
+        '@field' => $field,
+        '@user' => $editor ? 'editor' : 'non editor',
+        '@old' => implode(', ', $old),
+        '@new' => implode(', ', $new),
+      ]));
+    }
   }
 }
 

--- a/html/modules/custom/reliefweb_reporting/reliefweb_reporting.module
+++ b/html/modules/custom/reliefweb_reporting/reliefweb_reporting.module
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * ReliefWeb reporting module.
+ */
+
+/**
+ * Implements hook_mail().
+ */
+function reliefweb_reporting_mail(string $key, array &$message, array $params) {
+  if ($key !== 'reporting') {
+    return;
+  }
+
+  // Copy any extra headers (like the List-ID to identify the notification).
+  foreach ($params['headers'] as $key => $value) {
+    $message['headers'][$key] = $value;
+  }
+
+  // Ensure the Reply-To header is set and not duplicated due to different case.
+  $reply_to = $message['from'];
+  foreach (['reply-to', 'Reply-to', 'Reply-To'] as $key) {
+    if (isset($message['headers'][$key])) {
+      $reply_to = $message['headers'][$key];
+      unset($message['headers'][$key]);
+    }
+  }
+  $message['headers']['Reply-To'] = $reply_to;
+
+  // Set the attachments.
+  if (isset($params['attachments'])) {
+    $message['params']['attachments'] = $params['attachments'];
+  }
+
+  $message['subject'] = $params['subject'];
+  $message['body'] = $params['body'];
+}

--- a/html/modules/custom/reliefweb_reporting/src/Commands/ReliefWebReportingCommands.php
+++ b/html/modules/custom/reliefweb_reporting/src/Commands/ReliefWebReportingCommands.php
@@ -323,6 +323,160 @@ class ReliefWebReportingCommands extends DrushCommands {
   }
 
   /**
+   * Send weekly statistics about the AI tagging.
+   *
+   * @param string $recipients
+   *   Comma delimited list of recipients for the report email.
+   *
+   * @command reliefweb_reporting:send-weekly-ai-tagging-stats
+   *
+   * @usage reliefweb_reporting:send-weekly-ai-tagging-stats
+   *   Send weekly statistics about the AI tagging.
+   *
+   * @validate-module-enabled reliefweb_reporting
+   */
+  public function sendWeeklyAiTaggingStats($recipients) {
+    if (!empty($this->state->get('system.maintenance_mode', 0))) {
+      $this->logger()->warning(dt('Maintenance mode, aborting.'));
+      return TRUE;
+    }
+
+    if (empty($recipients)) {
+      $this->logger()->error(dt('Missing recipients.'));
+      return FALSE;
+    }
+
+    $from = $this->configFactory->get('system.site')->get('mail') ?? ini_get('sendmail_from');
+    if (empty($from)) {
+      $this->logger()->error(dt('Missing from address.'));
+      return FALSE;
+    }
+
+    // Format the from to include ReliefWeb if not already.
+    if (strpos($from, '<') === FALSE) {
+      $from = strtr('@sitename <@sitemail>', [
+        '@sitename' => $this->configFactory->get('system.site')->get('name') ?? 'ReliefWeb',
+        '@sitemail' => $from,
+      ]);
+    }
+
+    $recipients = implode(', ', preg_split('/,\s*/', trim($recipients)));
+
+    $last_sunday = strtotime('last sunday', time());
+    $last_week_sunday = strtotime('last sunday', $last_sunday);
+    $formatted_last_sunday = gmdate('Y-m-d', $last_sunday);
+    $formatted_last_week_sunday = gmdate('Y-m-d', $last_week_sunday);
+
+    $filename = "job-ai-tagging-stats-$formatted_last_week_sunday-$formatted_last_sunday.csv";
+    $subject = "Weekly job AI tagging stats - $formatted_last_week_sunday to $formatted_last_sunday";
+    $headers = [
+      'From' => $from,
+      'Reply-To' => $from,
+      'Content-Type' => 'text/plain; charset=utf-8',
+      'Content-Disposition' => 'inline',
+      'MIME-Version' => '1.0',
+    ];
+
+    $records = $this->database->query("
+      SELECT
+        nr.nid AS nid,
+        nr.vid As vid,
+        IFNULL(GROUP_CONCAT(DISTINCT ur.roles_target_id ORDER BY ur.roles_target_id SEPARATOR ','), '') AS roles,
+        GROUP_CONCAT(DISTINCT nfcc.field_career_categories_target_id ORDER BY nfcc.field_career_categories_target_id SEPARATOR ',') AS career_categories,
+        GROUP_CONCAT(DISTINCT nft.field_theme_target_id ORDER BY nft.field_theme_target_id SEPARATOR ',') AS themes
+      FROM node_revision AS nr
+      INNER JOIN node_field_data AS n
+        ON n.nid = nr.nid
+      INNER JOIN node_revision__reliefweb_job_tagger_status AS njts
+        ON njts.entity_id = n.nid
+        AND njts.revision_id = nr.vid
+        AND njts.reliefweb_job_tagger_status_value = 'processed'
+      LEFT JOIN user__roles AS ur
+        ON ur.entity_id = nr.revision_uid
+      LEFT JOIN node_revision__field_career_categories AS nfcc
+        ON nfcc.entity_id = nr.nid
+        AND nfcc.revision_id = nr.vid
+      LEFT JOIN node_revision__field_theme AS nft
+        ON nft.entity_id = nr.nid
+        AND nft.revision_id = nr.vid
+      WHERE n.type = 'job'
+        AND n.created >= UNIX_TIMESTAMP(DATE_SUB(DATE(NOW()), INTERVAL DAYOFWEEK(NOW()) + 6 DAY))
+        AND n.created < UNIX_TIMESTAMP(DATE_SUB(DATE(NOW()), INTERVAL DAYOFWEEK(NOW()) - 1 DAY))
+      GROUP BY nr.vid
+      ORDER BY nr.vid
+    ")->fetchAll(\PDO::FETCH_ASSOC);
+
+    $attachments = [];
+
+    if (empty($records)) {
+      $body = 'No jobs tagged by AI this week.';
+    }
+    else {
+      $jobs = [];
+      $changed_career_categories = [];
+      $changed_themes = [];
+
+      foreach ($records as $record) {
+        $nid = $record['nid'];
+
+        if (isset($jobs[$nid])) {
+          $previous = $jobs[$nid];
+
+          if (strpos($record['roles'], 'editor') !== FALSE) {
+            if ($record['career_categories'] !== $previous['career_categories']) {
+              $changed_career_categories[$nid] = TRUE;
+            }
+            if ($record['themes'] !== $previous['themes']) {
+              $changed_themes[$nid] = TRUE;
+            }
+          }
+        }
+
+        $jobs[$nid] = $record;
+      }
+
+      $data = [
+        'jobs_tagged_by_ai' => count($jobs),
+        'career_categories_changed_by_editors' => count($changed_career_categories),
+        'themes_changed_by_editors' => count($changed_themes),
+      ];
+
+      // Convert to CSV.
+      $handle = fopen('php://memory', 'r+');
+      fputcsv($handle, array_keys($data), "\t");
+      fputcsv($handle, array_values($data), "\t");
+      rewind($handle);
+      $csv = trim(stream_get_contents($handle));
+      fclose($handle);
+
+      $body = "Attachment: $filename";
+
+      $attachments[] = [
+        'filecontent' => $csv,
+        'filename' => $filename,
+        'filemime' => 'text/csv',
+      ];
+    }
+
+    // Send the email.
+    $message = $this->sendMail($from, $recipients, $subject, $body, $headers, $attachments);
+    if (!empty($message['result'])) {
+      $this->logger->info(dt('"@subject" sent to @recipients', [
+        '@subject' => $subject,
+        '@recipients' => $recipients,
+      ]));
+    }
+    else {
+      $this->logger->error(dt('Unable to send "@subject" to @recipients', [
+        '@subject' => $subject,
+        '@recipients' => $recipients,
+      ]));
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Send an email.
    *
    * @param string $from


### PR DESCRIPTION
Refs: RW-938

This adds some logging of the manual changes made to jobs tagged by the AI.

It also adds a drush command to the reporting module to send weekly stats about the AI tagging (number of tagged jobs, number of jobs with themes/career categories changed manually).
