### PR TITLE
[RW-975] Editor switch fix

### DIFF
--- a/html/modules/custom/reliefweb_fields/js/reliefweb_markdown_editor.js
+++ b/html/modules/custom/reliefweb_fields/js/reliefweb_markdown_editor.js
@@ -24,7 +24,13 @@
      *   The text format for the editor.
      */
     attach(element, format) {
-      // Nothing to do.
+      // Ensure the content is considered changed so that the saved value is
+      // the markdown content.
+      // Otherwise when switching from the Rich editor to the markdown editor
+      // without any change to the content then the original value is restored
+      // upon saving. But this original value is in HTML (converted from
+      // markdown to work with CKeditor).
+      element.setAttribute('data-editor-value-is-changed', 'true');
     },
 
     /**


### PR DESCRIPTION
Refs: RW-975

Ensure the markdown version of a text field is saved when changing the editor from Rich editor to markdown

## Tests

**Before checking out this branch**

1. Create a report, fill in the form (with some bold, links, list etc. in the body) and save
2. Edit the report, change the text format of the body to "Markdown" (**do not change the content of the body field**)
3. Save
4. Edit the report, the content of the body field is HTML instead markdown

**After checking out this branch**

1. Clear the cache
2. Repeat the steps above but this time (4) should show markdown instead of HTML in the body field
