### PR TITLE
[RW-1227] Store attachment hashes and prevent duplication

### DIFF
--- a/html/modules/custom/reliefweb_files/reliefweb_files.install
+++ b/html/modules/custom/reliefweb_files/reliefweb_files.install
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ * Install file for the reliefweb_file module.
+ */
+
+/**
+ * Implements hook_update_N().
+ *
+ * Update the node field_file storage definition to add the file_hash field.
+ */
+function reliefweb_files_update_10001() {
+  // Get the cached schema data for the field.
+  $kv_schema = \Drupal::keyValue('entity.storage_schema.sql')->get('node.field_schema_data.field_file');
+
+  foreach ($kv_schema as $table => &$info) {
+    $schema = \Drupal::database()->schema();
+    if (!$schema->fieldExists($table, 'field_file_file_hash')) {
+      $spec = [
+        'type' => 'varchar_ascii',
+        'length' => 64,
+        'not null' => FALSE,
+      ];
+      $schema->addField($table, 'field_file_file_hash', $spec);
+    }
+
+    // Add index if appropriate.
+    if (!$schema->indexExists($table, 'field_file_file_hash')) {
+      $schema->addIndex($table, 'field_file_file_hash', ['field_file_file_hash'], [
+        'fields' => [
+          'field_file_file_hash' => [
+            'type' => 'varchar_ascii',
+            'length' => 64,
+            'not null' => FALSE,
+          ],
+        ],
+        'indexes' => [
+          'field_file_file_hash' => ['field_file_file_hash'],
+        ],
+      ]);
+    }
+
+    // Update schema info in the key-value storage.
+    $info['fields']['field_file_file_hash'] = [
+      'type' => 'varchar_ascii',
+      'length' => 64,
+      'not null' => FALSE,
+    ];
+    $info['indexes']['field_file_file_hash'] = ['field_file_file_hash'];
+  }
+
+  // Save the updated schema info.
+  \Drupal::keyValue('entity.storage_schema.sql')->set('node.field_schema_data.field_file', $kv_schema);
+
+  // Update field storage definition with flag to prevent auto schema updates.
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $field_storage_definition = $entity_definition_update_manager->getFieldStorageDefinition('field_file', 'node');
+  $field_storage_definition->setSetting('column_changes_handled', TRUE);
+  $entity_definition_update_manager->updateFieldStorageDefinition($field_storage_definition);
+}

--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldFormatter/ReliefWebFileFileName.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldFormatter/ReliefWebFileFileName.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\reliefweb_files\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'reliefweb_file' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "reliefweb_file_file_name",
+ *   label = @Translation("ReliefWeb File - File name"),
+ *   field_types = {
+ *     "reliefweb_file"
+ *   }
+ * )
+ */
+class ReliefWebFileFileName extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $item) {
+      $elements[] = ['#markup' => $item->getFileName()];
+    }
+    return $elements;
+  }
+
+}

--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldFormatter/ReliefWebFileFileUrl.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldFormatter/ReliefWebFileFileUrl.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\reliefweb_files\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'reliefweb_file' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "reliefweb_file_file_url",
+ *   label = @Translation("ReliefWeb File - File URL"),
+ *   field_types = {
+ *     "reliefweb_file"
+ *   }
+ * )
+ */
+class ReliefWebFileFileUrl extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $item) {
+      $elements[] = ['#markup' => $item->getFileUrl()?->toString()];
+    }
+    return $elements;
+  }
+
+}

--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldWidget/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldWidget/ReliefWebFile.php
@@ -486,6 +486,7 @@ class ReliefWebFile extends WidgetBase {
       'file_name',
       'file_mime',
       'file_size',
+      'file_hash',
       'page_count',
       'preview_uuid',
     ];
@@ -789,7 +790,8 @@ class ReliefWebFile extends WidgetBase {
    *   Form state.
    */
   protected function uploadFiles(array $element, FormStateInterface $form_state) {
-    $validators = $this->createFieldItem()->getUploadValidators();
+    $entity = $form_state->getFormObject()?->getEntity();
+    $validators = $this->createFieldItem()->getUploadValidators($entity);
     return $this->processUploadedFiles($element, $form_state, $element['#name'], $validators);
   }
 
@@ -856,7 +858,8 @@ class ReliefWebFile extends WidgetBase {
 
     // Retrieve the upload validators for the original item. This will
     // ensure the replacement is of the same type.
-    $validators = $previous_item->getUploadValidators();
+    $entity = $form_state->getFormObject()?->getEntity();
+    $validators = $previous_item->getUploadValidators($entity);
 
     // Create a new field item with associated managed files and replace the
     // original values with its values.
@@ -1242,6 +1245,9 @@ class ReliefWebFile extends WidgetBase {
     // Save the file.
     $file->setTemporary();
     $file->save();
+
+    // Set the file hash if there was no validation errors.
+    $item->updateFileHash();
 
     return $item;
   }

--- a/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileHashConstraint.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileHashConstraint.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\reliefweb_files\Plugin\Validation\Constraint;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Drupal\reliefweb_files\Plugin\Field\FieldType\ReliefWebFile;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
+
+/**
+ * File hash constraint.
+ */
+#[Constraint(
+  id: 'ReliefWebFileHash',
+  label: new TranslatableMarkup('ReliefWeb File Hash', [], ['context' => 'Validation']),
+  type: 'file'
+)]
+class ReliefWebFileHashConstraint extends SymfonyConstraint {
+
+  /**
+   * Duplicate file error message.
+   *
+   * @var string
+   */
+  public string $duplicateFileError = 'Duplicate detected: file "@uuid" is already attached to "@label" (:url).';
+
+  /**
+   * Duplicate file form error message.
+   *
+   * @var string
+   */
+  public string $duplicateFileFormError = 'Duplicate detected: this file is already attached to <a href=":url" target="_blank">@label</a>.';
+
+  /**
+   * Missing file error message.
+   *
+   * @var string
+   */
+  public string $missingFileError = 'Unable to validate missing file %uri.';
+
+  /**
+   * Empty hash error message.
+   *
+   * @var string
+   */
+  public string $emptyHashError = 'Unable to calculate the hash of the file %uri.';
+
+  /**
+   * The field item the file is attached to.
+   *
+   * @var \Drupal\reliefweb_files\Plugin\Field\FieldType\ReliefWebFile
+   */
+  public ReliefWebFile $fieldItem;
+
+  /**
+   * The entity the file is attached to.
+   *
+   * @var ?\Drupal\Core\Entity\EntityInterface
+   */
+  public ?EntityInterface $entity;
+
+  /**
+   * Whether to the constraint is applied in a form a or not.
+   *
+   * @var bool
+   */
+  public bool $inForm = TRUE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultOption(): string {
+    return 'fieldItem';
+  }
+
+}

--- a/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileHashConstraintValidator.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileHashConstraintValidator.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\reliefweb_files\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\file\Plugin\Validation\Constraint\BaseFileConstraintValidator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validates the ReliefWeb file hash constraint.
+ */
+class ReliefWebFileHashConstraintValidator extends BaseFileConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate(mixed $value, Constraint $constraint) {
+    $file = $this->assertValueIsFile($value);
+    if (!$constraint instanceof ReliefWebFileHashConstraint) {
+      throw new UnexpectedTypeException($constraint, ReliefWebFileHashConstraint::class);
+    }
+
+    $uri = $file->getFileUri();
+    if (!file_exists($uri)) {
+      $this->context->addViolation($constraint->missingFileError, [
+        '%uri' => $uri,
+      ]);
+      return;
+    }
+
+    $field_item = $constraint->fieldItem;
+    $field_definition = $field_item->getFieldDefinition();
+    $field_name = $field_definition->getName();
+    $entity_type_id = $field_definition->getTargetEntityTypeId();
+
+    // Compute the file hash.
+    $hash = $field_item->calculateFileHashFromUri($uri);
+    if (empty($hash)) {
+      $this->context->addViolation($constraint->emptyHashError, [
+        '%uri' => $uri,
+      ]);
+      return;
+    }
+
+    // Retrieve entities with the same file hash.
+    $entities = $this->entityTypeManager
+      ->getStorage($entity_type_id)
+      ->loadByProperties([
+        $field_name . '.file_hash' => $hash,
+      ]);
+
+    if (empty($entities)) {
+      return;
+    }
+
+    $entity_id = $constraint->entity?->id();
+    $url_options = ['absolute' => TRUE];
+
+    // If there is an entity other than the one the file is attached to,
+    // then flag this as a duplication error.
+    ksort($entities);
+    foreach ($entities as $entity) {
+      if ($entity->id() !== $entity_id) {
+        $this->context->setConstraint($constraint);
+        if ($constraint->inForm) {
+          $this->context->addViolation($constraint->duplicateFileFormError, [
+            '@label' => $entity->label(),
+            ':url' => $entity->toUrl(options: $url_options)->toString(),
+          ]);
+        }
+        else {
+          $this->context->addViolation($constraint->duplicateFileError, [
+            '@uuid' => $field_item->getUuid(),
+            '@label' => $entity->label(),
+            ':url' => $entity->toUrl(options: $url_options)->toString(),
+          ]);
+        }
+        return;
+      }
+    }
+  }
+
+}

--- a/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileRealMimeTypeConstraint.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileRealMimeTypeConstraint.php
@@ -26,7 +26,7 @@ class ReliefWebFileRealMimeTypeConstraint extends SymfonyConstraint {
   public string $mimetypeMismatchError = 'Content type mismatch: This file claims to be %current_mimetype but is actually %content_mimetype.';
 
   /**
-   * File missing error message.
+   * Missing file error message.
    *
    * @var string
    */

--- a/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileRealMimeTypeConstraintValidator.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Validation/Constraint/ReliefWebFileRealMimeTypeConstraintValidator.php
@@ -108,7 +108,7 @@ class ReliefWebFileRealMimeTypeConstraintValidator extends BaseFileConstraintVal
 
     $uri = $file->getFileUri();
     if (!file_exists($uri)) {
-      $this->context->addViolation($constraint->fileMissingError, [
+      $this->context->addViolation($constraint->missingFileError, [
         '%uri' => $uri,
       ]);
       return;

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/EchoFlashUpdateImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/EchoFlashUpdateImporter.php
@@ -8,8 +8,9 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\reliefweb_import\Attribute\ReliefWebImporter;
 use Drupal\reliefweb_import\Plugin\ReliefWebImporterPluginBase;
-use Drupal\reliefweb_post_api\Plugin\ContentProcessorPluginInterface;
+use Drupal\reliefweb_post_api\Exception\DuplicateException;
 use Drupal\reliefweb_post_api\Helpers\HashHelper;
+use Drupal\reliefweb_post_api\Plugin\ContentProcessorPluginInterface;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
 
 /**
@@ -379,7 +380,13 @@ class EchoFlashUpdateImporter extends ReliefWebImporterPluginBase {
       catch (\Exception $exception) {
         $import_record['status'] = 'error';
         $import_record['message'] = $exception->getMessage();
-        $import_record['attempts'] = ($import_record['attempts'] ?? 0) + 1;
+        // In case of duplication, we do not try further imports.
+        if ($exception instanceof DuplicateException) {
+          $import_record['attempts'] = $max_import_attempts;
+        }
+        else {
+          $import_record['attempts'] = ($import_record['attempts'] ?? 0) + 1;
+        }
         $this->getLogger()->error(strtr('Unable to process Echo Flash Update document @id: @exception', [
           '@id' => $id,
           '@exception' => $exception->getMessage(),

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/InoreaderImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/InoreaderImporter.php
@@ -10,6 +10,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\ocha_content_classification\Entity\ClassificationWorkflowInterface;
 use Drupal\reliefweb_import\Attribute\ReliefWebImporter;
 use Drupal\reliefweb_import\Plugin\ReliefWebImporterPluginBase;
+use Drupal\reliefweb_post_api\Exception\DuplicateException;
 use Drupal\reliefweb_post_api\Helpers\HashHelper;
 use Drupal\reliefweb_post_api\Plugin\ContentProcessorPluginInterface;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
@@ -476,7 +477,13 @@ class InoreaderImporter extends ReliefWebImporterPluginBase {
       catch (\Exception $exception) {
         $import_record['status'] = 'error';
         $import_record['message'] = $exception->getMessage();
-        $import_record['attempts'] = ($import_record['attempts'] ?? 0) + 1;
+        // In case of duplication, we do not try further imports.
+        if ($exception instanceof DuplicateException) {
+          $import_record['attempts'] = $max_import_attempts;
+        }
+        else {
+          $import_record['attempts'] = ($import_record['attempts'] ?? 0) + 1;
+        }
         $this->getLogger()->error(strtr('Unable to process Inoreader @id: @exception', [
           '@id' => $id,
           '@exception' => $exception->getMessage(),

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
@@ -9,8 +9,9 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\reliefweb_import\Attribute\ReliefWebImporter;
 use Drupal\reliefweb_import\Plugin\ReliefWebImporterPluginBase;
-use Drupal\reliefweb_post_api\Plugin\ContentProcessorPluginInterface;
+use Drupal\reliefweb_post_api\Exception\DuplicateException;
 use Drupal\reliefweb_post_api\Helpers\HashHelper;
+use Drupal\reliefweb_post_api\Plugin\ContentProcessorPluginInterface;
 use Drupal\reliefweb_utility\Helpers\DateHelper;
 
 /**
@@ -426,7 +427,13 @@ class WfpLogClusterImporter extends ReliefWebImporterPluginBase {
       catch (\Exception $exception) {
         $import_record['status'] = 'error';
         $import_record['message'] = $exception->getMessage();
-        $import_record['attempts'] = ($import_record['attempts'] ?? 0) + 1;
+        // In case of duplication, we do not try further imports.
+        if ($exception instanceof DuplicateException) {
+          $import_record['attempts'] = $max_import_attempts;
+        }
+        else {
+          $import_record['attempts'] = ($import_record['attempts'] ?? 0) + 1;
+        }
         $this->getLogger()->error(strtr('Unable to process WFP Logcluster document @id: @exception', [
           '@id' => $id,
           '@exception' => $exception->getMessage(),

--- a/html/modules/custom/reliefweb_post_api/src/Exception/DuplicateException.php
+++ b/html/modules/custom/reliefweb_post_api/src/Exception/DuplicateException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\reliefweb_post_api\Exception;
+
+use Drupal\reliefweb_post_api\Plugin\ContentProcessorException;
+
+/**
+ * Error for duplication.
+ */
+class DuplicateException extends ContentProcessorException implements ExceptionInterface {}

--- a/html/modules/custom/reliefweb_post_api/src/Exception/ExceptionInterface.php
+++ b/html/modules/custom/reliefweb_post_api/src/Exception/ExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\reliefweb_post_api\Exception;
+
+/**
+ * Extension interface for the module.
+ */
+interface ExceptionInterface {}

--- a/html/modules/custom/reliefweb_post_api/src/Plugin/ContentProcessorPluginInterface.php
+++ b/html/modules/custom/reliefweb_post_api/src/Plugin/ContentProcessorPluginInterface.php
@@ -419,6 +419,8 @@ interface ContentProcessorPluginInterface {
    *
    * @param \Drupal\Core\TypedData\DataDefinitionInterface $definition
    *   Field item definition.
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   Entity the file field item will be attached to.
    * @param string $uuid
    *   File UUID.
    * @param string $file_name
@@ -435,7 +437,7 @@ interface ContentProcessorPluginInterface {
    * @return \Drupal\reliefweb_files\Plugin\Field\FieldType\ReliefWebFile|null
    *   ReliefWeb file field item.
    */
-  public function createReliefWebFileFieldItem(DataDefinitionInterface $definition, string $uuid, string $file_name, string $url, string $checksum, string $mimetype, string $max_size = ''): ?ReliefWebFile;
+  public function createReliefWebFileFieldItem(DataDefinitionInterface $definition, ContentEntityInterface $entity, string $uuid, string $file_name, string $url, string $checksum, string $mimetype, string $max_size = ''): ?ReliefWebFile;
 
   /**
    * Create and validate a file.

--- a/html/modules/custom/reliefweb_post_api/src/Plugin/reliefweb_post_api/ContentProcessor/Report.php
+++ b/html/modules/custom/reliefweb_post_api/src/Plugin/reliefweb_post_api/ContentProcessor/Report.php
@@ -6,7 +6,9 @@ namespace Drupal\reliefweb_post_api\Plugin\reliefweb_post_api\ContentProcessor;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
 use Drupal\reliefweb_post_api\Attribute\ContentProcessor;
+use Drupal\reliefweb_post_api\Exception\DuplicateException;
 use Drupal\reliefweb_post_api\Plugin\ContentProcessorException;
 use Drupal\reliefweb_post_api\Plugin\ContentProcessorPluginBase;
 
@@ -79,6 +81,37 @@ class Report extends ContentProcessorPluginBase {
         '@uuid' => $file['uuid'],
         '@url' => $file['url'],
       ]));
+    }
+
+    if ($type === 'file') {
+      if (empty($file['checksum'])) {
+        throw new ContentProcessorException(strtr('Missing @type checksum.', [
+          '@type' => $type,
+        ]));
+      }
+
+      $query = $this->database->select('node_field_data', 'n');
+      $query->join('node__field_file', 'ff', 'n.nid = ff.entity_id');
+      $query->leftJoin('path_alias', 'pa', "pa.path = CONCAT('/node/', n.nid)");
+
+      $result = $query
+        ->fields('n', ['title'])
+        ->fields('pa', ['alias'])
+        ->condition('n.type', 'report')
+        ->condition('ff.field_file_file_hash', $file['checksum'])
+        ->orderBy('n.nid', 'ASC')
+        ->range(0, 1)
+        ->execute()
+        ?->fetchAssoc();
+
+      if (!empty($result)) {
+        $url = Url::fromUserInput($result['alias'] ?: '/node/' . $nid, ['absolute' => TRUE]);
+        throw new DuplicateException(strtr('Duplicate detected: file "@uuid" is already attached to "@label" (:url).', [
+          '@uuid' => $file['uuid'],
+          '@label' => $result['title'],
+          ':url' => $url->toString(),
+        ]));
+      }
     }
   }
 

--- a/html/modules/custom/reliefweb_post_api/tests/src/ExistingSite/Plugin/ContentProcessorPluginBaseTest.php
+++ b/html/modules/custom/reliefweb_post_api/tests/src/ExistingSite/Plugin/ContentProcessorPluginBaseTest.php
@@ -1128,6 +1128,7 @@ abstract class ContentProcessorPluginBaseTest extends ExistingSiteBase {
 
     $item = $plugin->createReliefWebFileFieldItem(
       definition: $definition,
+      entity: $entity,
       uuid: 'bda0e2da-4229-53aa-9206-db72dfdac519',
       file_name: 'test.pdf',
       url: 'https://test.test/test.pdf',
@@ -1177,6 +1178,7 @@ abstract class ContentProcessorPluginBaseTest extends ExistingSiteBase {
 
     $plugin->createReliefWebFileFieldItem(
       definition: $definition,
+      entity: $entity,
       uuid: 'bda0e2da-4229-53aa-9206-db72dfdac519',
       file_name: 'test.pdf',
       url: 'https://test.test/test.pdf',


### PR DESCRIPTION
Refs: RW-1227

This adds a property to store the report attachment hash and a constraint to prevent duplication.
This also adjusts the post API to also handle file duplication and straight-up refuse submissions in that case.