### PR TITLE
[RW-1308] Prevent type error when there is no file available to generate its hash

### DIFF
--- a/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
+++ b/html/modules/custom/reliefweb_files/src/Plugin/Field/FieldType/ReliefWebFile.php
@@ -1991,10 +1991,10 @@ class ReliefWebFile extends FieldItemBase {
   /**
    * Update the file item's file hash.
    *
-   * @return string
+   * @return ?string
    *   The new file hash.
    */
-  public function updateFileHash(): string {
+  public function updateFileHash(): ?string {
     $file = $this->loadFile();
     if (empty($file)) {
       throw new \Exception('Unable to load the new local file to update the hash.');


### PR DESCRIPTION
Refs: RW-1308

Fix for the issues with the imports on the test envs after the weekly reset.