### PR TITLE
[RW-1078] Log number of jobs changed by editors for job tagging stats

### DIFF
--- a/html/modules/custom/reliefweb_reporting/reliefweb_reporting.module
+++ b/html/modules/custom/reliefweb_reporting/reliefweb_reporting.module
@@ -106,6 +106,7 @@ function reliefweb_reporting_get_weekly_ai_tagging_stats() {
     'jobs_tagged_by_ai' => count($jobs),
     'career_categories_changed_by_editors' => count($changed_career_categories),
     'themes_changed_by_editors' => count($changed_themes),
+    'jobs_changed_by_editors' => count($changed_career_categories + $changed_themes),
   ];
 
   return $data;


### PR DESCRIPTION
Refs: RW-1078

New `jobs_changed_by_editors` field.

Ex:

```
{
  "jobs_tagged_by_ai": 2738,
  "career_categories_changed_by_editors": 1223,
  "themes_changed_by_editors": 953,
  "jobs_changed_by_editors": 1552
}
```