### PR TITLE
[RW-1077] Decommission interactive content

### DIFF
--- a/html/modules/custom/reliefweb_entities/src/Services/ReportFormAlter.php
+++ b/html/modules/custom/reliefweb_entities/src/Services/ReportFormAlter.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\SortArray;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\reliefweb_entities\Entity\Report;
 use Drupal\reliefweb_entities\EntityFormAlterServiceBase;
 use Drupal\reliefweb_form\Helpers\FormHelper;
 use Drupal\reliefweb_utility\Helpers\UrlHelper;
@@ -73,6 +74,13 @@ class ReportFormAlter extends EntityFormAlterServiceBase {
 
     // Remove data (9420) option for content format field (Collab #3679).
     FormHelper::removeOptions($form, 'field_content_format', [9420]);
+
+    // Remove interactive (38974) format if the report is not tagged with it.
+    // @see https://humanitarian.atlassian.net/browse/RW-1077
+    $report = $form_state?->getFormObject()?->getEntity();
+    if ($report instanceof Report && $report?->field_content_format?->target_id != 38974) {
+      FormHelper::removeOptions($form, 'field_content_format', [38974]);
+    }
 
     // Remove Key document (2) option for feature field.
     FormHelper::removeOptions($form, 'field_feature', [2]);

--- a/html/modules/custom/reliefweb_rivers/src/Services/ReportRiver.php
+++ b/html/modules/custom/reliefweb_rivers/src/Services/ReportRiver.php
@@ -173,6 +173,10 @@ class ReportRiver extends RiverServiceBase {
         'name' => $this->t('Content format'),
         'type' => 'reference',
         'vocabulary' => 'content_format',
+        'exclude' => [
+          // Interactive (RW-1077).
+          38974,
+        ],
         'field' => 'format.id',
         'widget' => [
           'type' => 'options',

--- a/scripts/retagging/RW-1077.php
+++ b/scripts/retagging/RW-1077.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @file
+ * Retagging script for RW-1077.
+ */
+
+$proceed = TRUE;
+$save = TRUE;
+
+$content_format = 38974;
+
+$nids = \Drupal::database()->query("
+  SELECT DISTINCT n.nid
+  FROM {node_field_data} AS n
+  INNER JOIN {node__field_content_format} AS fcf
+  ON fcf.entity_id = n.nid
+  WHERE n.type = :bundle
+  AND fcf.field_content_format_target_id = :content_format
+  ORDER BY nid ASC
+", [
+  ":bundle" => "report",
+  ":content_format" => $content_format,
+])->fetchCol();
+
+$total = count($nids);
+
+echo "Found " . $total . " nodes to update" . PHP_EOL;
+
+if (!empty($proceed)) {
+  $storage = \Drupal::entityTypeManager()->getStorage("node");
+  $chunk_size = 100;
+  $now = time();
+  $progress = 1;
+
+  foreach (array_chunk($nids, $chunk_size) as $chunk) {
+    foreach ($storage->loadMultiple($chunk) as $node) {
+      $node->setModerationStatus('archive');
+      $node->notifications_content_disable = TRUE;
+      $node->setRevisionLogMessage("Automatic archiving of interactive content (Ref: RW-1077).");
+      $node->setRevisionUserId(2);
+      $node->setRevisionCreationTime($now);
+      $node->setNewRevision(TRUE);
+      if ($save) {
+        $node->save();
+      }
+
+      echo "Progress: $progress / $total..." . PHP_EOL;
+      $progress++;
+    }
+  }
+}


### PR DESCRIPTION
Refs: RW-1077

This does the following:
- Hide the "Interactive" content format in the report form unless editing an existing Interactive content.
- Hide the "Interactive" content format from the river filter.
- Add a script to archive the interactive content.