### PR TITLE
[RW-885] No need for personalized subscriptions page destination

### DIFF
--- a/html/modules/custom/reliefweb_subscriptions/src/Controller/UnsubscribeController.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/Controller/UnsubscribeController.php
@@ -181,7 +181,7 @@ class UnsubscribeController extends ControllerBase {
       ->condition('uid', $user->id())
       ->execute();
 
-    $subscription_page = '/user/' . $user->id() . '/notifications';
+    $subscription_page = '/user/notifications';
 
     if ($user->id() === $this->getCurrentUser()->id()) {
       $message = $this->t('To add new subscriptions or manage your list, please go to your <a href=":subscription_page">subscriptions</a> page.', [

--- a/html/modules/custom/reliefweb_subscriptions/src/Form/UnsubscribeForm.php
+++ b/html/modules/custom/reliefweb_subscriptions/src/Form/UnsubscribeForm.php
@@ -107,7 +107,7 @@ class UnsubscribeForm extends SubscriptionForm {
     ];
 
     $login_link = Url::fromRoute('user.login', [], [
-      'query' => ['destination' => '/user/' . $user->id() . '/notifications'],
+      'query' => ['destination' => '/user/notifications'],
     ]);
 
     $form['description'] = [


### PR DESCRIPTION
Refs: RW-885

The `/user/notifications` already redirects to the `/user/{uid}/notifications` page when logged in so let's avoid exposing the user ID unnecessarily.