### PR TITLE
feat: Re-use the ai job tagging stats for N8N-centric reporting.

### DIFF
--- a/html/modules/custom/reliefweb_reporting/reliefweb_reporting.module
+++ b/html/modules/custom/reliefweb_reporting/reliefweb_reporting.module
@@ -36,3 +36,77 @@ function reliefweb_reporting_mail(string $key, array &$message, array $params) {
   $message['subject'] = $params['subject'];
   $message['body'] = $params['body'];
 }
+
+/**
+ * Generate weekly AI tagging statistics.
+ */
+function reliefweb_reporting_get_weekly_ai_tagging_stats() {
+  $data = [];
+  $connection = \Drupal::database();
+
+  $records = $connection->query("
+    SELECT
+      nr.nid AS nid,
+      nr.vid As vid,
+      IFNULL(GROUP_CONCAT(DISTINCT ur.roles_target_id ORDER BY ur.roles_target_id SEPARATOR ','), '') AS roles,
+      GROUP_CONCAT(DISTINCT nfcc.field_career_categories_target_id ORDER BY nfcc.field_career_categories_target_id SEPARATOR ',') AS career_categories,
+      GROUP_CONCAT(DISTINCT nft.field_theme_target_id ORDER BY nft.field_theme_target_id SEPARATOR ',') AS themes
+    FROM node_revision AS nr
+    INNER JOIN node_field_data AS n
+      ON n.nid = nr.nid
+    INNER JOIN node_revision__reliefweb_job_tagger_status AS njts
+      ON njts.entity_id = n.nid
+      AND njts.revision_id = nr.vid
+      AND njts.reliefweb_job_tagger_status_value = 'processed'
+    LEFT JOIN user__roles AS ur
+      ON ur.entity_id = nr.revision_uid
+    LEFT JOIN node_revision__field_career_categories AS nfcc
+      ON nfcc.entity_id = nr.nid
+      AND nfcc.revision_id = nr.vid
+    LEFT JOIN node_revision__field_theme AS nft
+      ON nft.entity_id = nr.nid
+      AND nft.revision_id = nr.vid
+    WHERE n.type = 'job'
+      AND n.created >= UNIX_TIMESTAMP(DATE_SUB(DATE(NOW()), INTERVAL DAYOFWEEK(NOW()) + 6 DAY))
+      AND n.created < UNIX_TIMESTAMP(DATE_SUB(DATE(NOW()), INTERVAL DAYOFWEEK(NOW()) - 1 DAY))
+    GROUP BY nr.vid
+    ORDER BY nr.vid
+  ")->fetchAll(\PDO::FETCH_ASSOC);
+
+  if (empty($records)) {
+    return $data;
+  }
+
+  $jobs = [];
+  $changed_career_categories = [];
+  $changed_themes = [];
+
+  // Group the records into the categories we want to report.
+  foreach ($records as $record) {
+    $nid = $record['nid'];
+
+    if (isset($jobs[$nid])) {
+      $previous = $jobs[$nid];
+
+      if (strpos($record['roles'], 'editor') !== FALSE) {
+        if ($record['career_categories'] !== $previous['career_categories']) {
+          $changed_career_categories[$nid] = TRUE;
+        }
+        if ($record['themes'] !== $previous['themes']) {
+          $changed_themes[$nid] = TRUE;
+        }
+      }
+    }
+
+    $jobs[$nid] = $record;
+  }
+
+  // Assemble an array of statistics.
+  $data = [
+    'jobs_tagged_by_ai' => count($jobs),
+    'career_categories_changed_by_editors' => count($changed_career_categories),
+    'themes_changed_by_editors' => count($changed_themes),
+  ];
+
+  return $data;
+}

--- a/html/modules/custom/reliefweb_reporting/reliefweb_reporting.routing.yml
+++ b/html/modules/custom/reliefweb_reporting/reliefweb_reporting.routing.yml
@@ -1,0 +1,9 @@
+reliefweb_reporting.ai_job_tagging.json:
+  path: '/admin/reports/reliefweb/ai-job-tagging/json'
+  defaults:
+    _controller: '\Drupal\reliefweb_reporting\Controller\ReliefWebReportingController::weeklyAiTaggingStats'
+  options:
+    no_cache: TRUE
+  requirements:
+    # This line exists to stop PHPCS complaining about a lack of access check.
+    _access: 'TRUE'

--- a/html/modules/custom/reliefweb_reporting/src/Commands/ReliefWebReportingCommands.php
+++ b/html/modules/custom/reliefweb_reporting/src/Commands/ReliefWebReportingCommands.php
@@ -377,70 +377,16 @@ class ReliefWebReportingCommands extends DrushCommands {
       'MIME-Version' => '1.0',
     ];
 
-    $records = $this->database->query("
-      SELECT
-        nr.nid AS nid,
-        nr.vid As vid,
-        IFNULL(GROUP_CONCAT(DISTINCT ur.roles_target_id ORDER BY ur.roles_target_id SEPARATOR ','), '') AS roles,
-        GROUP_CONCAT(DISTINCT nfcc.field_career_categories_target_id ORDER BY nfcc.field_career_categories_target_id SEPARATOR ',') AS career_categories,
-        GROUP_CONCAT(DISTINCT nft.field_theme_target_id ORDER BY nft.field_theme_target_id SEPARATOR ',') AS themes
-      FROM node_revision AS nr
-      INNER JOIN node_field_data AS n
-        ON n.nid = nr.nid
-      INNER JOIN node_revision__reliefweb_job_tagger_status AS njts
-        ON njts.entity_id = n.nid
-        AND njts.revision_id = nr.vid
-        AND njts.reliefweb_job_tagger_status_value = 'processed'
-      LEFT JOIN user__roles AS ur
-        ON ur.entity_id = nr.revision_uid
-      LEFT JOIN node_revision__field_career_categories AS nfcc
-        ON nfcc.entity_id = nr.nid
-        AND nfcc.revision_id = nr.vid
-      LEFT JOIN node_revision__field_theme AS nft
-        ON nft.entity_id = nr.nid
-        AND nft.revision_id = nr.vid
-      WHERE n.type = 'job'
-        AND n.created >= UNIX_TIMESTAMP(DATE_SUB(DATE(NOW()), INTERVAL DAYOFWEEK(NOW()) + 6 DAY))
-        AND n.created < UNIX_TIMESTAMP(DATE_SUB(DATE(NOW()), INTERVAL DAYOFWEEK(NOW()) - 1 DAY))
-      GROUP BY nr.vid
-      ORDER BY nr.vid
-    ")->fetchAll(\PDO::FETCH_ASSOC);
-
     $attachments = [];
 
-    if (empty($records)) {
+    // Fetch the stats.
+    $data = reliefweb_reporting_get_weekly_ai_tagging_stats();
+
+    // Turn the stats into a CSV attachment if not empty.
+    if (empty($data)) {
       $body = 'No jobs tagged by AI this week.';
     }
     else {
-      $jobs = [];
-      $changed_career_categories = [];
-      $changed_themes = [];
-
-      foreach ($records as $record) {
-        $nid = $record['nid'];
-
-        if (isset($jobs[$nid])) {
-          $previous = $jobs[$nid];
-
-          if (strpos($record['roles'], 'editor') !== FALSE) {
-            if ($record['career_categories'] !== $previous['career_categories']) {
-              $changed_career_categories[$nid] = TRUE;
-            }
-            if ($record['themes'] !== $previous['themes']) {
-              $changed_themes[$nid] = TRUE;
-            }
-          }
-        }
-
-        $jobs[$nid] = $record;
-      }
-
-      $data = [
-        'jobs_tagged_by_ai' => count($jobs),
-        'career_categories_changed_by_editors' => count($changed_career_categories),
-        'themes_changed_by_editors' => count($changed_themes),
-      ];
-
       // Convert to CSV.
       $handle = fopen('php://memory', 'r+');
       fputcsv($handle, array_keys($data), "\t");

--- a/html/modules/custom/reliefweb_reporting/src/Controller/ReliefWebReportingController.php
+++ b/html/modules/custom/reliefweb_reporting/src/Controller/ReliefWebReportingController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\reliefweb_reporting\Controller;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Logger\LoggerChannelTrait;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class ReliefWebReporting Controller.
+ *
+ * @package Drupal\reliefweb_reporting\Controller
+ */
+class ReliefWebReportingController extends ControllerBase {
+  use LoggerChannelTrait;
+
+  /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Constructs controller.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The RequestStack object.
+   */
+  public function __construct(RequestStack $request_stack) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * Generate AI Job Tagging statistics.
+   *
+   * Call the helper to fetch the stas, the output them as JSON.
+   */
+  public function weeklyAiTaggingStats(RouteMatchInterface $route_match, Request $request) {
+
+    if ($this->access($this->currentUser())->isForbidden()) {
+      return new JsonResponse('{"error": "Access denied!"}', 403);
+    }
+
+    $data = reliefweb_reporting_get_weekly_ai_tagging_stats();
+
+    return new JsonResponse($data, 200);
+  }
+
+  /**
+   * Access result callback.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   Determines the access to controller.
+   */
+  public function access(AccountInterface $account) {
+    $header_secret = $this->requestStack->getCurrentRequest()->headers->get('reliefweb-reporting') ?? NULL;
+    $config_secret = $this->config('reliefweb_reporting')->get('statistics.key');
+    if ((!empty($header_secret) && $header_secret === $config_secret)
+      || $account->hasPermission('view site reports')) {
+      $access_result = AccessResult::allowed();
+    }
+    else {
+      $access_result = AccessResult::forbidden();
+      $logger = $this->getLogger('reliefweb_reporting');
+      $logger->warning('Unauthorized access to reporrs denied');
+    }
+    $access_result
+      ->setCacheMaxAge(0)
+      ->addCacheContexts([
+        'headers:reliefweb-reporting',
+        'user.roles',
+      ])
+      ->addCacheTags(['reliefweb_reporting']);
+    return $access_result;
+  }
+
+}


### PR DESCRIPTION
Abstract the report function and call it from both the drush command and the json stats route.

Refs: RW-938