### PR TITLE
[RW-1205] Allow partial reimport

### DIFF
--- a/config/reliefweb_import.plugin.importer.echo_flash_update.yml
+++ b/config/reliefweb_import.plugin.importer.echo_flash_update.yml
@@ -7,5 +7,10 @@ classification:
   specified_field_check: ''
   force_field_update: ''
   classified_fields: ''
+reimport:
+  enabled: true
+  fields: "*:no\r\ntitle:yes\r\nbody:yes"
+  statuses: "published:to-review\r\nto-review:to-review\r\nrefused:refused"
+  type: "*:none\r\npending:full\r\non-hold:partial\r\npublished:partial\r\nto-review:partial\r\nembargoed:partial"
 api_url: 'https://erccportal.jrc.ec.europa.eu/API/ERCC/EchoFlash/GetPagedItems?ItemsCurrentPageIndex=1&ItemsPageSize=50&Filter%5BStatus%5D%5B%5D=Published'
 timeout: 60

--- a/config/reliefweb_import.plugin.importer.unhcr_data.yml
+++ b/config/reliefweb_import.plugin.importer.unhcr_data.yml
@@ -7,6 +7,11 @@ classification:
   specified_field_check: '*:no'
   force_field_update: "*:yes\r\ntitle__value:no\r\nfield_source:no"
   classified_fields: '*:yes'
+reimport:
+  enabled: true
+  fields: "*:no\r\nfile:yes"
+  statuses: "published:to-review\r\nto-review:to-review\r\nrefused:refused"
+  type: "*:none\r\npending:full\r\non-hold:partial\r\npublished:partial\r\nto-review:partial\r\nembargoed:partial"
 api_url: 'https://data.unhcr.org'
 api_key: REPLACE_WITH_API_KEY
 list_endpoint: /api-content/documents.json

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -30,7 +30,6 @@ use Drupal\reliefweb_utility\Helpers\DateHelper;
 use Drupal\reliefweb_utility\Helpers\MailHelper;
 use Drupal\reliefweb_utility\Helpers\MediaHelper;
 use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
-use Drupal\reliefweb_utility\Helpers\StateHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\taxonomy\TermInterface;
@@ -750,7 +749,7 @@ function reliefweb_entities_adjust_moderation_status_based_on_classification_sta
     return;
   }
 
-  $publication_protection_default_status = StateHelper::getPublicationPreventionDefaultModerationStatus(
+  $publication_protection_default_status = ReliefWebStateHelper::getPublicationPreventionDefaultModerationStatus(
     $entity->getEntityTypeId(),
     $entity->bundle(),
   );

--- a/html/modules/custom/reliefweb_entities/reliefweb_entities.module
+++ b/html/modules/custom/reliefweb_entities/reliefweb_entities.module
@@ -30,6 +30,7 @@ use Drupal\reliefweb_utility\Helpers\DateHelper;
 use Drupal\reliefweb_utility\Helpers\MailHelper;
 use Drupal\reliefweb_utility\Helpers\MediaHelper;
 use Drupal\reliefweb_utility\Helpers\ReliefWebStateHelper;
+use Drupal\reliefweb_utility\Helpers\StateHelper;
 use Drupal\reliefweb_utility\Helpers\TaxonomyHelper;
 use Drupal\reliefweb_utility\Helpers\TextHelper;
 use Drupal\taxonomy\TermInterface;
@@ -749,15 +750,20 @@ function reliefweb_entities_adjust_moderation_status_based_on_classification_sta
     return;
   }
 
+  $publication_protection_default_status = StateHelper::getPublicationPreventionDefaultModerationStatus(
+    $entity->getEntityTypeId(),
+    $entity->bundle(),
+  );
+
   $status = match($entity->ocha_content_classification_status) {
     // Prevent publication if the document is queued for classification.
     // If the document is already in a non-published state then keep the current
     // status. This allows for example, to quickly mark a document as refused
     // or on-hold.
-    ClassificationStatus::Queued => $entity->isPublishedModerationStatus() ? 'pending' : $entity->getModerationStatus(),
+    ClassificationStatus::Queued => $entity->isPublishedModerationStatus() ? $publication_protection_default_status : $entity->getModerationStatus(),
     // Prevent publication if the document classification failed. A human should
     // review manually.
-    ClassificationStatus::Failed => 'on-hold',
+    ClassificationStatus::Failed => $entity->isPublishedModerationStatus() ? $publication_protection_default_status : $entity->getModerationStatus(),
     // For successful classification, we keep the current status.
     ClassificationStatus::Completed => $entity->getModerationStatus(),
     // This default case should not happen.

--- a/html/modules/custom/reliefweb_import/config/schema/reliefweb_import.schema.yml
+++ b/html/modules/custom/reliefweb_import/config/schema/reliefweb_import.schema.yml
@@ -34,6 +34,22 @@ reliefweb_import.plugin.importer:
         classified_fields:
           type: string
           label: 'Control which fields should be updated with classifier results.'
+    reimport:
+      type: mapping
+      label: 'Reimport settings'
+      mapping:
+        enabled:
+          type: boolean
+          label: 'Enable reimport.'
+        type:
+          type: string
+          label: 'Type of reimport based on entity moderation status.'
+        fields:
+          type: string
+          label: 'Control which fields should be updated when reimporting.'
+        statuses:
+          type: string
+          label: 'Moderation status mapping.'
 
 # UNHCR Data importer plugin settings.
 reliefweb_import.plugin.importer.unhcr_data:

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/EchoFlashUpdateImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/EchoFlashUpdateImporter.php
@@ -239,8 +239,8 @@ class EchoFlashUpdateImporter extends ReliefWebImporterPluginBase {
    *   The number of documents that were skipped or imported successfully.
    */
   protected function processDocuments(array $documents, string $provider_uuid, ContentProcessorPluginInterface $plugin): int {
-    // Source: Echo Flash Update.
-    $source = [620];
+    $entity_type_id = $this->getEntityTypeId();
+    $bundle = $this->getEntityBundle();
 
     // Retrieve the list of documents manually posted so we can exclude them
     // from the import.
@@ -265,8 +265,8 @@ class EchoFlashUpdateImporter extends ReliefWebImporterPluginBase {
       $import_record = [
         'importer' => $this->getPluginId(),
         'provider_uuid' => $provider_uuid,
-        'entity_type_id' => 'node',
-        'entity_bundle' => 'report',
+        'entity_type_id' => $entity_type_id,
+        'entity_bundle' => $bundle,
         'status' => 'pending',
         'message' => '',
         'attempts' => 0,
@@ -311,18 +311,6 @@ class EchoFlashUpdateImporter extends ReliefWebImporterPluginBase {
         '@id' => $id,
       ]));
 
-      // Check if how many times we tried to import this item.
-      if (!empty($import_record['attempts']) && $import_record['attempts'] >= $max_import_attempts) {
-        $import_record['status'] = 'error';
-        $import_record['message'] = 'Too many attempts.';
-        $import_records[$import_record['imported_item_uuid']] = $import_record;
-
-        $this->getLogger()->error(strtr('Too many import attempts for Echo Flash Update document @id, skipping.', [
-          '@id' => $id,
-        ]));
-        continue;
-      }
-
       // Generate a hash from the data we use to import the document. This is
       // used to detect changes that can affect the document on ReliefWeb.
       $filtered_document = $this->filterArrayByKeys($document, [
@@ -366,108 +354,32 @@ class EchoFlashUpdateImporter extends ReliefWebImporterPluginBase {
         continue;
       }
 
-      // Retrieve the title and clean it.
-      $title = $this->sanitizeText($document['Title'] ?? '');
+      // Check if how many times we tried to import this item.
+      if (!empty($import_record['attempts']) && $import_record['attempts'] >= $max_import_attempts) {
+        $import_record['status'] = 'error';
+        $import_record['message'] = 'Too many attempts.';
+        $import_records[$import_record['imported_item_uuid']] = $import_record;
 
-      // Retrieve the sources.
-      $sources = array_map(fn($item) => $this->sanitizeText($item['Name'] ?? ''), $document['ItemSources']);
-      $sources = array_unique(array_filter($sources));
+        $this->getLogger()->error(strtr('Too many import attempts for Echo Flash Update document @id, skipping.', [
+          '@id' => $id,
+        ]));
+        continue;
+      }
 
-      // Retrieve the publication date.
-      $published = $document['PublishedOnDate'] ?? $document['CreatedOnDate'] ?? time();
-      $published = DateHelper::format($published, 'custom', 'c');
-
-      // Title + (sources) + (ECHO Daily Flash of dd MM YYYY).
-      if (!empty($title)) {
-        $title = implode(' ', array_filter([
-          $title,
-          !empty($sources) ? '(' . implode(', ', $sources) . ')' : '',
-          '(ECHO Daily Flash of ' . DateHelper::format($published, 'custom', 'j F Y') . ')',
+      // Process the item data into importable data.
+      $data = $this->getImportData($uuid, $document);
+      if (empty($data)) {
+        $this->getLogger()->notice(strtr('No data to import for Echo Flash Update document @id.', [
+          '@id' => $id,
         ]));
       }
 
-      // Retrieve the description.
-      $body = $this->sanitizeText($document['Description'] ?? '', TRUE);
-
-      // Retrieve the countries.
-      $countries = [];
-      if (isset($document['Country']['Iso3'])) {
-        $country = $this->getCountryByIso($document['Country']['Iso3']);
-        if (!empty($country)) {
-          $countries[] = $country;
-        }
-      }
-      foreach ($document['Countries'] ?? [] as $location) {
-        if (isset($location['Iso3'])) {
-          $country = $this->getCountryByIso($location['Iso3']);
-          if (!empty($country)) {
-            $countries[] = $country;
-          }
-        }
-      }
-
-      // Tag with World if empty so that, at least, we can import.
-      if (empty($countries)) {
-        $countries = [254];
-      }
-
-      $countries = array_unique($countries);
-
-      // Extract the event types.
-      $event_type_codes = [];
-      if (isset($document['EventTypeCode'])) {
-        $event_type_code = strtoupper($document['EventTypeCode']);
-        $event_type_codes[$event_type_code] = $event_type_code;
-      }
-      elseif (isset($document['EventType']['Code'])) {
-        $event_type_code = strtoupper($document['EventType']['Code']);
-        $event_type_codes[$event_type_code] = $event_type_code;
-      }
-      if (isset($document['EventTypes'])) {
-        foreach ($document['EventTypes'] ?? [] as $event_type) {
-          if (isset($event_type['Code'])) {
-            $event_type_code = strtoupper($event_type['Code']);
-            $event_type_codes[$event_type_code] = $event_type_code;
-          }
-        }
-      }
-
-      // Disaster types and themes.
-      $disaster_types = [];
-      $themes = [];
-      foreach ($event_type_codes as $event_type_code) {
-        $disaster_type_code = $this->getDisasterTypeByCode($event_type_code);
-        if (isset($disaster_type_code)) {
-          $disaster_types[$event_type_code] = $disaster_type_code;
-        }
-        if (isset($this->themeMapping[$event_type_code])) {
-          $themes[$event_type_code] = $this->themeMapping[$event_type_code];
-        }
-      }
-
-      // Submission data.
-      $data = [
-        'provider' => $provider_uuid,
-        'bundle' => 'report',
-        'hash' => $hash,
-        'url' => $url,
-        'uuid' => $uuid,
-        'title' => $title,
-        'body' => $body,
-        'source' => $source,
-        'published' => $published,
-        'origin' => $url,
-        'language' => [267],
-        'country' => array_values($countries),
-        'format' => [8],
-      ];
-
-      if (!empty($disaster_types)) {
-        $data['disaster_type'] = array_values($disaster_types);
-      }
-      if (!empty($themes)) {
-        $data['theme'] = array_values($themes);
-      }
+      // Mandatory information.
+      $data['provider'] = $provider_uuid;
+      $data['bundle'] = 'report';
+      $data['hash'] = $hash;
+      $data['uuid'] = $uuid;
+      $data['url'] = $url;
 
       // Submit the document directly, no need to go through the queue.
       try {
@@ -501,6 +413,119 @@ class EchoFlashUpdateImporter extends ReliefWebImporterPluginBase {
     $this->saveImportRecords($import_records);
 
     return $processed;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function processDocumentData(string $uuid, array $document): array {
+    $data = [];
+
+    // Source: Echo Flash Update.
+    $source = [620];
+
+    // Document URL.
+    $url = $document['Link'];
+
+    // Retrieve the title and clean it.
+    $title = $this->sanitizeText($document['Title'] ?? '');
+
+    // Retrieve the sources.
+    $sources = array_map(fn($item) => $this->sanitizeText($item['Name'] ?? ''), $document['ItemSources']);
+    $sources = array_unique(array_filter($sources));
+
+    // Retrieve the publication date.
+    $published = $document['PublishedOnDate'] ?? $document['CreatedOnDate'] ?? time();
+    $published = DateHelper::format($published, 'custom', 'c');
+
+    // Title + (sources) + (ECHO Daily Flash of dd MM YYYY).
+    if (!empty($title)) {
+      $title = implode(' ', array_filter([
+        $title,
+        !empty($sources) ? '(' . implode(', ', $sources) . ')' : '',
+        '(ECHO Daily Flash of ' . DateHelper::format($published, 'custom', 'j F Y') . ')',
+      ]));
+    }
+
+    // Retrieve the description.
+    $body = $this->sanitizeText($document['Description'] ?? '', TRUE);
+
+    // Retrieve the countries.
+    $countries = [];
+    if (isset($document['Country']['Iso3'])) {
+      $country = $this->getCountryByIso($document['Country']['Iso3']);
+      if (!empty($country)) {
+        $countries[] = $country;
+      }
+    }
+    foreach ($document['Countries'] ?? [] as $location) {
+      if (isset($location['Iso3'])) {
+        $country = $this->getCountryByIso($location['Iso3']);
+        if (!empty($country)) {
+          $countries[] = $country;
+        }
+      }
+    }
+
+    // Tag with World if empty so that, at least, we can import.
+    if (empty($countries)) {
+      $countries = [254];
+    }
+
+    $countries = array_unique($countries);
+
+    // Extract the event types.
+    $event_type_codes = [];
+    if (isset($document['EventTypeCode'])) {
+      $event_type_code = strtoupper($document['EventTypeCode']);
+      $event_type_codes[$event_type_code] = $event_type_code;
+    }
+    elseif (isset($document['EventType']['Code'])) {
+      $event_type_code = strtoupper($document['EventType']['Code']);
+      $event_type_codes[$event_type_code] = $event_type_code;
+    }
+    if (isset($document['EventTypes'])) {
+      foreach ($document['EventTypes'] ?? [] as $event_type) {
+        if (isset($event_type['Code'])) {
+          $event_type_code = strtoupper($event_type['Code']);
+          $event_type_codes[$event_type_code] = $event_type_code;
+        }
+      }
+    }
+
+    // Disaster types and themes.
+    $disaster_types = [];
+    $themes = [];
+    foreach ($event_type_codes as $event_type_code) {
+      $disaster_type_code = $this->getDisasterTypeByCode($event_type_code);
+      if (isset($disaster_type_code)) {
+        $disaster_types[$event_type_code] = $disaster_type_code;
+      }
+      if (isset($this->themeMapping[$event_type_code])) {
+        $themes[$event_type_code] = $this->themeMapping[$event_type_code];
+      }
+    }
+
+    // Submission data.
+    $data = [
+      'title' => $title,
+      'body' => $body,
+      'source' => $source,
+      'published' => $published,
+      'origin' => $url,
+      'language' => [267],
+      'country' => array_values($countries),
+      'format' => [8],
+    ];
+
+    if (!empty($disaster_types)) {
+      $data['disaster_type'] = array_values($disaster_types);
+    }
+    if (!empty($themes)) {
+      $data['theme'] = array_values($themes);
+    }
+
+    return $data;
   }
 
 }

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/UnhcrDataImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/UnhcrDataImporter.php
@@ -826,6 +826,9 @@ class UnhcrDataImporter extends ReliefWebImporterPluginBase {
    *   The number of documents that were skipped or imported successfully.
    */
   protected function processDocuments(array $documents, string $provider_uuid, ContentProcessorPluginInterface $plugin): int {
+    $entity_type_id = $this->getEntityTypeId();
+    $bundle = $this->getEntityBundle();
+
     $schema = $this->getJsonSchema('report');
 
     // This is the list of extensions supported by the report attachment field.
@@ -844,13 +847,10 @@ class UnhcrDataImporter extends ReliefWebImporterPluginBase {
     // Max import attempts.
     $max_import_attempts = $this->getPluginSetting('max_import_attempts', 3, FALSE);
 
-    // Source: UNHCR.
-    $source = [2868];
-
     // The original mapping is ReliefWeb country ID to UNHCR country code for
-    // convenience in keeping it up to date. We need to flip it to easiy look
+    // convenience in keeping it up to date. We need to flip it to easily look
     // up the ID from the UNHCR code below.
-    $country_mapping = array_flip(array_filter($this->countryMapping));
+    $this->countryMapping = array_flip(array_filter($this->countryMapping));
 
     // Retrieve the list of documents manually posted so we can exclude them
     // from the import.
@@ -872,8 +872,8 @@ class UnhcrDataImporter extends ReliefWebImporterPluginBase {
       $import_record = [
         'importer' => $this->getPluginId(),
         'provider_uuid' => $provider_uuid,
-        'entity_type_id' => 'node',
-        'entity_bundle' => 'report',
+        'entity_type_id' => $entity_type_id,
+        'entity_bundle' => $bundle,
         'status' => 'pending',
         'message' => '',
         'attempts' => 0,
@@ -972,108 +972,20 @@ class UnhcrDataImporter extends ReliefWebImporterPluginBase {
         continue;
       }
 
-      // Retrieve the title and clean it.
-      $title = $this->sanitizeText($document['title'] ?? '');
-
-      // The documents in the UNHCR API seldom have descriptions or good ones
-      // so we simply skip the body.
-      $body = '';
-
-      // Retrieve the publication date.
-      $published = $document['publishDate'] ?? $document['created'] ?? NULL;
-
-      // Retrieve the document languages and default to English if none of the
-      // supported languages were found.
-      $languages = [];
-      foreach ($document['languageName'] ?? [] as $language) {
-        // Note: UNHCR language items have a 'name' property.
-        if (isset($this->languageMapping[$language['name']])) {
-          $languages[$language['name']] = $this->languageMapping[$language['name']];
-        }
-      }
-      if (empty($languages)) {
-        $languages['English'] = $this->languageMapping['English'];
+      // Process the item data into importable data.
+      $data = $this->getImportData($uuid, $document);
+      if (empty($data)) {
+        $this->getLogger()->notice(strtr('No data to import for UNHCR document @id.', [
+          '@id' => $id,
+        ]));
       }
 
-      // Retrieve the content format and map it to 'Other' if there is no match.
-      $formats = [9];
-      foreach ($document['docTypeName'] ?? [] as $type) {
-        // Note: UNHCR doc type items are name strings directly.
-        if (isset($this->formatMapping[$type])) {
-          $formats = [$this->formatMapping[$type]];
-          break;
-        }
-      }
-
-      // Retrieve the countries. Consider the first one as the primary country.
-      $countries = [];
-      foreach ($document['location'] ?? [] as $location) {
-        // Note: UNHCR location items have a 'code' property.
-        if (isset($country_mapping[$location['code']])) {
-          $country = [$location['code'] => $country_mapping[$location['code']]];
-          // If the location is in the title, add it at the beginning so it is
-          // considered the primary country.
-          if (isset($location['name'])) {
-            $country_name = trim(str_replace(' (country)', '', $location['name']));
-            if (mb_stripos($title, $country_name) !== FALSE) {
-              $countries = $country + $countries;
-              continue;
-            }
-          }
-          // Otherwise, add it at the end.
-          $countries = $countries + $country;
-        }
-      }
-      // Tag with World if empty so that, at least, we can import.
-      if (empty($countries)) {
-        $countries = [254];
-      }
-
-      // Retrieve the themes.
-      $themes = [];
-      foreach ($document['sectorName'] ?? [] as $sector) {
-        // Note: UNHCR sector items are name strings directly.
-        if (isset($this->themeMapping[$sector])) {
-          $themes[$sector] = $this->themeMapping[$sector];
-        }
-      }
-
-      // Retrieve the data for the attachment if any.
-      $files = [];
-      if (isset($document['downloadLink'])) {
-        $info = $this->getRemoteFileInfo($document['downloadLink']);
-        if (!empty($info)) {
-          $file_url = $document['downloadLink'];
-          $file_uuid = $this->generateUuid($file_url, $uuid);
-          $files[] = [
-            'url' => $file_url,
-            'uuid' => $file_uuid,
-          ] + $info;
-        }
-      }
-
-      // Submission data.
-      $data = [
-        'provider' => $provider_uuid,
-        'bundle' => 'report',
-        'hash' => $hash,
-        'url' => $url,
-        'uuid' => $uuid,
-        'title' => $title,
-        'body' => $body,
-        'source' => $source,
-        'published' => $published,
-        'origin' => $url,
-        'language' => array_values($languages),
-        'country' => array_values($countries),
-        'format' => array_values($formats),
-      ];
-
-      // Add the optional fields.
-      $data += array_filter([
-        'theme' => array_values($themes),
-        'file' => array_values($files),
-      ]);
+      // Mandatory information.
+      $data['provider'] = $provider_uuid;
+      $data['bundle'] = 'report';
+      $data['hash'] = $hash;
+      $data['uuid'] = $uuid;
+      $data['url'] = $url;
 
       // Submit the document directly, no need to go through the queue.
       try {
@@ -1107,6 +1019,119 @@ class UnhcrDataImporter extends ReliefWebImporterPluginBase {
     $this->saveImportRecords($import_records);
 
     return $processed;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function processDocumentData(string $uuid, array $document): array {
+    $data = [];
+
+    // Source: UNHCR.
+    $source = [2868];
+
+    // Document URL.
+    $url = $document['documentLink'];
+
+    // Retrieve the title and clean it.
+    $title = $this->sanitizeText($document['title'] ?? '');
+
+    // The documents in the UNHCR API seldom have descriptions or good ones
+    // so we simply skip the body.
+    $body = '';
+
+    // Retrieve the publication date.
+    $published = $document['publishDate'] ?? $document['created'] ?? NULL;
+
+    // Retrieve the document languages and default to English if none of the
+    // supported languages were found.
+    $languages = [];
+    foreach ($document['languageName'] ?? [] as $language) {
+      // Note: UNHCR language items have a 'name' property.
+      if (isset($this->languageMapping[$language['name']])) {
+        $languages[$language['name']] = $this->languageMapping[$language['name']];
+      }
+    }
+    if (empty($languages)) {
+      $languages['English'] = $this->languageMapping['English'];
+    }
+
+    // Retrieve the content format and map it to 'Other' if there is no match.
+    $formats = [9];
+    foreach ($document['docTypeName'] ?? [] as $type) {
+      // Note: UNHCR doc type items are name strings directly.
+      if (isset($this->formatMapping[$type])) {
+        $formats = [$this->formatMapping[$type]];
+        break;
+      }
+    }
+
+    // Retrieve the countries. Consider the first one as the primary country.
+    $countries = [];
+    foreach ($document['location'] ?? [] as $location) {
+      // Note: UNHCR location items have a 'code' property.
+      if (isset($this->countryMapping[$location['code']])) {
+        $country = [$location['code'] => $this->countryMapping[$location['code']]];
+        // If the location is in the title, add it at the beginning so it is
+        // considered the primary country.
+        if (isset($location['name'])) {
+          $country_name = trim(str_replace(' (country)', '', $location['name']));
+          if (mb_stripos($title, $country_name) !== FALSE) {
+            $countries = $country + $countries;
+            continue;
+          }
+        }
+        // Otherwise, add it at the end.
+        $countries = $countries + $country;
+      }
+    }
+    // Tag with World if empty so that, at least, we can import.
+    if (empty($countries)) {
+      $countries = [254];
+    }
+
+    // Retrieve the themes.
+    $themes = [];
+    foreach ($document['sectorName'] ?? [] as $sector) {
+      // Note: UNHCR sector items are name strings directly.
+      if (isset($this->themeMapping[$sector])) {
+        $themes[$sector] = $this->themeMapping[$sector];
+      }
+    }
+
+    // Retrieve the data for the attachment if any.
+    $files = [];
+    if (isset($document['downloadLink'])) {
+      $info = $this->getRemoteFileInfo($document['downloadLink']);
+      if (!empty($info)) {
+        $file_url = $document['downloadLink'];
+        $file_uuid = $this->generateUuid($file_url, $uuid);
+        $files[] = [
+          'url' => $file_url,
+          'uuid' => $file_uuid,
+        ] + $info;
+      }
+    }
+
+    // Submission data.
+    $data = [
+      'title' => $title,
+      'body' => $body,
+      'source' => $source,
+      'published' => $published,
+      'origin' => $url,
+      'language' => array_values($languages),
+      'country' => array_values($countries),
+      'format' => array_values($formats),
+    ];
+
+    // Add the optional fields.
+    $data += array_filter([
+      'theme' => array_values($themes),
+      'file' => array_values($files),
+    ]);
+
+    return $data;
   }
 
   /**

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginBase.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginBase.php
@@ -10,6 +10,7 @@ use Drupal\Component\Utility\Environment;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -287,7 +288,6 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
       '#open' => TRUE,
       '#tree' => TRUE,
     ];
-
     $form['classification']['enabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enabled'),
@@ -322,6 +322,39 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
       '#default_value' => $classification_settings['classified_fields'] ?? NULL,
     ];
 
+    $reimport_settings = $form_state->getValue('reimport', $this->getPluginSetting('reimport', [], FALSE));
+
+    $form['reimport'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Reimport settings'),
+      '#open' => TRUE,
+      '#tree' => TRUE,
+    ];
+    $form['reimport']['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enabled'),
+      '#description' => $this->t('Allow reimporting content.'),
+      '#default_value' => !empty($reimport_settings['enabled']),
+    ];
+    $form['reimport']['type'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Reimport type rules'),
+      '#description' => $this->t('Control the type of reimport (full, partial, none) based on the entity moderation status. Format: "status:full/partial/none" (one per line). Use "*:full/partial/none" to set default behavior for all statuses. "full" = replace all data like the initial import, "partial" = update only some fields, "none" = skip reimport.'),
+      '#default_value' => $reimport_settings['type'] ?? NULL,
+    ];
+    $form['reimport']['fields'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Field update rules'),
+      '#description' => $this->t('Control which fields should be updated when reimporting. Format: "field:yes/no" (one per line). Use "*:yes/no" to set default behavior for all fields. "yes" = update field, "no" = skip update.'),
+      '#default_value' => $reimport_settings['fields'] ?? NULL,
+    ];
+    $form['reimport']['statuses'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Moderations status mapping rules'),
+      '#description' => $this->t('Control how to change the moderation status when reimporting. Format: "status:other_status" (one per line). Use "*:status" to set default behavior for all statuses.'),
+      '#default_value' => $reimport_settings['statuses'] ?? NULL,
+    ];
+
     return $form;
   }
 
@@ -343,6 +376,141 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
    */
   public function defaultConfiguration(): array {
     return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityTypeId(): string {
+    return 'node';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'report';
+  }
+
+  /**
+   * Process a document's data into importable data.
+   *
+   * @param string $uuid
+   *   Document UUID.
+   * @param array $document
+   *   Raw imported document data.
+   *
+   * @return array
+   *   Data to import.
+   */
+  abstract protected function processDocumentData(string $uuid, array $document): array;
+
+  /**
+   * Get the data to import.
+   *
+   * @param string $uuid
+   *   Item uuid.
+   * @param array $document
+   *   Raw document data.
+   *
+   * @return array
+   *   Data to import.
+   */
+  protected function getImportData(string $uuid, array $document): array {
+    // If the entity doesn't already exist, then it's the initial import and
+    // we just return the processed item data.
+    // Otherwise we apply the reimport rules.
+    $entity = $this->entityRepository->loadEntityByUuid($this->getEntityTypeId(), $uuid);
+
+    // If the entity was already imported check if reimport is allowed.
+    if (!empty($entity) && $this->getPluginSetting('reimport.enabled', FALSE, FALSE) == FALSE) {
+      return [];
+    }
+
+    // Process the data and filter it out in case of reimport.
+    $data = $this->processDocumentData($uuid, $document);
+    return empty($entity) ? $data : $this->processReimportData($uuid, $data, $entity);
+  }
+
+  /**
+   * Process data for a reimport.
+   *
+   * @param string $uuid
+   *   Item uuid.
+   * @param array $data
+   *   Data to import.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Existing entity.
+   *
+   * @return array
+   *   Filtered data to import.
+   */
+  protected function processReimportData(string $uuid, array $data, EntityInterface $entity): array {
+    $reimport_type_setting = $this->getPluginSetting('reimport.type', '', FALSE);
+    $reimport_type_rules = $this->parseReimportType($reimport_type_setting);
+
+    // Skip reimport if there are no rules.
+    if (empty($reimport_type_rules)) {
+      return [];
+    }
+
+    // Get the current moderation status of the entity.
+    $status = $entity->getModerationStatus();
+    $reimport_type = $reimport_type_rules[$status] ?? $reimport_type_rules['*'] ?? 'none';
+
+    // Skip if reimport is disabled for the moderation status.
+    if ($reimport_type === 'none') {
+      return [];
+    }
+
+    // Use the full import data if the reimport type is full.
+    if ($reimport_type === 'full') {
+      return $data;
+    }
+
+    // Only keep certain fields.
+    $field_rules_setting = $this->getPluginSetting('reimport.fields', '', FALSE);
+    $field_rules = $this->parseFieldRules($field_rules_setting);
+
+    // No fields to preserve so nothing to reimport.
+    if (empty($field_rules)) {
+      return [];
+    }
+
+    // Only preserve certain fields for the update.
+    $filtered_data = [];
+    foreach ($data as $field => $value) {
+      $update = $field_rules[$field] ?? $field_rules['*'] ?? FALSE;
+      if ($update) {
+        $filtered_data[$field] = $value;
+      }
+    }
+
+    // Nothing to reimport.
+    if (empty($filtered_data)) {
+      return [];
+    }
+
+    // Update the moderation status of the current version for the entity.
+    $status_mapping_setting = $this->getPluginSetting('reimport.statuses', '', FALSE);
+    $status_mapping = $this->parseReimportStatusMapping($status_mapping_setting);
+    if (!empty($status_mapping)) {
+      // Update the moderation status.
+      $status = match(TRUE) {
+        !empty($status_mapping[$status]) => $status_mapping[$status],
+        !empty($status_mapping['*']) => $status_mapping['*'],
+        // No status override, let the content processor decide what to use.
+        default => NULL,
+      };
+      if (isset($status)) {
+        $filtered_data['status'] = $status;
+      }
+    }
+
+    // Set the partial reimport flag.
+    $filtered_data['partial'] = TRUE;
+
+    return $filtered_data;
   }
 
   /**
@@ -462,9 +630,9 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
   }
 
   /**
-   * Parses field rules string into an associative array.
+   * Parse field rules string into an associative array.
    *
-   * Converts a multi-line string of field rules in the format "field:yes/no"
+   * Convert a multi-line string of field rules in the format "field:yes/no"
    * into an associative array with field names as keys and boolean values.
    *
    * @param string $input
@@ -499,6 +667,85 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
 
     return array_reduce($matches, function ($result, $match) {
       $result[$match['field']] = ($match['value'] === 'yes');
+      return $result;
+    }, []);
+  }
+
+  /**
+   * Parse reimport type rules string into an associative array.
+   *
+   * @param string $input
+   *   Text with reimport type rules, one per line, in the format
+   *   "status:full/partial/none".
+   *   The wildcard "*" can be used to set a default rule for all statuses.
+   *
+   * @return array
+   *   Associative array where:
+   *   - Keys are statuses (or "*" for default rule)
+   *   - Values are strings: "full", "partial", "none"
+   *
+   * @example
+   *   Input:
+   *   ```
+   *   *:full
+   *   refused:none
+   *   published:partial
+   *   ```
+   *
+   *   Output:
+   *   ```
+   *   [
+   *     '*' => 'full',
+   *     'refused' => 'none',
+   *     'published' => 'partial',
+   *   ]
+   *   ```
+   */
+  protected function parseReimportType(string $input): array {
+    $input = strtolower($input);
+    preg_match_all('/^\s*(?<status>[^:]+)\s*:\s*(?<value>full|partial|none)\s*$/nim', $input, $matches, \PREG_SET_ORDER);
+
+    return array_reduce($matches, function ($result, $match) {
+      $result[$match['status']] = $match['value'];
+      return $result;
+    }, []);
+  }
+
+  /**
+   * Parse the reimport status mapping into an associative array.
+   *
+   * Converts a multi-line string of status to status mapping.
+   *
+   * @param string $input
+   *   Text with status mapping, one per line, in the format "source:target".
+   *   The wildcard "*" can be used to set a default mapping for all statuses.
+   *
+   * @return array
+   *   Associative array where:
+   *   - Keys are source statuses (or "*" for default rule)
+   *   - Values are target statuses
+   *
+   * @example
+   *   Input:
+   *   ```
+   *   *:pending
+   *   published:to-review
+   *   ```
+   *
+   *   Output:
+   *   ```
+   *   [
+   *     '*' => 'pending',
+   *     'published' => 'to-review',
+   *   ]
+   *   ```
+   */
+  protected function parseReimportStatusMapping(string $input): array {
+    $input = strtolower($input);
+    preg_match_all('/^\s*(?<source_status>[^:]+)\s*:\s*(?<target_status>\S+)\s*$/nim', $input, $matches, \PREG_SET_ORDER);
+
+    return array_reduce($matches, function ($result, $match) {
+      $result[$match['source_status']] = $match['target_status'];
       return $result;
     }, []);
   }
@@ -582,6 +829,8 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
    * @return array
    *   Associative array mapping external document IDs (keys) to their
    *   corresponding report node IDs (values).
+   *
+   * @todo this assumes report nodes currently. Should be extended.
    */
   protected function getManuallyPostedDocuments(
     array $document_ids,

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginInterface.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginInterface.php
@@ -89,6 +89,22 @@ interface ReliefWebImporterPluginInterface {
   public function getConfigurationKey(): string;
 
   /**
+   * Get the entity type ID the importer works with.
+   *
+   * @return string
+   *   Entity type ID.
+   */
+  public function getEntityTypeId(): string;
+
+  /**
+   * Get the entity bundle the importer works with.
+   *
+   * @return string
+   *   Entity bundle.
+   */
+  public function getEntityBundle(): string;
+
+  /**
    * Import newest and update content.
    *
    * @param int $limit

--- a/html/modules/custom/reliefweb_post_api/src/Controller/ReliefWebPostApi.php
+++ b/html/modules/custom/reliefweb_post_api/src/Controller/ReliefWebPostApi.php
@@ -195,6 +195,16 @@ class ReliefWebPostApi extends ControllerBase {
       // generated when saving the entity.
       unset($data['hash']);
 
+      // Make sure we don't have an unwanted status property. This will be
+      // set when saving the entity.
+      unset($data['status']);
+
+      // Disallow partial update for now.
+      // @todo review if/when we allow PATCH requests since we need to modify
+      // the schema validation in that case as well as a clean way to handle
+      // removing a non mandatory field value (ex: report theme).
+      unset($data['partial']);
+
       // Validate the content against the schema for the bundle.
       try {
         $plugin->validate($data);

--- a/html/modules/custom/reliefweb_post_api/src/Plugin/ContentProcessorPluginBase.php
+++ b/html/modules/custom/reliefweb_post_api/src/Plugin/ContentProcessorPluginBase.php
@@ -278,7 +278,7 @@ abstract class ContentProcessorPluginBase extends CorePluginBase implements Cont
     $message = match(TRUE) {
       $entity->isNew() =>  'Automatic creation from Post API.',
       !empty($data['partial']) => 'Automatic partial update from Post API.',
-      default => 'Automatic partial update from Post API.',
+      default => 'Automatic update from Post API.',
     };
 
     // Save the entity.

--- a/html/modules/custom/reliefweb_post_api/src/Plugin/ContentProcessorPluginBase.php
+++ b/html/modules/custom/reliefweb_post_api/src/Plugin/ContentProcessorPluginBase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\reliefweb_post_api\Plugin;
 
 use Drupal\Component\Render\MarkupInterface;
+use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\Bytes;
 use Drupal\Component\Utility\Environment;
 use Drupal\Component\Utility\NestedArray;
@@ -267,10 +268,18 @@ abstract class ContentProcessorPluginBase extends CorePluginBase implements Cont
     $this->setField($entity, 'field_post_api_hash', $hash);
 
     // Set the new status.
-    $entity->setModerationStatus($provider->getDefaultResourceStatus());
+    $status = match(TRUE) {
+      !empty($data['status']) => $data['status'],
+      default => $provider->getDefaultResourceStatus(),
+    };
+    $entity->setModerationStatus($status);
 
     // Set the log message based on whether it was updated or created.
-    $message = $entity->isNew() ? 'Automatic creation from Post API.' : 'Automatic update from Post API.';
+    $message = match(TRUE) {
+      $entity->isNew() =>  'Automatic creation from Post API.',
+      !empty($data['partial']) => 'Automatic partial update from Post API.',
+      default => 'Automatic partial update from Post API.',
+    };
 
     // Save the entity.
     $entity->setNewRevision(TRUE);
@@ -319,8 +328,27 @@ abstract class ContentProcessorPluginBase extends CorePluginBase implements Cont
     unset($data['provider']);
     unset($data['user']);
     unset($data['hash']);
+    unset($data['status']);
+
+    // Partial update.
+    $partial = !empty($data['partial']);
+    unset($data['partial']);
+
     $data = Helper::toJSON($data);
     $schema = $this->getPluginSetting('schema', $this->getJsonSchema());
+
+    // When doing a partial update, disable the check on the mandatory fields.
+    if ($partial) {
+      $decoded = Json::decode($schema);
+      if ($decoded) {
+        // Only preserve the URL and UUID as mandatory fields.
+        $decoded['required'] = ['url', 'uuid'];
+        $schema = Json::encode($decoded);
+      }
+    }
+
+    // Validate the schema.
+    // @todo improve error handling. See the `ocha_reliefweb` module.
     $result = $this->getSchemaValidator()->validate($data, $schema);
     if (!$result->isValid()) {
       $formatter = new ErrorFormatter();
@@ -440,6 +468,12 @@ abstract class ContentProcessorPluginBase extends CorePluginBase implements Cont
    * {@inheritdoc}
    */
   public function validateSources(array $data): void {
+    // In case of partial update, the source may not be present in which case
+    // we skip the validation.
+    if (!empty($data['partial']) && empty($data['source'])) {
+      return;
+    }
+
     $provider = $this->getProvider($data['provider'] ?? '');
     $sources = $provider->getAllowedSources() ?? [];
     // Empty allowed sources means any source is allowed.

--- a/html/modules/custom/reliefweb_utility/src/Helpers/ReliefWebStateHelper.php
+++ b/html/modules/custom/reliefweb_utility/src/Helpers/ReliefWebStateHelper.php
@@ -140,4 +140,25 @@ class ReliefWebStateHelper {
     return \Drupal::state()->get("reliefweb_role_default_moderation_status:$entity_type_id:$bundle:$role:$right", $default);
   }
 
+  /**
+   * Get the publication protection default moderation status.
+   *
+   * @param string $entity_type_id
+   *   Entity type ID.
+   * @param string $bundle
+   *   Entity bundle.
+   * @param string $default
+   *   Default status.
+   *
+   * @return string
+   *   Moderation status.
+   */
+  public static function getPublicationPreventionDefaultModerationStatus(
+    string $entity_type_id,
+    string $bundle,
+    string $default = 'pending',
+  ): string {
+    return \Drupal::state()->get("reliefweb_publication_prevention_default_moderation_status:$entity_type_id:$bundle", $default);
+  }
+
 }


### PR DESCRIPTION
Refs: RW-1205

This introduces partial reimport of imported content to prevent losing changes from the editorial team.

@attiks there are some changes to the import base plugin, notably with an abstract method to implement: `processDocumentData`. Look at the ECHO importer on how to implement it in the inoreader importer. There are also new config settings for reimport to add. Probably you can use the UNCHR importer ones:

```
reimport:
  enabled: true
  fields: "*:no\r\nfile:yes"
  statuses: "published:to-review\r\nto-review:to-review\r\nrefused:refused"
  type: "*:none\r\npending:full\r\non-hold:partial\r\npublished:partial\r\nto-review:partial\r\nembargoed:partial"
  ```

