### PR TITLE
docs: enhance descriptions in api schema

### DIFF
--- a/html/modules/custom/reliefweb_post_api/schemas/v2/job.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/job.json
@@ -142,7 +142,7 @@
             "maxItems": 1
         },
         "theme": {
-            "description": "Job theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
+            "description": "Job theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Only select the most relevant themes as over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/job.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/job.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "url": {
-            "description": "Unique URL to identify the document. Use the original canonical of the document if available.",
+            "description": "Unique URL to identify the job posting. Use the original canonical url if available.",
             "type": "string",
             "format": "iri",
             "maxLength": 2048
@@ -142,7 +142,7 @@
             "maxItems": 1
         },
         "theme": {
-            "description": "Job theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes.",
+            "description": "Job theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/job.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/job.json
@@ -16,7 +16,7 @@
             "format": "uuid"
         },
         "title": {
-            "description": "Job title.",
+            "description": "Job title.  The best job titles are brief and specific. Please refrain from indicating location, salary and other details in the title, if possible.",
             "type": "string",
             "minLength": 10,
             "maxLength": 255,
@@ -45,12 +45,12 @@
             "maxItems": 1
         },
         "closing_date": {
-            "description": "Closing date (ISO 8601) of the job.",
+            "description": "Closing date (ISO 8601) of the job. Please make sure it matches the closing date on your ad and/or job application portal, if applicable.",
             "type": "string",
             "format": "date-time"
         },
         "body": {
-            "description": "Job description in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>).",
+            "description": "Job description in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>). The description should be long enough and sufficient in order to attract qualified candidates.",
             "type": "string",
             "minLength": 10,
             "maxLength": 100000,
@@ -70,7 +70,7 @@
             }
         },
         "how_to_apply": {
-            "description": "Instructions on how to apply for the job in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>).",
+            "description": "Instructions on how to apply for the job in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>). Brief and clear instructions how to apply only. Not to be used to duplicate the job description.",
             "type": "string",
             "minLength": 10,
             "maxLength": 100000,
@@ -118,7 +118,7 @@
             }
         },
         "job_type": {
-            "description": "Job type as a single ID from https://api.reliefweb.int/v1/references/job-types.",
+            "description": "Job type as a single ID from https://api.reliefweb.int/v1/references/job-types. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -126,7 +126,7 @@
             "maxItems": 1
         },
         "job_experience": {
-            "description": "Job experience as a single ID from https://api.reliefweb.int/v1/references/job-experience.",
+            "description": "Job experience as a single ID from https://api.reliefweb.int/v1/references/job-experience. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -134,7 +134,7 @@
             "maxItems": 1
         },
         "career_category": {
-            "description": "Job career category as a single ID from https://api.reliefweb.int/v1/references/career-categories.",
+            "description": "Job career category as a single ID from https://api.reliefweb.int/v1/references/career-categories. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -142,7 +142,7 @@
             "maxItems": 1
         },
         "theme": {
-            "description": "Job theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability.",
+            "description": "Job theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
@@ -45,7 +45,7 @@
             "maxItems": 30
         },
         "country": {
-             "description": "Document country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. The first country in the list is considered the primary country, meaning the most relevant to the content of the document. Otherwise, enter them alphabetically. Only tag the most relevant countries.",
+             "description": "Document country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. The first country in the list is considered the primary country, meaning the most relevant to the content of the document. Otherwise, enter them alphabetically. Only tag the most relevant countries as over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
@@ -242,7 +242,7 @@
             "required": ["url", "uuid", "checksum", "description", "copyright"]
         },
         "disaster": {
-            "description": "Document disaster(s) as a list of IDs from https://api.reliefweb.int/v1/disasters. Only select the most relevant terms for the document. Over-tagging often results in reduced discoverability.",
+            "description": "Document disaster(s) as a list of IDs from https://api.reliefweb.int/v1/disasters. Only select the most relevant disasters as over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -250,7 +250,7 @@
             "maxItems": 30
         },
         "disaster_type": {
-            "description": "Document disaster type(s) as a list of IDs from https://api.reliefweb.int/v1/references/disaster-types. Over-tagging often results in reduced discoverability.",
+            "description": "Document disaster type(s) as a list of IDs from https://api.reliefweb.int/v1/references/disaster-types. Only select the most relevant disaster types as over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -258,7 +258,7 @@
             "maxItems": 30
         },
         "theme": {
-            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability.",
+            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Only select the most relevant themes as over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
@@ -54,7 +54,7 @@
             "maxItems": 300
         },
         "format": {
-            "description": "Document format as a single ID from https://api.reliefweb.int/v1/references/content-formats.",
+            "description": "Document format as a single ID from https://api.reliefweb.int/v1/references/content-formats. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -97,7 +97,7 @@
             }
         },
         "embargoed": {
-            "description": "Embargo date (ISO 8601) until which the document should not be published on ReliefWeb.",
+            "description": "Date (ISO 8601) until when the document is embargoed. It will be automatically published on that date. It must be a UTC/GMT date.",
             "type": "string",
             "format": "date-time"
         },
@@ -258,7 +258,7 @@
             "maxItems": 30
         },
         "theme": {
-            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Only select the most relevant themes as over-tagging often results in reduced discoverability.",
+            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Only select the most relevant themes as over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
@@ -242,7 +242,7 @@
             "required": ["url", "uuid", "checksum", "description", "copyright"]
         },
         "disaster": {
-            "description": "Document disaster(s) as a list of IDs from https://api.reliefweb.int/v1/disasters. Only select the most relevant terms for the document. Over tagging often results in reduced discoverability.",
+            "description": "Document disaster(s) as a list of IDs from https://api.reliefweb.int/v1/disasters. Only select the most relevant terms for the document. Over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -250,7 +250,7 @@
             "maxItems": 30
         },
         "disaster_type": {
-            "description": "Document disaster type(s) as a list of IDs from https://api.reliefweb.int/v1/references/disaster-types. Over tagging often results in reduced discoverability.",
+            "description": "Document disaster type(s) as a list of IDs from https://api.reliefweb.int/v1/references/disaster-types. Over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -258,7 +258,7 @@
             "maxItems": 30
         },
         "theme": {
-            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over tagging often results in reduced discoverability.",
+            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/report.json
@@ -16,7 +16,7 @@
             "format": "uuid"
         },
         "title": {
-            "description": "Document title.",
+            "description": "Document title. Use the original title of the article or file. If the title is from a series, add the date and other information as appropriate.",
             "type": "string",
             "minLength": 10,
             "maxLength": 255,
@@ -45,7 +45,7 @@
             "maxItems": 30
         },
         "country": {
-             "description": "Document country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. The first country in the list is considered the primary country, meaning the most relevant to the content of the document.",
+             "description": "Document country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. The first country in the list is considered the primary country, meaning the most relevant to the content of the document. Otherwise, enter them alphabetically. Only tag the most relevant countries.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -63,7 +63,7 @@
             "maxItems": 1
         },
         "language": {
-            "description": "Document language(s) as a list of IDs from https://api.reliefweb.int/v1/references/languages.",
+            "description": "Document language(s) as a list of IDs from https://api.reliefweb.int/v1/references/languages. If an attachment is not in one of the official UN languages, mention that in the description of the attachment.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -77,7 +77,7 @@
             "format": "date-time"
         },
         "body": {
-            "description": "Document content in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>).",
+            "description": "Document content in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>). For a textual article, put the entire content. For attachments, use an executive summary, overview or key points of the core document. Use the file field for the attachment.",
             "type": "string",
             "minLength": 10,
             "maxLength": 100000,
@@ -97,7 +97,7 @@
             }
         },
         "embargoed": {
-            "description": "Embargo date until which the document should not be published on ReliefWeb.",
+            "description": "Embargo date (ISO 8601) until which the document should not be published on ReliefWeb.",
             "type": "string",
             "format": "date-time"
         },
@@ -242,7 +242,7 @@
             "required": ["url", "uuid", "checksum", "description", "copyright"]
         },
         "disaster": {
-            "description": "Document disaster(s) as a list of IDs from https://api.reliefweb.int/v1/disasters.",
+            "description": "Document disaster(s) as a list of IDs from https://api.reliefweb.int/v1/disasters. Only select the most relevant terms for the document. Over tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -250,7 +250,7 @@
             "maxItems": 30
         },
         "disaster_type": {
-            "description": "Document disaster type(s) as a list of IDs from https://api.reliefweb.int/v1/references/disaster-types.",
+            "description": "Document disaster type(s) as a list of IDs from https://api.reliefweb.int/v1/references/disaster-types. Over tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -258,7 +258,7 @@
             "maxItems": 30
         },
         "theme": {
-            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes.",
+            "description": "Document theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
@@ -54,7 +54,7 @@
             "maxItems": 2
         },
         "country": {
-            "description": "Training country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. Mandatory when the training format is 'on-site', otherwise not allowed.",
+            "description": "Training country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. Mandatory when the training format includes 'on-site', otherwise not allowed.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -231,7 +231,7 @@
     },
     "allOf": [
         {
-            "description": "The country field is mandatory if the training format is 'on-site' otherwise the country field is not allowed",
+            "description": "The country field is mandatory if the training format includes 'on-site' otherwise the country field is not allowed",
             "if": {
                 "properties": {
                     "format": {

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
@@ -161,7 +161,7 @@
             "maxItems": 10
         },
         "professional_function": {
-            "description": "Professional function(s) as a list of IDs from https://api.reliefweb.int/v1/references/career-categories. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
+            "description": "Professional function(s) as a list of IDs from https://api.reliefweb.int/v1/references/career-categories. Only select the most relevant functions as over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -169,7 +169,7 @@
             "maxItems": 3
         },
         "theme": {
-            "description": "Training theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
+            "description": "Training theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Only select the most relevant themes as over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
@@ -16,7 +16,7 @@
             "format": "uuid"
         },
         "title": {
-            "description": "Document title.",
+            "description": "The title of the training. Other information such as location, date and Organization should not be included in this field.",
             "type": "string",
             "minLength": 10,
             "maxLength": 255,
@@ -97,7 +97,7 @@
                     "format": "date-time"
                 },
                 "registration_deadline": {
-                    "description": "Registration deadline (ISO 8601) of the document.",
+                    "description": "Registration deadline (ISO 8601) of the document. All advertisements should include a registration deadline unless it is an 'ongoing course'. Advertisements immediately expire after the registration deadline has passed. Advertisements tagged with 'Call for Papers' usually include a submission deadline in the body text, so they should not be ongoing ads. For Universities, any ads advertising degrees should not be ongoing ads and should have a deadline.",
                     "type": "string",
                     "format": "date-time"
                 }
@@ -109,7 +109,7 @@
             ]
         },
         "event_url": {
-            "description": "Event URL where more information can be found about the training opportunity.",
+            "description": "Event URL where more information can be found about the training opportunity. No social media URL should be used in this field, although it can be mentioned in the Body field.",
             "type": "string",
             "format": "iri",
             "maxLength": 2048
@@ -143,7 +143,7 @@
             }
         },
         "category": {
-            "description": "Training category as a single ID from https://api.reliefweb.int/v1/references/training-types.",
+            "description": "Training category as a single ID from https://api.reliefweb.int/v1/references/training-types. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -161,7 +161,7 @@
             "maxItems": 10
         },
         "professional_function": {
-            "description": "Professional function(s) as a list of IDs from https://api.reliefweb.int/v1/references/career-categories.",
+            "description": "Professional function(s) as a list of IDs from https://api.reliefweb.int/v1/references/career-categories. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -169,7 +169,7 @@
             "maxItems": 3
         },
         "theme": {
-            "description": "Training theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability.",
+            "description": "Training theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability. For definitions, see https://reliefweb.int/taxonomy-descriptions.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -177,7 +177,7 @@
             "maxItems": 3
         },
         "language": {
-            "description": "Language(s) in which this advertisement is written as a list of IDs from https://api.reliefweb.int/v1/references/languages.",
+            "description": "Language(s) in which this advertisement is written as a list of IDs from https://api.reliefweb.int/v1/references/languages. ReliefWeb accepts advertisements submitted in English, Spanish or French. This Advertisement Language refers to the language in which the submitted advertisement is written, not the actual language that will be used in the training/event.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -186,7 +186,7 @@
             "maxItems": 10
         },
         "body": {
-            "description": "Training content in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>).",
+            "description": "Training content in markdown or html (supported tags: <h1> <h2> <h3> <h4> <h5> <h6> <br> <p> <strong> <em> <a> <ul> <ol> <li> <blockquote>). The Body field must contain the complete description of the training opportunity (ex: introduction, methodology, objectives, target audience). This core information cannot be substituted by providing a link for 'further details'.",
             "type": "string",
             "minLength": 10,
             "maxLength": 100000,
@@ -206,7 +206,7 @@
             }
         },
         "how_to_register": {
-            "description": "How to register for the course/event with the application procedure/condition(s) and contact details.",
+            "description": "How to register for the course/event with the application procedure/condition(s) and contact details. This core information cannot be substituted by providing a link for 'further details'. If no registration is required, provide contact details, a link to the advertisement (on the Organization’s website) or include the text: 'No registration required.'",
             "type": "string",
             "minLength": 10,
             "maxLength": 100000,

--- a/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
+++ b/html/modules/custom/reliefweb_post_api/schemas/v2/training.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "url": {
-            "description": "Unique URL to identify the document. Use the original canonical of the document if available.",
+            "description": "Unique URL to identify the training opportunity. Use the original canonical url if available.",
             "type": "string",
             "format": "iri",
             "maxLength": 2048
@@ -54,7 +54,7 @@
             "maxItems": 2
         },
         "country": {
-            "description": "Training country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. Mandatory when the training format contains on-site otherwise not allowed.",
+            "description": "Training country(ies) as a list of IDs from https://api.reliefweb.int/v1/countries. Mandatory when the training format is 'on-site', otherwise not allowed.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -169,7 +169,7 @@
             "maxItems": 3
         },
         "theme": {
-            "description": "Training theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes.",
+            "description": "Training theme(s) as a list of IDs from https://api.reliefweb.int/v1/references/themes. Over-tagging often results in reduced discoverability.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -177,7 +177,7 @@
             "maxItems": 3
         },
         "language": {
-            "description": "Language(s) in which this advertisment is written as a list of IDs from https://api.reliefweb.int/v1/references/languages.",
+            "description": "Language(s) in which this advertisement is written as a list of IDs from https://api.reliefweb.int/v1/references/languages.",
             "type": "array",
             "items": {
                 "type": "integer"
@@ -231,7 +231,7 @@
     },
     "allOf": [
         {
-            "description": "The country field is mandatory if the training format contains on-site otherwise the country field is not allowed",
+            "description": "The country field is mandatory if the training format is 'on-site' otherwise the country field is not allowed",
             "if": {
                 "properties": {
                     "format": {


### PR DESCRIPTION
Refs: RW-831

Includes the information from https://unitednations.sharepoint.com/:w:/r/sites/OCHAIMB/Digital%20Services%20Section/06_Projects/ReliefWeb/ReliefWeb%20API/ReliefWeb%20POST%20API%20-%20starting%202024/ReliefWeb%20Post%20API%20%E2%80%93%20Editorial%20guidelines.docx?d=w6774e15ece2349e0813973d88c6e01b4&csf=1&web=1&e=muNaiv - and tries to gather everything into one place.

I was looking for a reference for this, but couldn't find one:
```
                {
                    "description": "Must contain letters (any language).",
                    "pattern": "\\p{L}+"
                },
```
I understand that `L` also includes numbers, punctuation, html tags, etc, but I'm not sure what it excludes.