### PR TITLE
chore: Remove the text underline from the login button-ish links by popular request.

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-document/rw-document.css
@@ -136,6 +136,7 @@
   border-radius: 3px;
   background: var(--cd-reliefweb-brand-blue--dark);
   font-weight: bold;
+  text-decoration: none;
 }
 .rw-document.rw-article--book .rw-article__content a[href^="/user/login/"]:hover,
 .rw-document.rw-article--book .rw-article__content a[href^="/user/login/"]:focus,


### PR DESCRIPTION
Colour changes, tiny icon images and other style changes are likely to follow in the not too distant future.