### PR TITLE
[RW-1076] Remove now redundant taxonomy_term_revision

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -106,7 +106,6 @@ module:
   system: 0
   taxonomy: 0
   taxonomy_term_preview: 0
-  taxonomy_term_revision: 0
   text: 0
   theme_switcher: 0
   token: 0

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -44,7 +44,6 @@ dependencies:
     - reliefweb_users
     - system
     - taxonomy
-    - taxonomy_term_revision
 id: editor
 label: Editor
 weight: 2
@@ -147,12 +146,12 @@ permissions:
   - 'edit terms in source'
   - 'edit terms in tag'
   - 'edit user posting rights'
+  - 'revert all taxonomy revisions'
   - 'revert announcement revisions'
   - 'revert blog_post revisions'
   - 'revert book revisions'
   - 'revert job revisions'
   - 'revert report revisions'
-  - 'revert term revision'
   - 'revert topic revisions'
   - 'revert training revisions'
   - 'see other bookmarks'
@@ -163,6 +162,7 @@ permissions:
   - 'use text format html'
   - 'use text format markdown'
   - 'view all media revisions'
+  - 'view all taxonomy revisions'
   - 'view announcement revisions'
   - 'view any content'
   - 'view blog_post revisions'
@@ -176,8 +176,6 @@ permissions:
   - 'view published guideline entities'
   - 'view reliefweb admin menu'
   - 'view report revisions'
-  - 'view term revision data'
-  - 'view term revision list'
   - 'view the administration theme'
   - 'view topic revisions'
   - 'view training revisions'

--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -33,7 +33,6 @@ dependencies:
     - reliefweb_users
     - system
     - taxonomy
-    - taxonomy_term_revision
 id: webmaster
 label: Webmaster
 weight: 4
@@ -65,8 +64,8 @@ permissions:
   - 'create terms in training_type'
   - 'create terms in vulnerable_group'
   - 'delete all guideline revisions'
+  - 'delete all taxonomy revisions'
   - 'delete guideline entities'
-  - 'delete term revision'
   - 'delete terms in career_category'
   - 'delete terms in content_format'
   - 'delete terms in country'
@@ -120,17 +119,16 @@ permissions:
   - 'guideline_list view revisions'
   - 'manage ocha ai chat config'
   - 'revert all guideline revisions'
-  - 'revert term revision'
+  - 'revert all taxonomy revisions'
   - 'see other bookmarks'
   - 'sort all guideline'
   - 'sort editorial guidelines'
   - 'use text format guideline'
   - 'view all guideline revisions'
+  - 'view all taxonomy revisions'
   - 'view ocha ai admin config menu'
   - 'view ocha ai chat logs'
   - 'view published guideline entities'
   - 'view reliefweb admin menu'
-  - 'view term revision data'
-  - 'view term revision list'
   - 'view the administration theme'
   - 'view unpublished guideline entities'

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -500,22 +500,6 @@ function reliefweb_entities_form_alter(array &$form, FormStateInterface $form_st
 }
 
 /**
- * Implements hook_module_implements_alter().
- */
-function reliefweb_entities_module_implements_alter(array &$implementation, $hook) {
-  // Remove the hook_entity_presave() implementation from the
-  // taxonomy_term_revision module because it doesn't allow us to speify the
-  // revision user or timestamp. This is replaced by
-  // reliefweb_entities_set_taxonomy_term_revision().
-  //
-  // @see taxonomy_term_revision_entity_presave()
-  // @see reliefweb_entities_set_taxonomy_term_revision()
-  if ($hook === 'entity_presave') {
-    unset($implementation['taxonomy_term_revision']);
-  }
-}
-
-/**
  * Implements hook_theme_registry_alter().
  */
 function reliefweb_entities_theme_registry_alter(array &$theme_registry) {
@@ -580,13 +564,8 @@ function reliefweb_entities_entity_presave(EntityInterface $entity) {
 /**
  * Set a taxonomy term's revision information.
  *
- * Note: this replaces the taxonomy_term_revision_entity_presave() which
- * is not flexible and forces the revision user ID and creation time.
- *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   Entity.
- *
- * @see taxonomy_term_revision_entity_presave()
  */
 function reliefweb_entities_set_taxonomy_term_revision(EntityInterface $entity) {
   // Saving new revision of term on each save.

--- a/html/modules/custom/reliefweb_fields/reliefweb_fields.info.yml
+++ b/html/modules/custom/reliefweb_fields/reliefweb_fields.info.yml
@@ -6,5 +6,4 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:reliefweb_form
   - drupal:taxonomy
-  - drupal:taxonomy_term_revision
   - drupal:taxonomy_term_preview

--- a/html/modules/custom/reliefweb_revisions/reliefweb_revisions.info.yml
+++ b/html/modules/custom/reliefweb_revisions/reliefweb_revisions.info.yml
@@ -5,4 +5,3 @@ package: reliefweb
 core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:reliefweb_utility
-  - taxonomy_term_revision:taxonomy_term_revision


### PR DESCRIPTION
Refs: RW-1076

This uninstalls the `taxonomy_term_revision` module since all of its functionalities are in Drupal core now (10.3+). The module itself will be remove from composer in another PR and deployment.