### PR TITLE
fix: Return the response object, so Drupal can do its thing.

### DIFF
--- a/html/modules/custom/reliefweb_entraid/src/Controller/AuthController.php
+++ b/html/modules/custom/reliefweb_entraid/src/Controller/AuthController.php
@@ -80,7 +80,7 @@ class AuthController extends ControllerBase implements ContainerInjectionInterfa
       $this->openIdConnectSession->saveOp('login');
       $response = $plugin->authorize($scopes);
 
-      return $response->send();
+      return $response;
     }
     catch (\Exception $exception) {
       $config = $this->config('openid_connect.client.entraid');


### PR DESCRIPTION
Basically, this allows Drupal to initialize a session for the (anonymous) user so that the state token can be stored.

Refs: OPS-10834