### PR TITLE
chore: pass on credentials to action

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -13,8 +13,10 @@ jobs:
       id: update-action
       uses: UN-OCHA/actions/composer-update@main
       with:
+        aws_access_key_id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
         github_access_token: ${{ secrets.PAT }}
-        patch_branch: 'develop'
-        patch_maintainers: ${{ vars.DRUPAL_MAINTAINERS }}
+        patch_branch: ${{ github.head_ref || github.ref_name }}
+        patch_maintainers: ${{ secrets.DRUPAL_MAINTAINERS }}
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel_name: ${{ vars.SLACK_CHANNEL }}


### PR DESCRIPTION
Refs: OPS-10254

This is needed for the new version of the update action that includes config - https://github.com/UN-OCHA/rwint9-site/actions/runs/10825529694