### PR TITLE
[RW-1001] Handle dates equal or before unix epoch

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11098,16 +11098,16 @@
         },
         {
             "name": "reliefweb/simple-datepicker",
-            "version": "v1.3.3",
+            "version": "v1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/rwint-simple-datepicker.git",
-                "reference": "88d9fc1d8695593bb708f639a16011a97ce2fc61"
+                "reference": "d01af1f9f14f88d2477b6a6b7e24783982cdd198"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/rwint-simple-datepicker/zipball/88d9fc1d8695593bb708f639a16011a97ce2fc61",
-                "reference": "88d9fc1d8695593bb708f639a16011a97ce2fc61",
+                "url": "https://api.github.com/repos/UN-OCHA/rwint-simple-datepicker/zipball/d01af1f9f14f88d2477b6a6b7e24783982cdd198",
+                "reference": "d01af1f9f14f88d2477b6a6b7e24783982cdd198",
                 "shasum": ""
             },
             "require": {
@@ -11126,9 +11126,9 @@
                 "reliefweb"
             ],
             "support": {
-                "source": "https://github.com/UN-OCHA/rwint-simple-datepicker/tree/v1.3.3"
+                "source": "https://github.com/UN-OCHA/rwint-simple-datepicker/tree/v1.3.4"
             },
-            "time": "2022-11-04T07:04:06+00:00"
+            "time": "2024-07-02T08:32:55+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
@@ -353,7 +353,7 @@ trait DocumentTrait {
    * @see Drupal\reliefweb_entities\DocumentInterface::createDate()
    */
   public function createDate($date) {
-    if (empty($date)) {
+    if (is_scalar($date) && $date !== '') {
       return NULL;
     }
     $date = is_numeric($date) ? '@' . $date : $date;

--- a/html/modules/custom/reliefweb_entities/src/Entity/Report.php
+++ b/html/modules/custom/reliefweb_entities/src/Entity/Report.php
@@ -210,7 +210,7 @@ class Report extends Node implements BundleEntityInterface, EntityModeratedInter
     if (!empty($this->field_bury->value) && !$this->field_original_publication_date->isEmpty()) {
       $date = $this->field_original_publication_date->value;
       $timestamp = DateHelper::getDateTimeStamp($date);
-      if (!empty($timestamp)) {
+      if (!is_null($timestamp)) {
         $this->_original_created = $this->getCreatedTime();
         $this->setCreatedTime($timestamp);
       }

--- a/html/modules/custom/reliefweb_utility/src/Helpers/DateHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/DateHelper.php
@@ -20,6 +20,9 @@ class DateHelper {
    *   A UNIX timestamp or NULL if the type of the date couldn't be inferred.
    */
   public static function getDateTimeStamp($date) {
+    if ($date === 0 || $date === '0') {
+      return 0;
+    }
     if (!empty($date)) {
       // Date object. It can be a PHP DateTime or DrupalDateTime...
       if (is_object($date)) {
@@ -78,7 +81,7 @@ class DateHelper {
    */
   public static function format($date, $type = 'medium', $format = '', $timezone = 'UTC', $langcode = NULL) {
     $timestamp = static::getDateTimeStamp($date);
-    if (empty($timestamp)) {
+    if (is_null($timestamp)) {
       return '';
     }
     return \Drupal::service('date.formatter')


### PR DESCRIPTION
Refs: RW-1001

- Update datepicker version with fix
- Update different places handling publication dates

### Tests

**Note:** This requires a valid 

1. Checkout the branch, run composer install, clear the cache
2. Create a report, set the original publication date to 1 Jan 1970, check that this can be done via the datepicker
3. Check "bury"
4. Save
5. Go to `/updates`, then click "last" in the pager at the bottom and check that the document appears and 1 Jan 1970 is displayed for `posted` and `original publication date` <-- You need a valid installation of the API to test that (so the document is indexed)
6. Repeat 2 to 5 with a date before 1 Jan 1970, notably that the datepicker works