### PR TITLE
chore: update ocha_ai module to 1.5.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -16576,16 +16576,16 @@
         },
         {
             "name": "unocha/ocha_ai",
-            "version": "v1.5.0",
+            "version": "v1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/ocha_ai.git",
-                "reference": "42ed56d238e182886cd7ccb02dd3f30e9c08e0eb"
+                "reference": "02bf7a6bee3771ad07bc8d83fc2a4ca5be51feac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/ocha_ai/zipball/42ed56d238e182886cd7ccb02dd3f30e9c08e0eb",
-                "reference": "42ed56d238e182886cd7ccb02dd3f30e9c08e0eb",
+                "url": "https://api.github.com/repos/UN-OCHA/ocha_ai/zipball/02bf7a6bee3771ad07bc8d83fc2a4ca5be51feac",
+                "reference": "02bf7a6bee3771ad07bc8d83fc2a4ca5be51feac",
                 "shasum": ""
             },
             "require": {
@@ -16617,9 +16617,9 @@
             "description": "OCHA AI module",
             "support": {
                 "issues": "https://github.com/UN-OCHA/ocha_ai/issues",
-                "source": "https://github.com/UN-OCHA/ocha_ai/tree/v1.5.0"
+                "source": "https://github.com/UN-OCHA/ocha_ai/tree/v1.5.1"
             },
-            "time": "2024-08-22T22:48:23+00:00"
+            "time": "2024-08-27T07:57:48+00:00"
         },
         {
             "name": "unocha/ocha_monitoring",


### PR DESCRIPTION
Refs: RW-1047

Bump the ocha_ai module to 1.5.1.