### PR TITLE
[RW-1001] More proper fix for node dates

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
+++ b/html/modules/custom/reliefweb_entities/src/DocumentTrait.php
@@ -353,11 +353,14 @@ trait DocumentTrait {
    * @see Drupal\reliefweb_entities\DocumentInterface::createDate()
    */
   public function createDate($date) {
-    if (is_scalar($date) && $date === '') {
-      return NULL;
+    if (is_string($date) || is_int($date)) {
+      $date = is_numeric($date) ? '@' . $date : $date;
+      return new \DateTime((string) $date, new \DateTimeZone('UTC'));
     }
-    $date = is_numeric($date) ? '@' . $date : $date;
-    return new \DateTime($date, new \DateTimeZone('UTC'));
+    elseif (is_a($date, \DateTime::class)) {
+      return $date;
+    }
+    return NULL;
   }
 
   /**


### PR DESCRIPTION
Refs: RW-1001

This avoids deprecation notice when the date is NULL like ongoing training for example.