### PR TITLE
[RW-1207] Log cluster importer config change proposal

### DIFF
--- a/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
+++ b/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
@@ -14,5 +14,5 @@ reimport:
   statuses: ''
 api_url: 'https://api.logcluster.org/1.0.0/en/documents'
 api_key: xyzzy
-max_age: 5
+max_age: 3
 timeout: 10

--- a/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
+++ b/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
@@ -15,4 +15,5 @@ reimport:
 api_url: 'https://api.logcluster.org/1.0.0/en/documents'
 api_key: xyzzy
 max_age: 3
+skip_document_types: 'Meeting Minutes'
 timeout: 10

--- a/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
+++ b/config/reliefweb_import.plugin.importer.wfp_logcluster.yml
@@ -12,7 +12,7 @@ reimport:
   type: ''
   fields: ''
   statuses: ''
-api_url: 'https://api.logcluster.org/1.0.0/en/activity-documents'
+api_url: 'https://api.logcluster.org/1.0.0/en/documents'
 api_key: xyzzy
 max_age: 5
 timeout: 10


### PR DESCRIPTION
Refs: RW-1207

@attiks This is relates to my questions in the [ticket](https://humanitarian.atlassian.net/browse/RW-1207?focusedCommentId=203530):

- Use `documents` endpoint instead of `activity-documents` to match the inoreader feeds and have documents sorted by date
- Reduce max-age to 3 days to avoid trying to import the same documents over and over
- Exclude "Meeting Minutes".