### PR TITLE
[RW-1210] Support body as source for report classification

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4146,7 +4146,7 @@
                 "shasum": "fc8ea60619b6b4682bade340e13fb4565d3a7e0c"
             },
             "require": {
-                "drupal/core": "^9.1 || ^10"
+                "drupal/core": "^10"
             },
             "type": "drupal-module",
             "extra": {
@@ -4349,7 +4349,7 @@
                 "shasum": "c25246747dac4372c7d5a5a5fd0f276d9e468eff"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10",
+                "drupal/core": "^10",
                 "drupal/mailsystem": "^4"
             },
             "require-dev": {
@@ -5205,7 +5205,7 @@
                 "shasum": "4623b9d0de4c624857df10daaa8c68793942ad87"
             },
             "require": {
-                "drupal/core": "^10.3 || ^11",
+                "drupal/core": "^10",
                 "enshrined/svg-sanitize": ">=0.15 <1.0"
             },
             "type": "drupal-module",
@@ -5365,7 +5365,7 @@
                 "shasum": "4aa9b119c9c992fd9930fa50f97cd89959c3bafb"
             },
             "require": {
-                "drupal/core": "^8.9 || ^9 || ^10 || ^11"
+                "drupal/core": "^10"
             },
             "type": "drupal-module",
             "extra": {
@@ -17573,16 +17573,16 @@
         },
         {
             "name": "unocha/ocha_ai",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/ocha_ai.git",
-                "reference": "c7f669b3d0489799795b718745ca84287f1ed1f4"
+                "reference": "aaf71e53723aaad6dc49ae016b835be9fda1f2ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/ocha_ai/zipball/c7f669b3d0489799795b718745ca84287f1ed1f4",
-                "reference": "c7f669b3d0489799795b718745ca84287f1ed1f4",
+                "url": "https://api.github.com/repos/UN-OCHA/ocha_ai/zipball/aaf71e53723aaad6dc49ae016b835be9fda1f2ad",
+                "reference": "aaf71e53723aaad6dc49ae016b835be9fda1f2ad",
                 "shasum": ""
             },
             "require": {
@@ -17614,9 +17614,9 @@
             "description": "OCHA AI module",
             "support": {
                 "issues": "https://github.com/UN-OCHA/ocha_ai/issues",
-                "source": "https://github.com/UN-OCHA/ocha_ai/tree/v1.11.0"
+                "source": "https://github.com/UN-OCHA/ocha_ai/tree/v1.12.0"
             },
-            "time": "2025-04-15T06:30:47+00:00"
+            "time": "2025-04-28T07:47:39+00:00"
         },
         {
             "name": "unocha/ocha_content_classification",

--- a/config/ocha_content_classification.ocha_classification_workflow.node_report.yml
+++ b/config/ocha_content_classification.ocha_classification_workflow.node_report.yml
@@ -12,6 +12,8 @@ target:
   bundle: report
 fields:
   analyzable:
+    body:
+      enabled: true
     field_file:
       enabled: true
   classifiable:
@@ -70,6 +72,10 @@ classifier:
   settings:
     analyzable:
       fields:
+        body:
+          placeholder: source_content
+          processor: reliefweb_body
+          file: true
         field_file:
           placeholder: source_document
           processor: reliefweb_attachment

--- a/html/modules/custom/reliefweb_import/src/Plugin/OchaContentAnalyzableFieldProcessor/ReliefWebBodyProcessor.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/OchaContentAnalyzableFieldProcessor/ReliefWebBodyProcessor.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\reliefweb_import\Plugin\OchaContentAnalyzableFieldProcessor;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ocha_content_classification\Attribute\OchaContentAnalyzableFieldProcessor;
+use Drupal\ocha_content_classification\Plugin\OchaContentAnalyzableFieldProcessor\StripAndTrimProcessor;
+
+/**
+ * ReliefWeb body processor.
+ */
+#[OchaContentAnalyzableFieldProcessor(
+  id: 'reliefweb_body',
+  label: new TranslatableMarkup('ReliefWeb Body'),
+  description: new TranslatableMarkup('Process the ReliefWeb body field, converting to markdown and prepending the title.'),
+  types: [
+    'text_with_summary',
+  ]
+)]
+class ReliefWebBodyProcessor extends StripAndTrimProcessor {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function toFiles(string $placeholder, FieldItemListInterface $field): array {
+    $files = parent::toFiles($placeholder, $field);
+
+    // Prepend the title to have better context.
+    if (!empty($files)) {
+      $title = trim((string) $field->getEntity()->label());
+      foreach ($files as $index => $file) {
+        if (!empty($file['data'])) {
+          $data = $file['data'];
+          $files[$index]['data'] = match($file['mimetype']) {
+            'text/markdown' => "# $title\n\n$data",
+            'text/html' =>  "<h1>$title</h1>\n$data",
+            default => "$title\n\n$data",
+          };
+        }
+      }
+    }
+
+    return $files;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supports(FieldDefinitionInterface $field_definition): bool {
+    $supported = parent::supports($field_definition);
+    return $supported && $field_definition->getName() === 'body';
+  }
+
+}


### PR DESCRIPTION
Refs: RW-1210

This enables the body field as analyzable field and uses a new field processor to prepend the title to the body field for better context. The body field is passed as attachment and so is handled the same way than attachments.

Note: this bumps the ocha_ai version to handle this approach.