### PR TITLE
Chore: D11 compatibility of composer update action until all modules support D11

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -22,3 +22,4 @@ jobs:
         slack_channel_name: ${{ vars.SLACK_CHANNEL }}
         source_directory: html/modules/custom,html/themes/custom
         output_format: "table"
+        composer_scripts: "true"


### PR DESCRIPTION
Allow scripts so the "lenient" script that is necessary for some modules still requiring D10 in their info file can be installed.