### PR TITLE
[OPS-10828] Add Entra ID login/registration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "unocha/gtm_barebones": "^1.1",
         "unocha/ocha_ai": "^1.7",
         "unocha/ocha_content_classification": "^1.0",
+        "unocha/ocha_entraid": "^1.0",
         "unocha/ocha_monitoring": "^1.0",
         "webflo/drupal-finder": "^1.2.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8b3d79cb86b6b8956b17662a2b2dba7",
+    "content-hash": "44aba325c78bc76813d54e96d5698924",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -17721,6 +17721,49 @@
                 "source": "https://github.com/UN-OCHA/ocha_content_classification/tree/v1.0.1"
             },
             "time": "2024-11-15T07:26:19+00:00"
+        },
+        {
+            "name": "unocha/ocha_entraid",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/UN-OCHA/ocha_entraid.git",
+                "reference": "bc788a50b42971f4dbbfb101c619cf033cdceb4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/UN-OCHA/ocha_entraid/zipball/bc788a50b42971f4dbbfb101c619cf033cdceb4d",
+                "reference": "bc788a50b42971f4dbbfb101c619cf033cdceb4d",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/core": "^10",
+                "drupal/honeypot": "^2",
+                "drupal/openid_connect": "dev-3.x",
+                "drupal/openid_connect_windows_aad": "^2.0@beta",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "drupal/coder": "^8.3",
+                "phpcompatibility/php-compatibility": "^9.3"
+            },
+            "type": "drupal-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "UNOCHA"
+                }
+            ],
+            "description": "OCHA Entra ID module",
+            "support": {
+                "issues": "https://github.com/UN-OCHA/ocha_entraid/issues",
+                "source": "https://github.com/UN-OCHA/ocha_entraid/tree/v1.0.0"
+            },
+            "time": "2024-11-12T06:36:39+00:00"
         },
         {
             "name": "unocha/ocha_monitoring",

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -61,6 +61,7 @@ module:
   ocha_ai: 0
   ocha_ai_chat: 0
   ocha_ai_tag: 0
+  ocha_entraid: 0
   ocha_content_classification: 0
   ocha_monitoring: 0
   openid_connect: 0

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -77,7 +77,6 @@ module:
   reliefweb_disaster_map: 0
   reliefweb_dsr: 0
   reliefweb_entities: 0
-  reliefweb_entraid: 0
   reliefweb_fields: 0
   reliefweb_files: 0
   reliefweb_form: 0

--- a/config/ocha_entraid.settings.yml
+++ b/config/ocha_entraid.settings.yml
@@ -1,0 +1,30 @@
+_core:
+  default_config_hash: NAmQvdKWBfPlHEZzOU3fgGjxcYBQTfz7xn9goDv0r80
+uimc_api:
+  token_url: ''
+  registration_url: ''
+  user_details_url: ''
+  group_management_url: ''
+  username: ''
+  password: ''
+  consumer_key: ''
+  consumer_secret: ''
+  send_email: false
+  verify_ssl: true
+  request_timeout: 10
+  default_group: ''
+  encryption_key: ''
+messages:
+  invalid_email: 'Invalid valid email address.'
+  login_explanation: '<p>Please enter your email address to access your account.</p>'
+  login_account_blocked: 'We encountered an issue with your account. Please reach out for assistance.'
+  login_account_not_found: 'We were unable to find your account. Please check your information and try again.'
+  login_account_verification_error: 'We encountered an issue while verifying your account. Please try again later or reach out for assistance if the problem persists.'
+  login_redirection_error: 'We are experiencing difficulties with the login process. Please try again later or reach out for assistance if the issue continues.'
+  registration_explanation: '<p>Create an account to easily access our services.<br>If you already possess a UN email address, please <a href="/user/login/entraid">log in here</a> directly.</p>'
+  registration_invalid_first_name: 'First name must contain only letters, spaces, hyphens, or apostrophes and be no longer than 30 characters.'
+  registration_invalid_last_name: 'Last name must contain only letters, spaces, hyphens, or apostrophes and be no longer than 30 characters.'
+  registration_invalid_email: 'Email must contain only letters, numbers, hyphens, or periods and be no longer than 100 characters.'
+  registration_success: 'Thank you for signing up. Please wait a moment and then log in to finalize your registration.'
+  registration_success_with_email: 'Thank you for signing up! A confirmation email has been sent to your mailbox. Please check your email and follow the instructions to finalize your registration.'
+  registration_failure: 'We encountered an issue while processing your registration. Please try again later or reach out for assistance.'

--- a/html/modules/custom/reliefweb_entraid/README.md
+++ b/html/modules/custom/reliefweb_entraid/README.md
@@ -3,4 +3,4 @@ Reliefweb Entra ID
 
 This module provides user authentication tweaks for Entra ID
 
-* Provide a `/user/login/entraid` callback to redirect to the Entra ID login workflow.
+* Provide a `/user/login/reliefweb-entraid-direct` callback to redirect to the Entra ID login workflow.

--- a/html/modules/custom/reliefweb_entraid/reliefweb_entraid.routing.yml
+++ b/html/modules/custom/reliefweb_entraid/reliefweb_entraid.routing.yml
@@ -1,5 +1,5 @@
 reliefweb_entraid.login:
-  path: '/user/login/entraid'
+  path: '/user/login/reliefweb-entraid-direct'
   defaults:
     _controller: '\Drupal\reliefweb_entraid\Controller\AuthController::redirectLogin'
     _title: 'Login with Unite ID'

--- a/html/modules/custom/reliefweb_entraid/tests/src/ExistingSite/ReliefwebEntraidLoginTest.php
+++ b/html/modules/custom/reliefweb_entraid/tests/src/ExistingSite/ReliefwebEntraidLoginTest.php
@@ -49,6 +49,12 @@ class ReliefwebEntraidLoginTest extends ExistingSiteBase {
    * @covers ::redirectLogin()
    */
   public function testRedirectLogin() {
+    // Skip if the module is not installed.
+    if (!$this->container->get('module_handler')->moduleExists('reliefweb_entraid')) {
+      $this->assertTrue(TRUE);
+      return;
+    }
+
     // Get the EntraID configuration.
     $entraid_config = $this->container
       ->get('config.factory')

--- a/html/modules/custom/reliefweb_entraid/tests/src/ExistingSite/ReliefwebEntraidLoginTest.php
+++ b/html/modules/custom/reliefweb_entraid/tests/src/ExistingSite/ReliefwebEntraidLoginTest.php
@@ -63,7 +63,7 @@ class ReliefwebEntraidLoginTest extends ExistingSiteBase {
 
     // The incomplete config will results in an exception and 404 response
     // will be returned.
-    $this->drupalGet('/user/login/entraid');
+    $this->drupalGet('/user/login/reliefweb-entraid-direct');
     $this->assertSession()->statusCodeEquals(404);
 
     // Set the endpoints. We just point at the robots.txt as we know it exists
@@ -75,7 +75,7 @@ class ReliefwebEntraidLoginTest extends ExistingSiteBase {
     $entraid_config->setData($data)->save();
 
     // If the redirection works, a 200 will be returned.
-    $this->drupalGet('/user/login/entraid');
+    $this->drupalGet('/user/login/reliefweb-entraid-direct');
     $this->assertSession()->statusCodeEquals(200);
     $this->assertStringContainsString('Disallow:', $this->getSession()->getPage()->getContent());
   }


### PR DESCRIPTION
Refs: OPS-10828, OPS-10896

This adds the https://github.com/UN-OCHA/ocha_entraid module and disable the `reliefweb_entraid` module (to be removed in another PR).

Note: permissions to access the login and registration forms are not yet set since we are still waiting for some approval (see OPS-10896) but that can be added via the UI and later saved to code (see https://github.com/UN-OCHA/rwint9-site/pull/960)