### PR TITLE
[RW-796] Allow use of the rich editor for reports

### DIFF
--- a/config/core.entity_form_display.node.report.default.yml
+++ b/config/core.entity_form_display.node.report.default.yml
@@ -34,23 +34,22 @@ dependencies:
     - datetime
     - inline_entity_form
     - path
-    - reliefweb_files
     - reliefweb_fields
-    - text
+    - reliefweb_files
 id: node.report.default
 targetEntityType: node
 bundle: report
 mode: default
 content:
   body:
-    type: text_textarea_with_summary
+    type: reliefweb_formatted_text
     weight: 2
     region: content
     settings:
+      max_heading_level: 2
+      strip_embedded_content: true
       rows: 20
-      summary_rows: 3
       placeholder: ''
-      show_summary: false
     third_party_settings:
       allowed_formats:
         hide_help: '0'
@@ -196,6 +195,7 @@ content:
       collapsible: false
       collapsed: false
       revision: false
+      removed_reference: optional
     third_party_settings: {  }
   field_headline_summary:
     type: string_textarea
@@ -229,6 +229,7 @@ content:
       collapsible: false
       collapsed: true
       revision: false
+      removed_reference: optional
     third_party_settings: {  }
   field_language:
     type: options_buttons

--- a/config/editor.editor.markdown.yml
+++ b/config/editor.editor.markdown.yml
@@ -1,0 +1,12 @@
+uuid: 1ba50662-d847-4924-b8d2-e61456ceab6f
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.markdown
+  module:
+    - reliefweb_fields
+format: markdown
+editor: reliefweb_markdown_editor
+settings: {  }
+image_upload: {  }

--- a/config/editor.editor.markdown_editor.yml
+++ b/config/editor.editor.markdown_editor.yml
@@ -16,6 +16,7 @@ settings:
       - heading
       - '|'
       - link
+      - blockQuote
       - '|'
       - bulletedList
       - numberedList

--- a/config/field.field.node.report.body.yml
+++ b/config/field.field.node.report.body.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.body
     - filter.format.markdown
+    - filter.format.markdown_editor
     - node.type.report
   module:
     - text
@@ -13,7 +14,7 @@ field_name: body
 entity_type: node
 bundle: report
 label: Body
-description: ''
+description: 'To add image tracking code (ex: <code>&lt;img src="..."&gt;</code> for The Conversation source), please use the <strong>Markdown</strong> text format.'
 required: false
 translatable: true
 default_value: {  }
@@ -22,5 +23,6 @@ settings:
   display_summary: false
   required_summary: false
   allowed_formats:
+    - markdown_editor
     - markdown
 field_type: text_with_summary

--- a/config/filter.format.guideline.yml
+++ b/config/filter.format.guideline.yml
@@ -10,7 +10,7 @@ dependencies:
     - reliefweb_utility
 name: Guideline
 format: guideline
-weight: 0
+weight: -5
 filters:
   editor_file_reference:
     id: editor_file_reference

--- a/config/filter.format.html.yml
+++ b/config/filter.format.html.yml
@@ -7,7 +7,7 @@ dependencies:
     - reliefweb_utility
 name: HTML
 format: html
-weight: -8
+weight: -7
 filters:
   filter_align:
     id: filter_align

--- a/config/filter.format.markdown.yml
+++ b/config/filter.format.markdown.yml
@@ -7,7 +7,7 @@ dependencies:
     - reliefweb_utility
 name: Markdown
 format: markdown
-weight: -10
+weight: -9
 filters:
   filter_align:
     id: filter_align

--- a/config/filter.format.markdown_editor.yml
+++ b/config/filter.format.markdown_editor.yml
@@ -8,9 +8,9 @@ dependencies:
     - reliefweb_fields
     - reliefweb_guidelines
     - reliefweb_utility
-name: 'Markdown with Editor'
+name: 'Rich Editor'
 format: markdown_editor
-weight: -6
+weight: -10
 filters:
   editor_file_reference:
     id: editor_file_reference
@@ -48,7 +48,7 @@ filters:
     status: true
     weight: -49
     settings:
-      allowed_html: '<br> <p> <h2> <h3> <h4> <h5> <h6> <strong> <em> <a href> <ul> <ol> <li>'
+      allowed_html: '<br> <p> <h2> <h3> <h4> <h5> <h6> <strong> <em> <blockquote> <a href> <ul> <ol> <li>'
       filter_html_help: false
       filter_html_nofollow: true
   filter_html_escape:

--- a/config/filter.format.plain_text.yml
+++ b/config/filter.format.plain_text.yml
@@ -6,7 +6,7 @@ _core:
   default_config_hash: NIKBt6kw_uPhNI0qtR2DnRf7mSOgAQdx7Q94SKMjXbQ
 name: 'Plain text'
 format: plain_text
-weight: -9
+weight: -8
 filters:
   filter_autop:
     id: filter_autop

--- a/config/filter.format.token_markdown.yml
+++ b/config/filter.format.token_markdown.yml
@@ -7,7 +7,7 @@ dependencies:
     - reliefweb_utility
 name: 'Token & Markdown'
 format: token_markdown
-weight: -7
+weight: -6
 filters:
   filter_align:
     id: filter_align

--- a/html/modules/custom/reliefweb_fields/README.md
+++ b/html/modules/custom/reliefweb_fields/README.md
@@ -35,6 +35,12 @@ This module provides custom field types, widgets, formatters and related plugins
 
 This module provides a [CKEditor 5 plugin](js/plugins/reliefweb_formatted_text/plugin.js) enabled when using a `ReliefWebFormattedText` widget to limit selectable headings and handle their conversion.
 
+## ReliefWeb Markdown Editor
+
+This module provides a [Text editor](src/Plugin/Editor/ReliefWebMarkdownEditor.php) that does nothing special but allows to hook into the behavior of the core editor module and convert markdown to or from HTML when switching text formats in the forms.
+
+There is also a XSS filtering class to help with that. See details in [comments](src/EditorXssFilter/ReliefWebMarkdownXssFilter.php).
+
 ## Forms
 
 This module provides 2 entity form controllers for the `user_posting_rights` form view mode of sources and the `profile` form view mode of countries and disasters.

--- a/html/modules/custom/reliefweb_fields/js/reliefweb_markdown_editor.js
+++ b/html/modules/custom/reliefweb_fields/js/reliefweb_markdown_editor.js
@@ -1,0 +1,58 @@
+/**
+ * @file
+ * ReliefWeb Markdown editor implementation of {@link Drupal.editors} API.
+ */
+((Drupal) => {
+
+  'use strict';
+
+  /**
+   * Integration with the Drupal editor API.
+   *
+   * @namespace
+   *
+   * @see Drupal.editorAttach
+   */
+  Drupal.editors['reliefweb_markdown_editor'] = {
+
+    /**
+     * Editor attach callback.
+     *
+     * @param {HTMLElement} element
+     *   The element to attach the editor to.
+     * @param {string} format
+     *   The text format for the editor.
+     */
+    attach(element, format) {
+      // Nothing to do.
+    },
+
+    /**
+     * Editor detach callback.
+     *
+     * @param {HTMLElement} element
+     *   The element to detach the editor from.
+     * @param {string} format
+     *   The text format used for the editor.
+     * @param {string} trigger
+     *   The event trigger for the detach.
+     */
+    detach(element, format, trigger) {
+      // Nothing to do.
+    },
+
+    /**
+     * Registers a callback which CKEditor 5 will call on change:data event.
+     *
+     * @param {HTMLElement} element
+     *   The element where the change occurred.
+     * @param {function} callback
+     *   Callback called with the value of the editor.
+     */
+    onChange(element, callback) {
+      // Nothing to do.
+    }
+
+  };
+
+})(Drupal);

--- a/html/modules/custom/reliefweb_fields/reliefweb_fields.libraries.yml
+++ b/html/modules/custom/reliefweb_fields/reliefweb_fields.libraries.yml
@@ -29,3 +29,11 @@ reliefweb-options:
 ckeditor5.reliefweb_formatted_text:
   js:
     js/plugins/reliefweb_formatted_text/plugin.js: {}
+
+reliefweb.editor.markdown:
+  js:
+    js/reliefweb_markdown_editor.js: {}
+  dependencies:
+    - core/once
+    - core/drupal
+    - editor/drupal.editor

--- a/html/modules/custom/reliefweb_fields/reliefweb_fields.module
+++ b/html/modules/custom/reliefweb_fields/reliefweb_fields.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\filter\FilterFormatInterface;
 use Drupal\reliefweb_fields\Plugin\Field\FieldWidget\ReliefWebLinks;
 use Drupal\reliefweb_fields\Plugin\Field\FieldWidget\ReliefWebUserPostingRights;
 
@@ -43,4 +44,22 @@ function reliefweb_fields_user_update(EntityInterface $entity) {
  */
 function reliefweb_fields_user_delete(EntityInterface $entity) {
   ReliefWebUserPostingRights::updateFields('delete', $entity);
+}
+
+/**
+ * Implements hook_editor_xss_filter_alter().
+ *
+ * Change the filter XSS class so that we can also convert the text from
+ * markdown to HTML or the opposite.
+ *
+ * @see editor_filter_xss()
+ * @see \Drupal\reliefweb_fields\EditorXssFilter\ReliefWebMarkdownXssFilter::filterXss()
+ */
+function reliefweb_fields_editor_xss_filter_alter(string &$editor_xss_filter_class, FilterFormatInterface $format, FilterFormatInterface $original_format = NULL) {
+  if (
+    editor_load($format->id())?->getEditor() === 'reliefweb_markdown_editor' ||
+    !empty($format->filters('reliefweb_formatted_text')?->status)
+  ) {
+    $editor_xss_filter_class = '\Drupal\reliefweb_fields\EditorXssFilter\ReliefWebMarkdownXssFilter';
+  }
 }

--- a/html/modules/custom/reliefweb_fields/src/EditorXssFilter/ReliefWebMarkdownXssFilter.php
+++ b/html/modules/custom/reliefweb_fields/src/EditorXssFilter/ReliefWebMarkdownXssFilter.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\reliefweb_fields\EditorXssFilter;
+
+use Drupal\editor\EditorXssFilter\Standard;
+use Drupal\filter\FilterFormatInterface;
+use Drupal\reliefweb_utility\Helpers\HtmlSanitizer;
+use Drupal\reliefweb_utility\Helpers\TextHelper;
+use Drupal\reliefweb_utility\HtmlToMarkdown\Converters\TextConverter;
+use League\HTMLToMarkdown\HtmlConverter;
+
+/**
+ * Defines the standard text editor XSS filter.
+ */
+class ReliefWebMarkdownXssFilter extends Standard {
+
+  /**
+   * {@inheritdoc}
+   *
+   * In addition to the XSS filtering, we convert the editor content (`$html)
+   * from HTML to markdown or the opposite when the text format is changed via
+   * the UI.
+   *
+   * Drupal doesn't provide many hooks to be able to do handle text format
+   * changes made via the UI. The UI notably shows a confirmation popup to
+   * possibly cancel the text format change.
+   *
+   * As a result we cannot use drupal form ajax API because we cannot detect the
+   * cancellation.
+   *
+   * The only way to act on the content when the text format actually changes is
+   * to leverage the call to the `editor.filter_xss` route which is used to
+   * sanitize the text before passing it to the new text format's editor.
+   *
+   * For that, we check the current route and if it's the XSS filtering one from
+   * the editor then we convert the editor's content if appropriate.
+   *
+   * It's important to filter on the route because the XSS filtering is also
+   * done when saving the entity form in which case we would possibly get an
+   * extra unwanted conversion.
+   *
+   * @see editor_filter_xss()
+   * @see editor/drupal.editor
+   */
+  public static function filterXss($html, FilterFormatInterface $format, FilterFormatInterface $original_format = NULL) {
+    $destination_editor = editor_load($format->id())?->getEditor();
+    $from_ui = \Drupal::request()->attributes->get('_route') === 'editor.filter_xss';
+
+    // No conversion if the this is called outside of a form or there is only
+    // text format provided.
+    if (!$from_ui || is_null($original_format) || $format->id() === $original_format->id()) {
+      // The `reliefweb_markdown_editor` handles only plain text so is XSS safe.
+      if ($destination_editor === 'reliefweb_markdown_editor') {
+        return $html;
+      }
+      else {
+        return parent::filterXss($html, $format, $original_format);
+      }
+    }
+
+    $source_editor = editor_load($original_format->id())?->getEditor();
+
+    // The `reliefweb_markdown_editor` editor is a dummy editor (not change to
+    // the textarea) that accepts markdown/plain text as content.
+    $source_is_markdown = $source_editor === 'reliefweb_markdown_editor';
+    $destination_is_markdown = $destination_editor === 'reliefweb_markdown_editor';
+
+    // The `reliefweb_formatted_text` filter is used to flag a text format so
+    // that the HTML content from its editor (ex: CKEditor 5) is converted to
+    // markdown when saved.
+    $source_is_html = !empty($original_format->filters('reliefweb_formatted_text')?->status);
+    $destination_is_html = !empty($format->filters('reliefweb_formatted_text')?->status);
+
+    // Convert HTML to markdown.
+    if ($source_is_html && $destination_is_markdown) {
+      // Filter XSS.
+      $html = parent::filterXss($html, $format, $original_format);
+
+      // Sanitize the HTML string.
+      // @todo how to retrieve the heading offset from the widget?
+      $html = HtmlSanitizer::sanitize($html, FALSE, 1);
+
+      // Remove embedded content.
+      // @todo how to retrieve whether to strip or not embedded content
+      // from the widget?
+      $html = TextHelper::stripEmbeddedContent($html);
+
+      // Convert to markdown.
+      $converter = new HtmlConverter();
+      $converter->getConfig()->setOption('strip_tags', TRUE);
+      $converter->getConfig()->setOption('use_autolinks', FALSE);
+      $converter->getConfig()->setOption('header_style', 'atx');
+      $converter->getConfig()->setOption('strip_placeholder_links', TRUE);
+
+      // Use our own text converter to avoid unwanted character escaping.
+      $converter->getEnvironment()->addConverter(new TextConverter());
+
+      $html = trim($converter->convert($html));
+    }
+    // Convert markdown to HTML.
+    elseif ($source_is_markdown && $destination_is_html) {
+      // XSS filtering is included in the conversion.
+      $html = check_markup($html, $format->id());
+    }
+
+    return $html;
+  }
+
+}

--- a/html/modules/custom/reliefweb_fields/src/Plugin/Editor/ReliefWebMarkdownEditor.php
+++ b/html/modules/custom/reliefweb_fields/src/Plugin/Editor/ReliefWebMarkdownEditor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\reliefweb_fields\Plugin\Editor;
+
+use Drupal\editor\Entity\Editor;
+use Drupal\editor\Plugin\EditorBase;
+
+/**
+ * Defines a markdown text editor for Drupal.
+ *
+ * @Editor(
+ *   id = "reliefweb_markdown_editor",
+ *   label = @Translation("ReliefWeb markdown editor"),
+ *   supports_content_filtering = TRUE,
+ *   supports_inline_editing = FALSE,
+ *   is_xss_safe = FALSE,
+ *   supported_element_types = {
+ *     "textarea"
+ *   }
+ * )
+ *
+ * @internal
+ *   Plugin classes are internal.
+ */
+class ReliefWebMarkdownEditor extends EditorBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * phpcs:disable Drupal.NamingConventions.ValidFunctionName
+   */
+  public function getJSSettings(Editor $editor) {
+    // phpcs:enable Drupal.NamingConventions.ValidFunctionName
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLibraries(Editor $editor) {
+    return [
+      'reliefweb_fields/reliefweb.editor.markdown',
+    ];
+  }
+
+}

--- a/html/modules/custom/reliefweb_utility/src/Plugin/Filter/MarkdownFilter.php
+++ b/html/modules/custom/reliefweb_utility/src/Plugin/Filter/MarkdownFilter.php
@@ -18,7 +18,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *
  * @Filter(
  *   id = "filter_markdown",
- *   title = @Translation("Convert a markdown text to HTML"),
+ *   title = @Translation("Convert markdown to HTML"),
+ *   description = @Translation("Convert a markdown text to HTML"),
  *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_IRREVERSIBLE,
  *   weight = -20
  * )

--- a/html/themes/custom/common_design_subtheme/css/typography.css
+++ b/html/themes/custom/common_design_subtheme/css/typography.css
@@ -164,3 +164,13 @@ code {
   background: var(--cd-reliefweb-brand-grey--light);
   font-family: monospace;
 }
+
+blockquote {
+  overflow: hidden;
+  margin-right: 0;
+  margin-left: 0;
+  padding-right: 1.5rem;
+  padding-left: 1.5rem;
+  border-left: 5px solid var(--cd-reliefweb-brand-grey--light);
+  font-style: italic;
+}


### PR DESCRIPTION
Refs: RW-796

This sets the rich editor text format (ckeditor5 with some markdown conversion) as the default text format for reports similar to the jobs and training.

The default text format for existing content is still the `markdown` one to avoid losing data (the text can contain some extra stuff like image tracking code etc. tables which are really uncommon) but new reports use the `rich editor` text format.

To be able to switch between text formats without losing most of the content, this PR introduces some hack to convert the text between HTML (ckeditor 5) and markdown (textarea). See the comment in the `ReliefWebMarkdownXssFilter.php` file for mode details.

Jobs/training still continue to only use the Rich editor and should be unaffected by those changes (except for the addition of the blockquote option).

## Tests

**New report**

1. Log in as an editor
2. Create a report, confirm the body uses the `Rich editor` text editor
3. Add some content with bold, links etc.
4. Switch the text format to `markdown` and confirm the markdown text seems correct
5. Switch back to `Rich editor` and confirm the HTML is the same as (3)
6. Fill the rest of the mandatory fields
7. Save
8. Check the revision history at the bottom and confirm that the `body` is in markdown format
9. Edit again the report
10. Check that the text format is `Rich editor` and the body content seems correct
11. Switch to `markdown`
12. Change something in the title for example to see a new entry in the revision history
13. Save
14. Confirm that the revision history shows the same body (markdown) and that the content on the page is correct

**Old report**

1. Edit an old report (published before this PR)
2. Confirm that the text format is `markdown`
3. Save and confirm there is no new entry in the revision history or at least than the body is the same
4. Edit the report
5. Switch to `Rich editor`
6. Check that the content seems correct
7. Save, check the revision history has a new entry and that the markdown of the body is mostly the same as before


**Jobs/training**

1. Create a new job
2. Check that the body and how to apply use the rich editor **and** that there no text format selector
3. Fill in the form
4. Save, check that everything looks correct
5. Edit an existing job, change something in the body, save and check that everything is correct
6. Repeat the above for training

**Blog**

Edit a blog and confirm that only markdown or HTML are available as text formats (the rich editor may be added later after this PR is reviewed and validated).