### PR TITLE
[RW-1207] Log cluster import fixes

### DIFF
--- a/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
+++ b/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
@@ -1,18 +1,18 @@
-enabled: 1
-max_import_attempts: '3'
+enabled: true
+max_import_attempts: 3
 classification:
   enabled: false
-  check_user_permissions: 0
-  prevent_publication: 0
+  check_user_permissions: false
+  prevent_publication: false
   specified_field_check: '*:no'
   force_field_update: "*:yes\r\nfield_source:no"
   classified_fields: "*:yes\r\nfield_source:no"
 reimport:
-  enabled: 0
+  enabled: false
   type: ''
   fields: ''
   statuses: ''
 api_url: 'https://api.logcluster.org/1.0.0/en/activity-documents'
 api_key: xyzzy
 max_age: 5
-timeout: '10'
+timeout: 10

--- a/html/modules/custom/reliefweb_import/config/schema/reliefweb_import.schema.yml
+++ b/html/modules/custom/reliefweb_import/config/schema/reliefweb_import.schema.yml
@@ -131,6 +131,9 @@ reliefweb_import.plugin.importer.wfp_logcluster:
     max_age:
       type: integer
       label: 'Max age in days.'
+    skip_document_types:
+      type: string
+      label: List of Logistic Cluster document types to skip.'
     timeout:
       type: integer
       label: 'Connection and request timeout.'

--- a/html/modules/custom/reliefweb_import/config/schema/reliefweb_import.schema.yml
+++ b/html/modules/custom/reliefweb_import/config/schema/reliefweb_import.schema.yml
@@ -129,7 +129,7 @@ reliefweb_import.plugin.importer.wfp_logcluster:
       type: string
       label: 'API Key.'
     max_age:
-      type: string
+      type: integer
       label: 'Max age in days.'
     timeout:
       type: integer

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
@@ -67,7 +67,7 @@ class WfpLogClusterImporter extends ReliefWebImporterPluginBase {
     'Infographic' => 12570,
     'Lessons Learned' => 6,
     'Main documents' => 9,
-    'Maps' => 'Map',
+    'Maps' => 12,
     'Meeting Minutes' => 9,
     'NFR' => 9,
     'Operation Overview' => 9,

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
@@ -288,6 +288,17 @@ class WfpLogClusterImporter extends ReliefWebImporterPluginBase {
     // Max import attempts.
     $max_import_attempts = $this->getPluginSetting('max_import_attempts', 3, FALSE);
 
+    // Fix the document paths.
+    // Make sure the document path is to the Logistic Cluster site not its API.
+    // The path is correct when using the `documents` endpoint but incorrect
+    // when using the `activity-documents` endpoint.
+    foreach ($documents as $key => $document) {
+      if (isset($document['path'])) {
+        $url = str_replace('://api.', '://', $document['path'] ?? '');
+        $documents[$key]['path'] = $url;
+      }
+    }
+
     // Retrieve the list of existing import records for the documents.
     $uuids = array_filter(array_map(fn($item) => $this->generateUuid($item['path'] ?? ''), $documents));
     $existing_import_records = $this->getExistingImportRecords($uuids);

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
@@ -499,7 +499,7 @@ class WfpLogClusterImporter extends ReliefWebImporterPluginBase {
     $body = '';
 
     // Retrieve the publication date.
-    $published = strtotime($document['last_update'] ?? $document['date']);
+    $published = strtotime($document['date'] ?? $document['last_update']);
     $published = DateHelper::format($published, 'custom', 'c');
 
     // Retrieve the document languages and default to English if none of the

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/WfpLogClusterImporter.php
@@ -114,10 +114,11 @@ class WfpLogClusterImporter extends ReliefWebImporterPluginBase {
     ];
 
     $form['max_age'] = [
-      '#type' => 'textfield',
+      '#type' => 'number',
       '#title' => $this->t('Max age in days of documents to retrieve'),
       '#description' => $this->t('The maximum age in days of documents to retrieve.'),
-      '#default_value' => $form_state->getValue('max_age', $this->getPluginSetting('max_age', '', FALSE)),
+      '#default_value' => $form_state->getValue('max_age', $this->getPluginSetting('max_age', 3, FALSE)),
+      '#min' => 1,
       '#required' => TRUE,
     ];
 


### PR DESCRIPTION
Refs: RW-1207

- proper mapping for maps in logcluster importer
- ensure the logcluser document path are to the main site not the api
- skip import of documents already manually posted
- make sure to use the document date for the original publication date not the last update to match the content on the log cluster site
- log cluster schema max age type
- add logcluster importer plugin setting to skip some document types