### PR TITLE
updates: unpin honeypot module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "drupal/environment_indicator": "^4.0",
         "drupal/geofield": "^1.52",
         "drupal/guidelines": "^1.0",
-        "drupal/honeypot": "2.1.4",
+        "drupal/honeypot": "^2",
         "drupal/imageapi_optimize_binaries": "^1.0@beta",
         "drupal/imageapi_optimize_webp": "^2.0",
         "drupal/imagemagick": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d7b796e9e7f1356ad2af30815556e7e",
+    "content-hash": "5932e9c04b8cbb46f2d99bd534e1b120",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3655,29 +3655,29 @@
         },
         {
             "name": "drupal/honeypot",
-            "version": "2.1.4",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/honeypot.git",
-                "reference": "2.1.4"
+                "reference": "2.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.4.zip",
-                "reference": "2.1.4",
-                "shasum": "adf76c3520c0e458177dbe6d638aa2d6ae40a95b"
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.2.0.zip",
+                "reference": "2.2.0",
+                "shasum": "56397c3779ebac1526cce9ecd39385017ee9a837"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^10.3 || ^11"
             },
             "require-dev": {
-                "drupal/rules": "^3.x-dev"
+                "drupal/rules": "^4.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.4",
-                    "datestamp": "1723489062",
+                    "version": "2.2.0",
+                    "datestamp": "1723761042",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Refs: updates

There was some version confusion in honeypot some months ago that meant we should insist on v2.1 before moving to 2.2. That happened in https://github.com/UN-OCHA/rwint9-site/pull/886 which links to the d.o issue.

I think we're okay to unpin the module again now. The changes from 2.1 to 2.2 are listed here: https://www.drupal.org/project/honeypot/releases/2.2.0
