### PR TITLE
[RW-940] Prevent parsing reference links when converting revision logs

### DIFF
--- a/html/modules/custom/reliefweb_utility/src/Helpers/MarkdownHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/MarkdownHelper.php
@@ -187,6 +187,9 @@ class MarkdownHelper {
       ],
     ];
 
+    // Prevent link references `[foo]: /url` from being parsed.
+    $text = preg_replace('#^(\s*)\[([^]]+)\]:(\s+)#', '$1\[$2\]:$3', $text);
+
     // Create an Environment with all the CommonMark parsers and renderers for
     // inline elements.
     $environment = new Environment($config);

--- a/html/modules/custom/reliefweb_utility/tests/src/Unit/MarkdownHelperTest.php
+++ b/html/modules/custom/reliefweb_utility/tests/src/Unit/MarkdownHelperTest.php
@@ -97,4 +97,17 @@ class MarkdownHelperTest extends UnitTestCase {
     ];
   }
 
+  /**
+   * @covers \Drupal\reliefweb_utility\Helpers\MarkdownHelper::convertInlinesOnly
+   */
+  public function testConvertInlinesOnly() {
+    $text = "test [link](https://test.test)\n\nthis **not** a paragraph\n\n* list item 1\n* list item 2\n";
+    $expected = "test <a rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://test.test\">link</a>\n\nthis <strong>not</strong> a paragraph\n\n* list item 1\n* list item 2\n";
+    $this->assertEquals($expected, MarkdownHelper::convertInlinesOnly($text));
+
+    $text = "[test]: /test";
+    $expected = "[test]: /test\n";
+    $this->assertEquals($expected, MarkdownHelper::convertInlinesOnly($text));
+  }
+
 }


### PR DESCRIPTION
Refs: RW-940

Prevent parsing markdown **reference links**: `[foo]: /url` when displaying revision logs.