### PR TITLE
fix(chore): Avoid a deprecation warning by not passing a null into parse_str when a url has no query part.

### DIFF
--- a/html/modules/custom/reliefweb_rivers/src/Parameters.php
+++ b/html/modules/custom/reliefweb_rivers/src/Parameters.php
@@ -482,7 +482,8 @@ class Parameters {
   public static function createFromUrl($url, array $exclude = ['q', 'page']) {
     $query = [];
     if (is_string($url)) {
-      parse_str(parse_url($url, PHP_URL_QUERY), $query);
+      $parsed = parse_url($url, PHP_URL_QUERY) ?? '';
+      parse_str($parsed, $query);
     }
     return new static($query, $exclude);
   }


### PR DESCRIPTION
Using a temporary variable for readbility.