### PR TITLE
[RW-1071] Fix revision user/time for terms

### DIFF
--- a/html/modules/custom/reliefweb_fields/src/Form/TaxonomyTermProfile.php
+++ b/html/modules/custom/reliefweb_fields/src/Form/TaxonomyTermProfile.php
@@ -42,6 +42,8 @@ class TaxonomyTermProfile extends TermForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    $this->entity->setRevisionUserId($this->currentUser()->id());
+    $this->entity->setRevisionCreationTime(time());
     $this->entity->setRevisionLogMessage(strtr('!bundle profile update', [
       '!bundle' => $this->getBundleLabel(),
     ]));

--- a/html/modules/custom/reliefweb_fields/src/Form/TaxonomyTermUserPostingRights.php
+++ b/html/modules/custom/reliefweb_fields/src/Form/TaxonomyTermUserPostingRights.php
@@ -42,6 +42,8 @@ class TaxonomyTermUserPostingRights extends TermForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    $this->entity->setRevisionUserId($this->currentUser()->id());
+    $this->entity->setRevisionCreationTime(time());
     $this->entity->setRevisionLogMessage('User posting rights update');
     return parent::save($form, $form_state);
   }


### PR DESCRIPTION
Refs: RW-1071

This ensures that the revision user and timestamp are correctly set when editing a term profile or user posting rights.