### PR TITLE
[OPS-10284] Use main branch of github actions in composer-update workflow

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Update The Thing
       id: update-action
-      uses: UN-OCHA/actions/composer-update@dev
+      uses: UN-OCHA/actions/composer-update@main
       with:
         aws_access_key_id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Refs: OPS-10284

The action fails because there is no `dev` branch for https://github.com/UN-OCHA/actions