### PR TITLE
[RW-978] Fix: revert revision user for job tagger

### DIFF
--- a/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
+++ b/html/modules/custom/reliefweb_job_tagger/src/Plugin/QueueWorker/OchaAiJobTagTaggerWorker.php
@@ -179,8 +179,6 @@ class OchaAiJobTagTaggerWorker extends QueueWorkerBase implements ContainerFacto
         ]);
       }
 
-      // Use the system user for the revisions so it's easier to identify them.
-      $node->setRevisionUserId(2);
       $node->setRevisionCreationTime(time());
       $node->setRevisionLogMessage('Job has been updated by AI.');
       $node->set('reliefweb_job_tagger_status', 'processed');


### PR DESCRIPTION
Refs: RW-978

**Note**: this a fix for the `v2.9.0` so the PR is against the `main` branch.

This revert the revision user change from https://github.com/UN-OCHA/rwint9-site/pull/802/commits/de10e81df6edf847d75fe775997ac13da41279f3. (The change for the timestamp is correct.)

Using the system user conflicts with https://github.com/UN-OCHA/rwint9-site/blob/56e52073fa5c7ce9211632c5fe0a39582d25959b/html/modules/custom/reliefweb_entities/src/OpportunityDocumentTrait.php#L21.
