### PR TITLE
chore: switch remaining twitter links to handle x instead

### DIFF
--- a/config/reliefweb_entities.settings.yml
+++ b/config/reliefweb_entities.settings.yml
@@ -3,7 +3,8 @@ allowed_social_media_links:
   instagram: Instagram
   medium: Medium
   linkedin: LinkedIn
-  twitter: Twitter
+  twitter: X
+  x: X
   youtube: YouTube
 cron:
   embargoed_reports_limit: 20

--- a/html/modules/custom/reliefweb_entities/config/install/reliefweb_entities.settings.yml
+++ b/html/modules/custom/reliefweb_entities/config/install/reliefweb_entities.settings.yml
@@ -4,7 +4,8 @@ allowed_social_media_links:
   instagram: 'Instagram'
   medium: 'Medium'
   linkedin: 'LinkedIn'
-  twitter: 'Twitter'
+  twitter: 'X'
+  x: 'X'
   youtube: 'YouTube'
 # Entity related cron task settings.
 cron:

--- a/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
@@ -91,12 +91,12 @@ trait DocumentTrait {
         ],
       ]),
     ];
-    $links['twitter'] = [
-      'title' => $this->t('Share this on Twitter'),
-      'url' => Url::fromUri('https://twitter.com/share', [
+    $links['x'] = [
+      'title' => $this->t('Share this on X'),
+      'url' => Url::fromUri('https://x.com/share', [
         'query' => [
-          'url' => $url . '&utm_source=twitter.com',
-          // Truncate the title as text for twitter to stay within the allowed
+          'url' => $url . '&utm_source=x.com',
+          // Truncate the title as text for X to stay within the allowed
           // number of characters.
           'text' => Unicode::truncate($title, 90, FALSE, TRUE),
           'via' => 'reliefweb',

--- a/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content--blog.html.twig
+++ b/html/modules/custom/reliefweb_subscriptions/templates/reliefweb-subscriptions-content--blog.html.twig
@@ -49,7 +49,7 @@
 {% apply spaceless %}
 <div>
 <a href="https://www.facebook.com/reliefweb">Facebook</a><span> - </span>
-<a href="https://twitter.com/reliefweb">Twitter</a><span> - </span>
+<a href="https://x.com/reliefweb">X</a><span> - </span>
 <a href="https://www.linkedin.com/company/reliefweb">LinkedIn</a><span> - </span>
 <a href="https://www.instagram.com/reliefweb1996/">Instagram</a><span> - </span>
 <a href="https://t.me/+8QT4PI32MbY3MDdh">Telegram</a>

--- a/html/themes/custom/common_design_subtheme/components/rw-social-media-links/rw-social-media-links.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-social-media-links/rw-social-media-links.css
@@ -74,7 +74,7 @@
 .rw-entity-social-media-links--icons-only a[href*="facebook"]:before {
   background: var(--rw-icons--social-media--facebook-full--48--dark-blue);
 }
-.rw-entity-social-media-links--icons-only a[href*="twitter"]:before {
+.rw-entity-social-media-links--icons-only a[href*="x.com"]:before {
   background: var(--rw-icons--social-media--twitter-full--48--dark-blue);
 }
 .rw-entity-social-media-links--icons-only a[href*="linkedin"]:before {

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-social-menu.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-social-menu.html.twig
@@ -17,8 +17,8 @@
         </a>
       </li>
       <li class="cd-footer-social__item">
-        <a href="https://twitter.com/reliefweb" class="cd-footer-social__link">
-          <span class="visually-hidden">Twitter</span>
+        <a href="https://x.com/reliefweb" class="cd-footer-social__link">
+          <span class="visually-hidden">X</span>
 
           <svg class="cd-icon cd-icon--twitter" aria-hidden="true" focusable="false" width="32" height="32">
             <use xlink:href="#cd-icon--sm-tt-def"></use>


### PR DESCRIPTION
Refs: RW-997

Social share now goes to X instead of twitter.com - the icon has already been changed:
![reports-page](https://github.com/UN-OCHA/rwint9-site/assets/67453/13ec46f9-bd04-44c8-9ae9-82dfbc0ba7b6)

The footer link also goes to x.com rather than twitter (again, the icon has already been changed):
![social-footer](https://github.com/UN-OCHA/rwint9-site/assets/67453/47bde4c4-83d3-4c2b-bfe3-e6ce1b3b17a2)

Twitter and x links are now shown for organizations as X links:
![organization-link](https://github.com/UN-OCHA/rwint9-site/assets/67453/d1b03b7a-ecc1-4e54-8889-8045b456826a)

I believe it's better to leave twitter ones as they are, rather than updating them in the database. If we have both an 'x' and a 'twitter' link, it will look odd so editors might be encouraged to remove one of them:
![organization-link-with-duplicate](https://github.com/UN-OCHA/rwint9-site/assets/67453/1b1accc7-ddad-4d9a-8cb2-bf1ac175d339)

We're still using the word 'twitter' for the icons - and for the metatags x documentation still refers to 'twitter cards' etc.