### PR TITLE
chore: remove classy theme too

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -122,7 +122,6 @@ module:
   minimal: 1000
 theme:
   stable: 0
-  classy: 0
   common_design: 0
   common_design_subtheme: 0
   claro: 0


### PR DESCRIPTION
Refs: OPS-11317

Further to https://github.com/UN-OCHA/rwint9-site/pull/1004 and not properly tested, but I don't think Classy is being used anywhere - and uninstalling it doesn't seem to make any difference. It was removed from SLT when we upgraded to Drupal9 and also isn't yet Drupal 11 compatible: https://www.drupal.org/project/classy/issues/3461089