### PR TITLE
[Rw-939] Add patch to prevent php notice from Drupal core PHP mailer

### DIFF
--- a/PATCHES/core--drupal--3418098-php-mailer.patch
+++ b/PATCHES/core--drupal--3418098-php-mailer.patch
@@ -1,0 +1,13 @@
+diff --git a/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php b/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php
+index 09a56006a6..1767dc4875 100644
+--- a/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php
++++ b/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php
+@@ -113,7 +113,7 @@ public function mail(array $message) {
+     $mail_body = preg_replace('@\r?\n@', $line_endings, $message['body']);
+     $mail_headers = $headers->toString();
+ 
+-    if (!$this->request->server->has('WINDIR') && !str_contains($this->request->server->get('SERVER_SOFTWARE'), 'Win32')) {
++    if (!$this->request->server->has('WINDIR') && !str_contains($this->request->server->get('SERVER_SOFTWARE', ''), 'Win32')) {
+       // On most non-Windows systems, the "-f" option to the sendmail command
+       // is used to set the Return-Path. There is no space between -f and
+       // the value of the return path.

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -6,7 +6,8 @@
         "drupal/core" : {
             "https://www.drupal.org/project/drupal/issues/3047110": "PATCHES/core--drupal--3047110-taxonomy-term-moderation-class.patch",
             "https://www.drupal.org/project/drupal/issues/3008292": "PATCHES/core--drupal--3008292-image-upload-validators.patch",
-            "https://www.drupal.org/project/drupal/issues/3143617": "PATCHES/core--drupal--3143617-pager-parameter.patch"
+            "https://www.drupal.org/project/drupal/issues/3143617": "PATCHES/core--drupal--3143617-pager-parameter.patch",
+            "https://www.drupal.org/project/drupal/issues/3418098": "PATCHES/core--drupal--3418098-php-mailer.patch"
         },
         "drupal/guidelines": {
             "Drupal 10 compatibility": "PATCHES/guidelines-drupal-10-compatibility.patch"


### PR DESCRIPTION
Refs: RW-939

Tiny patch to avoid the following PHP notice when sending emails:

> str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in docroot/core/lib/Drupal/Core/Mail/Plugin/Mail/PhpMail.php line 114