### PR TITLE
chore: add csp exception for clarity analytics

### DIFF
--- a/config/seckit.settings.yml
+++ b/config/seckit.settings.yml
@@ -8,9 +8,9 @@ seckit_xss:
       webkit: false
     report-only: false
     default-src: "'self'"
-    script-src: "'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com  https://www.googleadservices.com  https://googleads.g.doubleclick.net https://cdn.popupsmart.com"
+    script-src: "'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com  https://www.googleadservices.com  https://googleads.g.doubleclick.net https://cdn.popupsmart.com https://*.clarity.ms https://c.bing.com"
     object-src: "'none'"
-    style-src: "'self' 'unsafe-inline' https://googletagmanager.com https://tagmanager.google.com fonts.googleapis.com https://cdn.popupsmart.com"
+    style-src: "'self' 'unsafe-inline' https://googletagmanager.com https://tagmanager.google.com fonts.googleapis.com https://cdn.popupsmart.com https://*.clarity.ms https://c.bing.com"
     img-src: "'self' data: https://*"
     media-src: "'none'"
     frame-src: "'self' https://www.googletagmanager.com https://bid.g.doubleclick.net https://td.doubleclick.net https://*.mapbox.com https://www.youtube.com https://youtu.be https://app.powerbi.com *.un.org https://cdnapisec.kaltura.com"


### PR DESCRIPTION
Refs: RW-1164

The documentation suggests putting the exceptions for default-src, which
feels like overreach.
