### PR TITLE
[RW-1093] Ensure long text is properly broken in documents

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
@@ -96,8 +96,8 @@
   }
 }
 
-/* Ensure long URLs in WYSIWYG wrap */
-.rw-article__content a {
+/* Ensure long strings wrap. */
+.rw-article__content {
   overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
Refs: RW-1093

Replace the rule to break long links with a more generic one to also break long strings outside of links.