### PR TITLE
[OPS-10504] Add back unsafe-eval for GTM compatibility

### DIFF
--- a/config/seckit.settings.yml
+++ b/config/seckit.settings.yml
@@ -8,7 +8,7 @@ seckit_xss:
       webkit: false
     report-only: false
     default-src: "'self'"
-    script-src: "'self' 'unsafe-inline' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com  https://www.googleadservices.com  https://googleads.g.doubleclick.net"
+    script-src: "'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com  https://www.googleadservices.com  https://googleads.g.doubleclick.net"
     object-src: "'none'"
     style-src: "'self' 'unsafe-inline' https://googletagmanager.com https://tagmanager.google.com fonts.googleapis.com"
     img-src: "'self' data: https://*"


### PR DESCRIPTION
Refs: OPS-10504

This adds back the `unsafe-eval` to issues with GTM...