### PR TITLE
[RW-1155] Add module to help against job/training post spamming

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -72,6 +72,7 @@ module:
   redirect: 0
   reliefweb_ai: 0
   reliefweb_analytics: 0
+  reliefweb_anti_spam: 0
   reliefweb_api: 0
   reliefweb_bookmarks: 0
   reliefweb_contact: 0

--- a/config/reliefweb_anti_spam.settings.yml
+++ b/config/reliefweb_anti_spam.settings.yml
@@ -1,0 +1,15 @@
+_core:
+  default_config_hash: VtU3f6WKNIyX9_daOVXiXfzX2-dlruf6cVe0s-LKreM
+post_limit:
+  enabled: true
+  number: 1
+  frequency: day
+validation:
+  blacklisted_domains: ''
+  title_min_words: 2
+  title_min_length: 10
+  body_min_words: 20
+  body_min_length: 100
+error_messages:
+  content_quality: 'The content of your submission does not meet our quality standards. Please review and revise.'
+  submission_frequency: 'You have reached the maximum number of submissions allowed at this time. Please try again later.'

--- a/config/reliefweb_anti_spam.settings.yml
+++ b/config/reliefweb_anti_spam.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: VtU3f6WKNIyX9_daOVXiXfzX2-dlruf6cVe0s-LKreM
 post_limit:
   enabled: true
-  number: 1
+  number: 5
   frequency: day
 validation:
   blacklisted_domains: ''

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -31,6 +31,7 @@ dependencies:
     - node
     - ocha_content_classification
     - path
+    - reliefweb_anti_spam
     - reliefweb_bookmarks
     - reliefweb_fields
     - reliefweb_files
@@ -64,6 +65,7 @@ permissions:
   - 'administer url aliases'
   - 'archive content'
   - 'bypass ocha content classification'
+  - 'bypass reliefweb anti spam'
   - 'create announcement content'
   - 'create blog_post content'
   - 'create book content'

--- a/config/user.role.webmaster.yml
+++ b/config/user.role.webmaster.yml
@@ -27,6 +27,7 @@ dependencies:
     - guidelines
     - ocha_ai
     - ocha_ai_chat
+    - reliefweb_anti_spam
     - reliefweb_bookmarks
     - reliefweb_guidelines
     - reliefweb_users
@@ -43,6 +44,7 @@ permissions:
   - 'access taxonomy overview'
   - 'add content to books'
   - 'add guideline entities'
+  - 'administer reliefweb anti-spam settings'
   - 'create new books'
   - 'create terms in career_category'
   - 'create terms in content_format'

--- a/html/modules/custom/reliefweb_anti_spam/README.md
+++ b/html/modules/custom/reliefweb_anti_spam/README.md
@@ -1,0 +1,4 @@
+ReliefWeb Anti-spam
+===================
+
+This module adds extra validation to limit job/training spamming.

--- a/html/modules/custom/reliefweb_anti_spam/config/install/reliefweb_anti_spam.settings.yml
+++ b/html/modules/custom/reliefweb_anti_spam/config/install/reliefweb_anti_spam.settings.yml
@@ -1,0 +1,13 @@
+post_limit:
+  enabled: true
+  number: 1
+  frequency: 'day'
+validation:
+  blacklisted_domains: ''
+  title_min_words: 3
+  title_min_length: 20
+  body_min_words: 50
+  body_min_length: 200
+error_messages:
+  content_quality: 'The content of your submission does not meet our quality standards. Please review and revise.'
+  submission_frequency: 'You have reached the maximum number of submissions allowed at this time. Please try again later.'

--- a/html/modules/custom/reliefweb_anti_spam/config/schema/reliefweb_anti_spam.schema.yml
+++ b/html/modules/custom/reliefweb_anti_spam/config/schema/reliefweb_anti_spam.schema.yml
@@ -1,0 +1,46 @@
+reliefweb_anti_spam.settings:
+  type: config_object
+  label: 'ReliefWeb Anti-Spam settings'
+  mapping:
+    post_limit:
+      type: mapping
+      label: 'Post limit settings'
+      mapping:
+        enabled:
+          type: boolean
+          label: 'Enable post limit'
+        number:
+          type: integer
+          label: 'Number of posts'
+        frequency:
+          type: string
+          label: 'Frequency'
+    validation:
+      type: mapping
+      label: 'Validation settings'
+      mapping:
+        blacklisted_domains:
+          type: string
+          label: 'Blacklisted domains'
+        title_min_words:
+          type: integer
+          label: 'Minimum words in title'
+        title_min_length:
+          type: integer
+          label: 'Minimum length of title'
+        body_min_words:
+          type: integer
+          label: 'Minimum words in body'
+        body_min_length:
+          type: integer
+          label: 'Minimum length of body'
+    error_messages:
+      type: mapping
+      label: 'Error messages'
+      mapping:
+        content_quality:
+          type: string
+          label: 'Content quality error message'
+        submission_frequency:
+          type: string
+          label: 'Submission frequency error message'

--- a/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.info.yml
+++ b/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.info.yml
@@ -1,0 +1,7 @@
+type: module
+name: ReliefWeb Anti-Spam
+description: Limits job and training post spamming on ReliefWeb by implementing submission restrictions.
+package: ReliefWeb
+core_version_requirement: ^10 || ^11
+dependencies:
+  - reliefweb_moderation:reliefweb_moderation

--- a/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.links.menu.yml
+++ b/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.links.menu.yml
@@ -1,0 +1,6 @@
+reliefweb_anti_spam.settings:
+  title: 'ReliefWeb Anti-Spam'
+  description: 'Configure ReliefWeb Anti-Spam settings.'
+  parent: system.admin_config_content
+  route_name: reliefweb_anti_spam.settings
+  weight: 100

--- a/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.module
+++ b/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.module
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * @file
+ * Module file for the reliefweb_anti_spam module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\reliefweb_moderation\Helpers\UserPostingRightsHelper;
+use Drupal\reliefweb_utility\Helpers\TextHelper;
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Adds custom validation to job and training node forms.
+ */
+function reliefweb_anti_spam_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  // Job and training creation form.
+  $form_ids = [
+    'node_job_form',
+    'node_training_form',
+  ];
+
+  // Add the anti spam validation early to bail out quickly.
+  if (in_array($form_id, $form_ids)) {
+    if (isset($form['#validate'])) {
+      $form['#validate'][] = 'reliefweb_anti_spam_node_form_validate';
+    }
+    else {
+      $form['#validate'] = ['reliefweb_anti_spam_node_form_validate'];
+    }
+  }
+}
+
+/**
+ * Custom validation handler for job and training node forms.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ */
+function reliefweb_anti_spam_node_form_validate(array &$form, FormStateInterface $form_state): void {
+  /** @var \Drupal\Core\Session\AccountInterface $user */
+  $user = \Drupal::currentUser();
+
+  // Check if the user has permission to bypass anti-spam validation.
+  if ($user->hasPermission('bypass reliefweb anti spam')) {
+    return;
+  }
+
+  /** @var \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory */
+  $logger_factory = \Drupal::service('logger.factory');
+  $logger = $logger_factory->get('reliefweb_anti_spam');
+
+  $config = \Drupal::config('reliefweb_anti_spam.settings');
+  $node = $form_state->getFormObject()->getEntity();
+  $bundle = $node->bundle();
+  $node_id = (int) $node->id();
+
+  // Check submission frequency if the user has never been validated for any
+  // source, meaning the user is not allowed or trusted for any source.
+  if (!UserPostingRightsHelper::isUserAllowedOrTrustedForAnySource($user, $bundle)) {
+    if ($config->get('post_limit.enabled') && !reliefweb_anti_spam_check_submission_frequency($user, $bundle, $node_id)) {
+      $form_state->setError($form, $config->get('error_messages.submission_frequency'));
+      $logger->warning('Submission frequency limit exceeded for user @uid', ['@uid' => $user->id()]);
+      return;
+    }
+  }
+
+  // Check content quality.
+  $title = TextHelper::sanitizeText($form_state->getValue('title')[0]['value'] ?? '');
+  $body = TextHelper::sanitizeText(strip_tags($form_state->getValue('body')[0]['value'] ?? ''), TRUE);
+  $how_to_apply = TextHelper::sanitizeText(strip_tags($form_state->getValue('field_how_to_apply')[0]['value'] ?? ''), TRUE);
+
+  if (reliefweb_anti_spam_check_blacklisted_domains($title . ' ' . $body . ' ' . $how_to_apply)) {
+    $form_state->setError($form, $config->get('error_messages.content_quality'));
+    $logger->warning('Blacklisted domain detected in submission from user @uid', ['@uid' => $user->id()]);
+    return;
+  }
+
+  if (reliefweb_anti_spam_contains_url($title)) {
+    $form_state->setError($form, $config->get('error_messages.content_quality'));
+    $logger->warning('URL detected in title of submission from user @uid', ['@uid' => $user->id()]);
+    return;
+  }
+
+  if (reliefweb_anti_spam_only_contains_urls($body)) {
+    $form_state->setError($form, $config->get('error_messages.content_quality'));
+    $logger->warning('Body only contains URLs in submission from user @uid', ['@uid' => $user->id()]);
+    return;
+  }
+
+  if (!reliefweb_anti_spam_check_word_count('title', $title)) {
+    $form_state->setError($form, $config->get('error_messages.content_quality'));
+    $logger->warning('Title word count requirements not met in submission from user @uid', ['@uid' => $user->id()]);
+    return;
+  }
+
+  if (!reliefweb_anti_spam_check_content_length('title', $title)) {
+    $form_state->setError($form, $config->get('error_messages.content_quality'));
+    $logger->warning('Title content length requirements not met in submission from user @uid', ['@uid' => $user->id()]);
+    return;
+  }
+
+  if (!reliefweb_anti_spam_check_word_count('body', $body)) {
+    $form_state->setError($form, $config->get('error_messages.content_quality'));
+    $logger->warning('Body word count requirements not met in submission from user @uid', ['@uid' => $user->id()]);
+    return;
+  }
+
+  if (!reliefweb_anti_spam_check_content_length('body', $body)) {
+    $form_state->setError($form, $config->get('error_messages.content_quality'));
+    $logger->warning('Body content length requirements not met in submission from user @uid', ['@uid' => $user->id()]);
+    return;
+  }
+}
+
+/**
+ * Check if the user has exceeded the submission frequency limit.
+ *
+ * @param \Drupal\Core\Session\AccountInterface $user
+ *   The user to check.
+ * @param string $bundle
+ *   Entity bundle.
+ * @param ?int $node_id
+ *   Node ID to exclude when retrieving the number of submissions for the user.
+ *
+ * @return bool
+ *   TRUE if the user has not exceeded the limit, FALSE otherwise.
+ */
+function reliefweb_anti_spam_check_submission_frequency(AccountInterface $user, string $bundle, ?int $node_id = NULL): bool {
+  $config = \Drupal::config('reliefweb_anti_spam.settings');
+  $limit = (int) $config->get('post_limit.number');
+  $frequency = $config->get('post_limit.frequency');
+
+  $query = \Drupal::entityQuery('node')
+    ->condition('type', $bundle, '=')
+    ->condition('uid', $user->id())
+    ->accessCheck(FALSE)
+    ->count();
+
+  if (isset($node_id)) {
+    $query->condition('nid', $node_id, '<>');
+  }
+
+  if ($frequency !== 'ever') {
+    $query->condition('created', \Drupal::time()->getRequestTime() - reliefweb_anti_spam_get_frequency_time($frequency), '>=');
+  }
+
+  $count = $query->execute();
+
+  return $count < $limit;
+}
+
+/**
+ * Convert frequency string to seconds.
+ *
+ * @param string $frequency
+ *   The frequency string (hour, day, week, month, year, or ever).
+ *
+ * @return int
+ *   The number of seconds for the given frequency.
+ */
+function reliefweb_anti_spam_get_frequency_time(string $frequency): int {
+  return match ($frequency) {
+    'hour' => 3600,
+    'day' => 86400,
+    'week' => 604800,
+    'month' => 2592000,
+    'year' => 31536000,
+    default => 0,
+  };
+}
+
+/**
+ * Check if content contains blacklisted domains.
+ *
+ * @param string $content
+ *   The content to check.
+ *
+ * @return bool
+ *   TRUE if blacklisted domains are found, FALSE otherwise.
+ */
+function reliefweb_anti_spam_check_blacklisted_domains(string $content): bool {
+  $config = \Drupal::config('reliefweb_anti_spam.settings');
+  $blacklisted_domains = explode("\n", $config->get('validation.blacklisted_domains'));
+
+  foreach ($blacklisted_domains as $domain) {
+    $domain = trim($domain);
+    if (!empty($domain) && mb_stripos($content, $domain) !== FALSE) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+ * Check if a string contains a URL.
+ *
+ * @param string $text
+ *   The text to check.
+ *
+ * @return bool
+ *   TRUE if the text contains a URL, FALSE otherwise.
+ */
+function reliefweb_anti_spam_contains_url(string $text): bool {
+  return (bool) preg_match('/https?:\/\//u', $text);
+}
+
+/**
+ * Check if a string only contains URLs.
+ *
+ * @param string $text
+ *   The text to check.
+ *
+ * @return bool
+ *   TRUE if the text only contains URLs, FALSE otherwise.
+ */
+function reliefweb_anti_spam_only_contains_urls(string $text): bool {
+  return (bool) preg_match('/^(https?:\/\/\S+\s*)+$/u', $text);
+}
+
+/**
+ * Check if content meets minimum word count requirements.
+ *
+ * @param string $field
+ *   Field to check (title or body).
+ * @param string $value
+ *   Field value.
+ *
+ * @return bool
+ *   TRUE if content meets requirements, FALSE otherwise.
+ */
+function reliefweb_anti_spam_check_word_count(string $field, string $value): bool {
+  $min = \Drupal::config('reliefweb_anti_spam.settings')
+    ->get('validation.' . $field . '_min_words');
+
+  $word_count = count(preg_split('/\s+/u', $value, -1, PREG_SPLIT_NO_EMPTY));
+
+  return $word_count >= $min;
+}
+
+/**
+ * Check if content meets minimum length requirements.
+ *
+ * @param string $field
+ *   Field to check (title or body).
+ * @param string $value
+ *   Field value.
+ *
+ * @return bool
+ *   TRUE if content meets requirements, FALSE otherwise.
+ */
+function reliefweb_anti_spam_check_content_length(string $field, string $value): bool {
+  $min = \Drupal::config('reliefweb_anti_spam.settings')
+    ->get('validation.' . $field . '_min_length');
+
+  return mb_strlen($value) >= $min;
+}

--- a/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.permissions.yml
+++ b/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.permissions.yml
@@ -1,0 +1,7 @@
+administer reliefweb anti-spam settings:
+  title: 'Administer ReliefWeb Anti-Spam settings'
+  description: 'Allow access to the ReliefWeb Anti-Spam settings form.'
+
+bypass reliefweb anti spam:
+  title: 'Bypass ReliefWeb Anti-Spam validation'
+  description: 'Allow users to bypass the anti-spam checks when submitting job or training posts.'

--- a/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.routing.yml
+++ b/html/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.routing.yml
@@ -1,0 +1,7 @@
+reliefweb_anti_spam.settings:
+  path: '/admin/config/content/reliefweb-anti-spam'
+  defaults:
+    _form: '\Drupal\reliefweb_anti_spam\Form\ReliefWebAntiSpamSettingsForm'
+    _title: 'ReliefWeb Anti-Spam Settings'
+  requirements:
+    _permission: 'administer reliefweb anti-spam settings'

--- a/html/modules/custom/reliefweb_anti_spam/src/Form/ReliefWebAntiSpamSettingsForm.php
+++ b/html/modules/custom/reliefweb_anti_spam/src/Form/ReliefWebAntiSpamSettingsForm.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\reliefweb_anti_spam\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configuration form for ReliefWeb Anti-Spam settings.
+ */
+class ReliefWebAntiSpamSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['reliefweb_anti_spam.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'reliefweb_anti_spam_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('reliefweb_anti_spam.settings');
+
+    // Unverified User Post Limit.
+    $form['post_limit'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Unverified User Post Limit'),
+      '#tree' => TRUE,
+    ];
+
+    $form['post_limit']['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable post limit for unverified users'),
+      '#default_value' => $config->get('post_limit.enabled') ?? FALSE,
+    ];
+
+    $form['post_limit']['number'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Number of posts'),
+      '#min' => 1,
+      '#default_value' => $config->get('post_limit.number') ?? 1,
+      '#states' => [
+        'visible' => [
+          ':input[name="post_limit[enabled]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['post_limit']['frequency'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Frequency'),
+      '#options' => [
+        'ever' => $this->t('Ever (until verified)'),
+        'hour' => $this->t('Per hour'),
+        'day' => $this->t('Per day'),
+        'week' => $this->t('Per week'),
+        'month' => $this->t('Per month'),
+        'year' => $this->t('Per year'),
+      ],
+      '#default_value' => $config->get('post_limit.frequency') ?? 'day',
+      '#states' => [
+        'visible' => [
+          ':input[name="post_limit[enabled]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    // Validation Settings.
+    $form['validation'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Validation Settings'),
+      '#tree' => TRUE,
+    ];
+
+    $form['validation']['blacklisted_domains'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Blacklisted domains'),
+      '#description' => $this->t('Enter one domain per line. Posts containing these domains in title, body, or "How to Apply" field will be rejected.'),
+      '#default_value' => $config->get('validation.blacklisted_domains') ?? '',
+    ];
+
+    $form['validation']['title_min_words'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Minimum number of words in title'),
+      '#min' => 1,
+      '#default_value' => $config->get('validation.title_min_words') ?? 3,
+    ];
+
+    $form['validation']['title_min_length'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Minimum length of title'),
+      '#min' => 1,
+      '#default_value' => $config->get('validation.title_min_length') ?? 20,
+    ];
+
+    $form['validation']['body_min_words'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Minimum number of words in body'),
+      '#min' => 1,
+      '#default_value' => $config->get('validation.body_min_words') ?? 50,
+    ];
+
+    $form['validation']['body_min_length'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Minimum length of body'),
+      '#min' => 1,
+      '#default_value' => $config->get('validation.body_min_length') ?? 200,
+    ];
+
+    // Tiered Error Messages.
+    $form['error_messages'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Error Messages'),
+      '#tree' => TRUE,
+    ];
+
+    $form['error_messages']['content_quality'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Content Quality Error'),
+      '#default_value' => $config->get('error_messages.content_quality') ?? 'The content of your submission does not meet our quality standards. Please review and revise.',
+      '#description' => $this->t('This message will be shown for issues related to content quality (e.g., minimum length, word count, blacklisted domains).'),
+    ];
+
+    $form['error_messages']['submission_frequency'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Submission Frequency Error'),
+      '#default_value' => $config->get('error_messages.submission_frequency') ?? 'You have reached the maximum number of submissions allowed at this time. Please try again later.',
+      '#description' => $this->t('This message will be shown when a user exceeds the allowed submission frequency.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $config = $this->config('reliefweb_anti_spam.settings');
+
+    // Save post limit settings.
+    $config->set('post_limit.enabled', $form_state->getValue(['post_limit', 'enabled']));
+    $config->set('post_limit.number', $form_state->getValue(['post_limit', 'number']));
+    $config->set('post_limit.frequency', $form_state->getValue(['post_limit', 'frequency']));
+
+    // Save validation settings.
+    $config->set('validation.blacklisted_domains', $form_state->getValue(['validation', 'blacklisted_domains']));
+    $config->set('validation.title_min_words', $form_state->getValue(['validation', 'title_min_words']));
+    $config->set('validation.title_min_length', $form_state->getValue(['validation', 'title_min_length']));
+    $config->set('validation.body_min_words', $form_state->getValue(['validation', 'body_min_words']));
+    $config->set('validation.body_min_length', $form_state->getValue(['validation', 'body_min_length']));
+
+    // Save tiered error messages.
+    $config->set('error_messages.content_quality', $form_state->getValue(['error_messages', 'content_quality']));
+    $config->set('error_messages.submission_frequency', $form_state->getValue(['error_messages', 'submission_frequency']));
+
+    $config->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/html/modules/custom/reliefweb_anti_spam/tests/src/ExistingSite/ReliefWebAntiSpamTest.php
+++ b/html/modules/custom/reliefweb_anti_spam/tests/src/ExistingSite/ReliefWebAntiSpamTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\reliefweb_anti_spam\ExistingSite;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Tests for the ReliefWeb Anti-Spam module.
+ *
+ * @group reliefweb_anti_spam
+ */
+class ReliefWebAntiSpamTest extends ExistingSiteBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'taxonomy',
+    'reliefweb_anti_spam',
+    'reliefweb_moderation',
+    'reliefweb_utility',
+  ];
+
+  /**
+   * Original configuration values for restoration after the test run.
+   *
+   * @var array
+   */
+  protected array $originalConfiguration = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->setConfigValues('reliefweb_anti_spam.settings', [
+      'post_limit.enabled' => TRUE,
+      'post_limit.number' => 1,
+      'post_limit.frequency' => 'day',
+      'validation.blacklisted_domains' => '',
+      'validation.title_min_words' => 1,
+      'validation.title_min_length' => 1,
+      'validation.body_min_words' => 1,
+      'validation.body_min_length' => 1,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    $this->resetConfigValues();
+    parent::tearDown();
+  }
+
+  /**
+   * Replace configuration values and store the original ones.
+   *
+   * @param string $name
+   *   Config name.
+   * @param array $values
+   *   Associative array of config values to override.
+   */
+  protected function setConfigValues(string $name, array $values): void {
+    $config = $this->container->get('config.factory')->getEditable($name);
+    foreach ($values as $key => $value) {
+      if (!isset($this->originalConfiguration[$name][$key])) {
+        $this->originalConfiguration[$name][$key] = $config->get($key);
+      }
+      $config->set($key, $value);
+    }
+    $config->save();
+  }
+
+  /**
+   * Reset the configuration changes.
+   */
+  protected function resetConfigValues(): void {
+    $config_factory = $this->container->get('config.factory');
+    foreach ($this->originalConfiguration as $name => $values) {
+      $config = $config_factory->getEditable($name);
+      foreach ($values as $key => $value) {
+        $config->set($key, $value);
+      }
+      $config->save();
+    }
+  }
+
+  /**
+   * Tests that a user cannot submit a job with a blacklisted domain.
+   */
+  public function testBlacklistedDomainSubmission(): void {
+    // Create a user with permissions to create job nodes and log in.
+    $user = $this->createUser(['create job content']);
+    $this->drupalLogin($user);
+
+    // Set up configuration with a blacklisted domain.
+    $this->setConfigValues('reliefweb_anti_spam.settings', [
+      'validation.blacklisted_domains' => 'blacklisteddomain.com',
+    ]);
+
+    // Navigate to the form page.
+    $this->drupalGet('/node/add/job');
+
+    // Submit the form.
+    $this->submitForm([
+      'title[0][value]' => 'Job Title with blacklisteddomain.com',
+      'body[0][value]' => 'This is a job description.',
+      'field_how_to_apply[0][value]' => 'Apply here.',
+    ], 'Submit');
+
+    // Get the error message.
+    $message = $this->container->get('config.factory')
+      ->get('reliefweb_anti_spam.settings')
+      ->get('error_messages.content_quality');
+
+    // Assert that an error message is displayed.
+    $this->assertSession()->pageTextContains($message);
+  }
+
+  /**
+   * Tests that a user cannot exceed submission frequency limits.
+   */
+  public function testSubmissionFrequencyLimit(): void {
+    // Create a user with permissions to create job nodes and log in.
+    $user = $this->createUser(['create job content']);
+    $this->drupalLogin($user);
+
+    // Set up configuration for post limit.
+    $this->setConfigValues('reliefweb_anti_spam.settings', [
+      'post_limit.enabled' => TRUE,
+       // Allow only one submission.
+      'post_limit.number' => 1,
+      // Set frequency to daily.
+      'post_limit.frequency' => 'day',
+    ]);
+
+    // Create a job posted by the user to simulate a previous submission.
+    $this->createNode([
+      'type' => 'job',
+      'uid' => $user->id(),
+    ]);
+
+    // Navigate to the form page.
+    $this->drupalGet('/node/add/job');
+
+    // Attempt to create a second job node submission within the same frequency
+    // period.
+    $this->submitForm([
+      'title[0][value]' => 'Second Job Title',
+      'body[0][value]' => 'This is the second job description.',
+      'field_how_to_apply[0][value]' => 'Apply here.',
+    ], 'Submit');
+
+    // Assert that an error message is displayed for exceeding submission limit.
+    $message = $this->container->get('config.factory')
+      ->get('reliefweb_anti_spam.settings')
+      ->get('error_messages.submission_frequency');
+
+    // Assert that the error message is displayed on the page.
+    $this->assertSession()->pageTextContains($message);
+  }
+
+  /**
+   * Tests that valid submissions are accepted without errors.
+   */
+  public function testValidSubmission(): void {
+    // Create a user with permissions to create job nodes and log in.
+    $user = $this->createUser(['create job content']);
+    $this->drupalLogin($user);
+
+    // Set up configuration without blacklisted domains and allow submissions.
+    $this->setConfigValues('reliefweb_anti_spam.settings', [
+      'validation.blacklisted_domains' => '',
+      // Disable post limit for this test.
+      'post_limit.enabled' => FALSE,
+    ]);
+
+    // Navigate to the form page.
+    $this->drupalGet('/node/add/job');
+
+    // Create a valid job node submission.
+    $this->submitForm([
+      'title[0][value]' => 'Valid Job Title',
+      'body[0][value]' => 'This is a valid job description.',
+      'field_how_to_apply[0][value]' => 'Apply here.',
+    ], 'Submit');
+
+    // Assert that the submission was successful and redirected to the node
+    // page.
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+  /**
+   * Tests that a user cannot submit a job with a URL in the title.
+   */
+  public function testUrlInTitleSubmission(): void {
+    // Create a user with permissions to create job nodes and log in.
+    $user = $this->createUser(['create job content']);
+    $this->drupalLogin($user);
+
+    // Navigate to the form page.
+    $this->drupalGet('/node/add/job');
+
+    // Submit the form with URL in title.
+    $this->submitForm([
+      'title[0][value]' => 'Job Title with http://example.com',
+      'body[0][value]' => 'This is a valid job description.',
+      'field_how_to_apply[0][value]' => 'Apply here.',
+    ], 'Submit');
+
+    // Get the error message for URL in title validation.
+    $message = $this->container->get('config.factory')
+      ->get('reliefweb_anti_spam.settings')
+      ->get('error_messages.content_quality');
+
+    // Assert that an error message is displayed for URL in title.
+    $this->assertSession()->pageTextContains($message);
+  }
+
+  /**
+   * Tests that a user cannot submit a body containing only URLs.
+   */
+  public function testBodyOnlyUrlsSubmission(): void {
+    // Create a user with permissions to create job nodes and log in.
+    $user = $this->createUser(['create job content']);
+    $this->drupalLogin($user);
+
+    // Navigate to the form page.
+    $this->drupalGet('/node/add/job');
+
+    // Submit the form with body containing only URLs.
+    $this->submitForm([
+      'title[0][value]' => 'Valid Job Title',
+      'body[0][value]' => "http://example.com\nhttp://anotherexample.com",
+      'field_how_to_apply[0][value]' => '',
+    ], 'Submit');
+
+    // Get the error message for body only URLs validation.
+    $message = $this->container->get('config.factory')
+      ->get('reliefweb_anti_spam.settings')
+      ->get('error_messages.content_quality');
+
+    // Assert that an error message is displayed for body containing only URLs.
+    $this->assertSession()->pageTextContains($message);
+  }
+
+}

--- a/html/modules/custom/reliefweb_anti_spam/tests/src/Unit/ReliefWebAntiSpamTest.php
+++ b/html/modules/custom/reliefweb_anti_spam/tests/src/Unit/ReliefWebAntiSpamTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Drupal\Tests\reliefweb_anti_spam\Unit;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Unit tests for the reliefweb_anti_spam module.
+ *
+ * @group reliefweb_anti_spam
+ */
+class ReliefWebAntiSpamTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // DEBUG.
+    require_once DRUPAL_ROOT . '/modules/custom/reliefweb_anti_spam/reliefweb_anti_spam.module';
+
+    parent::setUp();
+
+    $container = new ContainerBuilder();
+
+    $this->setUpConfigFactory($container);
+    $this->setUpTimeService($container);
+
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Sets up the configuration factory mock.
+   *
+   * @param \Drupal\Core\DependencyInjection\ContainerInterface $container
+   *   The container to which set the service.
+   * @param array $settings
+   *   Settings overrides.
+   */
+  protected function setUpConfigFactory(ContainerInterface $container, array $settings = []): void {
+    $settings += [
+      'post_limit.enabled' => TRUE,
+      'post_limit.number' => 5,
+      'post_limit.frequency' => 'day',
+      'validation.blacklisted_domains' => 'badsite.com',
+      'validation.title_min_words' => 3,
+      'validation.title_min_length' => 10,
+      'validation.body_min_words' => 5,
+      'validation.body_min_length' => 20,
+    ];
+
+    // Create a mock configuration.
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnMap([
+      ['post_limit.enabled', $settings['post_limit.enabled']],
+      ['post_limit.number', $settings['post_limit.number']],
+      ['post_limit.frequency', $settings['post_limit.frequency']],
+      ['validation.blacklisted_domains', $settings['validation.blacklisted_domains']],
+      ['validation.title_min_words', $settings['validation.title_min_words']],
+      ['validation.title_min_length', $settings['validation.title_min_length']],
+      ['validation.body_min_words', $settings['validation.body_min_words']],
+      ['validation.body_min_length', $settings['validation.body_min_length']],
+    ]);
+
+    // Mock the config factory service.
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_factory->method('get')->willReturn($config);
+
+    // Set up the container with the mocked config factory.
+    $container->set('config.factory', $config_factory);
+  }
+
+  /**
+   * Sets up the time service mock.
+   *
+   * @param \Drupal\Core\DependencyInjection\ContainerInterface $container
+   *   The container to which set the service.
+   */
+  protected function setUpTimeService(ContainerInterface $container) {
+    // Create a mock for the TimeInterface service.
+    $time_service = $this->createMock(TimeInterface::class);
+
+    // Set up expected behavior for time-related methods.
+    $time_service->method('getRequestTime')->willReturn(time());
+
+    // Set up container with mocked time service.
+    $container->set('datetime.time', $time_service);
+  }
+
+  /**
+   * Sets up the entity query mock.
+   *
+   * @param \Drupal\Core\DependencyInjection\ContainerInterface $container
+   *   The container to which set the service.
+   * @param int $result
+   *   Result of the count query.
+   */
+  protected function setUpEntityQuery(ContainerInterface $container, int $result): void {
+    // Mock the entity storage.
+    $entity_storage = $this->createMock(EntityStorageInterface::class);
+
+    // Mock the query object.
+    $query = $this->createMock(QueryInterface::class);
+
+    // Set up expected behavior for the query.
+    $query->method('condition')->willReturn($query);
+    $query->method('accessCheck')->willReturn($query);
+    $query->method('count')->willReturn($query);
+    $query->method('execute')->willReturn($result);
+
+    // Mock the getQuery method to return our mocked query.
+    $entity_storage->method('getQuery')->willReturn($query);
+
+    // Mock the entity type manager.
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+
+    // Set up expected behavior for getting storage.
+    $entity_type_manager->method('getStorage')->willReturn($entity_storage);
+
+    // Set up the container with the mocked entity type manager.
+    $container->set('entity_type.manager', $entity_type_manager);
+    $this->query = $query;
+  }
+
+  /**
+   * Test submission frequency checking.
+   */
+  public function testCheckSubmissionFrequency(): void {
+    // Create a mock user.
+    $user = $this->createMock(UserInterface::class);
+    $user->method('id')->willReturn(123);
+
+    $container = \Drupal::getContainer();
+
+    // Test with frequency set to 'day' and limit set to 5.
+    $this->setUpConfigFactory($container, [
+      'post_limit.number' => 5,
+      'post_limit.frequency' => 'day',
+    ]);
+
+    // Simulate that the user has made 3 submissions.
+    $this->setUpEntityQuery($container, 3);
+    $result = reliefweb_anti_spam_check_submission_frequency($user, 'job');
+    $this->assertTrue($result, 'User should be allowed to submit, as they have not exceeded the limit.');
+
+    // Simulate that the user has made 5 submissions.
+    $this->setUpEntityQuery($container, 5);
+    $result = reliefweb_anti_spam_check_submission_frequency($user, 'job');
+    $this->assertFalse($result, 'User should not be allowed to submit, as they have reached the limit.');
+
+    // Simulate that the user has made 6 submissions.
+    $this->setUpEntityQuery($container, 6);
+    $result = reliefweb_anti_spam_check_submission_frequency($user, 'job');
+    $this->assertFalse($result, 'User should not be allowed to submit, as they have exceeded the limit.');
+
+    // Now test with a frequency of 'ever'.
+    $this->setUpConfigFactory($container, [
+      'post_limit.number' => 3,
+      'post_limit.frequency' => 'ever',
+    ]);
+
+    // Simulate that the user has made 2 submissions.
+    $this->setUpEntityQuery($container, 2);
+    $result = reliefweb_anti_spam_check_submission_frequency($user, 'job');
+    $this->assertTrue($result, 'User should be allowed to submit, as they have not exceeded the limit.');
+
+    // Simulate that the user has made 3 submissions.
+    $this->setUpEntityQuery($container, 3);
+    $result = reliefweb_anti_spam_check_submission_frequency($user, 'job');
+    $this->assertFalse($result, 'User should not be allowed to submit, as they have reached the limit.');
+
+    // Simulate that the user has made 4 submissions.
+    $this->setUpEntityQuery($container, 4);
+    $result = reliefweb_anti_spam_check_submission_frequency($user, 'job');
+    $this->assertFalse($result, 'User should not be allowed to submit, as they have exceeded the limit.');
+  }
+
+  /**
+   * Test blacklisted domains checking.
+   */
+  public function testCheckBlacklistedDomains(): void {
+    // Test content with a blacklisted domain.
+    $content = 'This is a test with a badsite.com link.';
+    $result = reliefweb_anti_spam_check_blacklisted_domains($content);
+    $this->assertTrue($result);
+
+    // Test clean content.
+    $content = 'This is a clean test.';
+    $result = reliefweb_anti_spam_check_blacklisted_domains($content);
+    $this->assertFalse($result);
+  }
+
+  /**
+   * Test URL detection in text.
+   */
+  public function testContainsUrl(): void {
+    // Test text containing URL.
+    $text_with_url = 'Check this link: http://example.com';
+    $text_without_url = 'This is just text.';
+
+    $this->assertTrue(reliefweb_anti_spam_contains_url($text_with_url));
+    $this->assertFalse(reliefweb_anti_spam_contains_url($text_without_url));
+  }
+
+  /**
+   * Test if text only contains URLs.
+   */
+  public function testOnlyContainsUrls(): void {
+    // Test text that only contains URLs.
+    $url_text = 'http://example.com http://example.org';
+    $mixed_text = 'http://example.com and some text.';
+
+    $this->assertTrue(reliefweb_anti_spam_only_contains_urls($url_text));
+    $this->assertFalse(reliefweb_anti_spam_only_contains_urls($mixed_text));
+  }
+
+  /**
+   * Test content word count requirements.
+   */
+  public function testCheckWordCount(): void {
+    // Valid content.
+    $title = 'A Valid Title';
+    $body = 'This body has enough words to pass validation.';
+
+    // Assuming configuration values are set correctly in setUpConfigFactory().
+    $this->assertTrue(reliefweb_anti_spam_check_word_count('title', $title));
+    $this->assertTrue(reliefweb_anti_spam_check_word_count('body', $body));
+
+    // Invalid content.
+    $title_short = 'Short';
+    $body_short = 'Too short.';
+
+    $this->assertFalse(reliefweb_anti_spam_check_word_count('title', $title_short));
+    $this->assertFalse(reliefweb_anti_spam_check_word_count('title', $body_short));
+  }
+
+  /**
+   * Test content length requirements.
+   */
+  public function testCheckContentLength(): void {
+    // Valid content.
+    $title = 'A Valid Title';
+    $body = 'This body has enough words to pass validation.';
+
+    // Assuming configuration values are set correctly in setUpConfigFactory().
+    $this->assertTrue(reliefweb_anti_spam_check_content_length('title', $title));
+    $this->assertTrue(reliefweb_anti_spam_check_content_length('body', $body));
+
+    // Invalid content.
+    $title_short = 'Short';
+    $body_short = 'Too short.';
+
+    $this->assertFalse(reliefweb_anti_spam_check_content_length('title', $title_short));
+    $this->assertFalse(reliefweb_anti_spam_check_content_length('body', $body_short));
+  }
+
+}

--- a/html/modules/custom/reliefweb_utility/src/Helpers/TextHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/TextHelper.php
@@ -59,6 +59,52 @@ class TextHelper {
   }
 
   /**
+   * Sanitize a UTF-8 string.
+   *
+   * This method performs the following operations:
+   * 1. Replaces all whitespace characters with a single space.
+   * 2. Replaces consecutive spaces with a single space.
+   * 3. Removes all Unicode control characters.
+   * 4. Removes heading and trailing spaces from the text.
+   *
+   * Optionally it also preserves new lines but collapses consecutive ones.
+   *
+   * @param string $text
+   *   The input UTF-8 string to be processed.
+   * @param bool $preserve_newline
+   *   If TRUE, ensure the new lines are preserved.
+   *
+   * @return string
+   *   Sanitized text.
+   */
+  public static function sanitizeText(string $text, bool $preserve_newline = FALSE): string {
+    if ($preserve_newline) {
+      // Remove new lines with a placeholder.
+      $text = preg_replace('/(?:\r?\n\r?)+/', '{{{{NEWLINE}}}}', $text);
+    }
+
+    // Replace HTML non breaking spaces.
+    $text = str_replace(['&nbsp;', '&#160;'], ' ', $text);
+
+    // Replace all whitespace characters (including non-breaking spaces) with
+    // a single space.
+    $text = preg_replace('/\p{Z}+/u', ' ', $text);
+
+    // Replace consecutive spaces with a single space.
+    $text = preg_replace('/\s+/u', ' ', $text);
+
+    // Remove all control and format characters.
+    $text = preg_replace('/\p{C}/u', '', $text);
+
+    if ($preserve_newline) {
+      // Remove new lines with a placeholder.
+      $text = str_replace('{{{{NEWLINE}}}}', "\n", $text);
+    }
+
+    return static::trimText($text);
+  }
+
+  /**
    * Remove embedded content in html or markdown format from the given text.
    *
    * Note: it's using a very basic pattern matching that may not work with

--- a/html/modules/custom/reliefweb_utility/tests/src/Unit/TextHelperTest.php
+++ b/html/modules/custom/reliefweb_utility/tests/src/Unit/TextHelperTest.php
@@ -81,6 +81,64 @@ class TextHelperTest extends UnitTestCase {
   }
 
   /**
+   * Test sanitize text.
+   *
+   * @covers \Drupal\reliefweb_utility\Helpers\TextHelper::sanitizeText
+   */
+  public function testSanitizeText() {
+    $tests = [
+      [
+        'input' => "  Multiple   spaces   and\ttabs  ",
+        'expected' => "Multiple spaces and tabs",
+        'preserve_newline' => FALSE,
+      ],
+      [
+        'input' => "Line breaks\nshould be\r\nremoved",
+        'expected' => "Line breaks should be removed",
+        'preserve_newline' => FALSE,
+      ],
+      [
+        'input' => "Line breaks\nshould be\r\npreserved",
+        'expected' => "Line breaks\nshould be\npreserved",
+        'preserve_newline' => TRUE,
+      ],
+      [
+        'input' => "Unicode\u{200B}zero-width\u{200B}space",
+        'expected' => "Unicodezero-widthspace",
+        'preserve_newline' => FALSE,
+      ],
+      [
+        'input' => "Multiple\n\n\nNewlines",
+        'expected' => "Multiple\nNewlines",
+        'preserve_newline' => TRUE,
+      ],
+      [
+        'input' => "Non-breaking\u{00A0}space",
+        'expected' => "Non-breaking space",
+        'preserve_newline' => FALSE,
+      ],
+      [
+        'input' => "Control\u{0007}character",
+        'expected' => "Controlcharacter",
+        'preserve_newline' => FALSE,
+      ],
+      [
+        'input' => "HTML&nbsp;non-breaking-space",
+        'expected' => "HTML non-breaking-space",
+        'preserve_newline' => FALSE,
+      ],
+    ];
+
+    foreach ($tests as $test) {
+      $this->assertEquals(
+        $test['expected'],
+        TextHelper::sanitizeText($test['input'], $test['preserve_newline']),
+        'Failed sanitizing: ' . $test['input']
+      );
+    }
+  }
+
+  /**
    * Test strip embedded content..
    *
    * @covers \Drupal\reliefweb_utility\Helpers\TextHelper::stripEmbeddedContent


### PR DESCRIPTION
Refs: RW-1155

This adds a `reliefweb_anti_spam` module with some rules to get rid of obvious spam attempts and possibly restrict the number of posts for a given period for unverified users.