### PR TITLE
[RW-1350] Ensure the entity updated fields is a list

### DIFF
--- a/html/modules/custom/reliefweb_ai/reliefweb_ai.module
+++ b/html/modules/custom/reliefweb_ai/reliefweb_ai.module
@@ -259,7 +259,10 @@ function reliefweb_ai_ocha_content_classification_post_classify_entity(
     $data,
   ) ?? [];
 
-  return array_unique(array_merge($language_updated_fields, $body_updated_fields)) ?: NULL;
+  return array_values(array_unique(array_merge(
+    $language_updated_fields,
+    $body_updated_fields
+  ))) ?: NULL;
 }
 
 /**
@@ -293,57 +296,53 @@ function reliefweb_ai_post_classification_language_update(
 
   // Call the hook so other modules can set the language.
   $module_handler = \Drupal::moduleHandler();
-  $lang_code = $module_handler->invokeAll('reliefweb_ai_force_language', [$entity]);
-  if ($lang_code) {
+  $language_term_ids = $module_handler->invokeAll('reliefweb_ai_force_language', [$entity]);
+  if (!empty($language_term_ids)) {
     // If multiple modules return a language, use the first non-null one.
-    if (is_array($lang_code)) {
-      $lang_code = array_values($lang_code);
-      $lang_code = reset($lang_code);
-    }
-    if ($lang_code) {
-      $entity->set('field_language', $lang_code);
-      return ['field_language'];
-    }
-  }
-
-  $settings = \Drupal::config('reliefweb_ai.settings')->get('language_detection');
-  if (empty($settings)) {
-    return NULL;
-  }
-
-  // Retrieve the text samples extracted from the source document.
-  $tag = $settings['tag'] ?? 'content';
-  $text = reliefweb_ai_extract_text_from_llm_output($data['output'], $tag, $classifier);
-
-  // Add the title.
-  if (!empty($settings['use_title'])) {
-    $title = (string) $entity->label();
-    $text = $title . ' ' . $text;
-  }
-
-  $text = trim(strip_tags($text));
-  if (!empty($text)) {
-    // Detect the language from the content returned by the AI.
-    $language = LanguageHelper::detectTextLanguage($text);
+    $language_term_id = reset($language_term_ids);
   }
   else {
-    // Default to English.
-    $language = 'en';
+    $settings = \Drupal::config('reliefweb_ai.settings')->get('language_detection');
+    if (empty($settings)) {
+      return NULL;
+    }
+
+    // Retrieve the text samples extracted from the source document.
+    $tag = $settings['tag'] ?? 'content';
+    $text = reliefweb_ai_extract_text_from_llm_output($data['output'], $tag, $classifier);
+
+    // Add the title.
+    if (!empty($settings['use_title'])) {
+      $title = (string) $entity->label();
+      $text = $title . ' ' . $text;
+    }
+
+    $text = trim(strip_tags($text));
+    if (!empty($text)) {
+      // Detect the language from the content returned by the AI.
+      $language = LanguageHelper::detectTextLanguage($text);
+    }
+    else {
+      // Default to Other.
+      $language = 'ot';
+    }
+
+    // Retrieve the available languages.
+    $languages = \Drupal::database()
+      ->select('taxonomy_term__field_language_code', 't')
+      ->fields('t', ['field_language_code_value', 'entity_id'])
+      ->execute()
+      ?->fetchAllKeyed() ?? [];
+    $languages = array_change_key_case($languages, \CASE_LOWER);
+
+    // Default to Other if there is no matching term for the language code.
+    $language_term_id = $languages[$language] ?? $languages['ot'] ?? NULL;
   }
 
-  // Retrieve the available languages.
-  $languages = \Drupal::database()
-    ->select('taxonomy_term__field_language_code', 't')
-    ->fields('t', ['field_language_code_value', 'entity_id'])
-    ->execute()
-    ?->fetchAllKeyed() ?? [];
-  $languages = array_change_key_case($languages, \CASE_LOWER);
-
-  // Default to Other if there is no matching term for the language code.
-  $language_term_id = $languages[$language] ?? $languages['ot'] ?? NULL;
-
   // Update the entity with the detected language.
-  if ($language_term_id != $entity->field_language?->target_id) {
+  // No strict equality comparison since the ID may be a numeric string or an
+  // an integer.
+  if (isset($language_term_id) && $language_term_id != $entity->field_language?->target_id) {
     $entity->set('field_language', $language_term_id);
     return ['field_language'];
   }
@@ -704,10 +703,12 @@ function reliefweb_ai_add_ai_updated_fields_to_entity(EntityInterface $entity): 
     return;
   }
 
-  $updated_fields = json_decode($record->updated_fields);
-  if (empty($updated_fields)) {
+  $updated_fields = json_decode($record->updated_fields, TRUE);
+  if (empty($updated_fields) || !is_array($updated_fields)) {
     return;
   }
+
+  $updated_fields = array_values($updated_fields);
 
   // Not using strict equality because they may be numeric strings.
   if ($entity->getRevisionId() != $record->entity_revision_id) {

--- a/html/modules/custom/reliefweb_import/reliefweb_import.module
+++ b/html/modules/custom/reliefweb_import/reliefweb_import.module
@@ -149,12 +149,19 @@ function reliefweb_import_ocha_content_classification_post_classify_entity(
 ): ?array {
   $importer = reliefweb_import_get_entity_importer($entity);
   if (!isset($importer)) {
-    return $updated_fields;
+    return NULL;
   }
 
   // Let the importer decide which entity fields to update.
-  $importer->alterContentClassificationPostClassify($entity, $updated_fields);
-  return array_unique(array_values($updated_fields));
+  $fields = $importer->contentClassificationPostClassify(
+    $entity,
+    $workflow,
+    $classifier,
+    $updated_fields,
+    $data
+  ) ?? [];
+
+  return array_values(array_unique($fields)) ?: NULL;
 }
 
 /**
@@ -162,7 +169,7 @@ function reliefweb_import_ocha_content_classification_post_classify_entity(
  */
 function reliefweb_import_reliefweb_ai_force_language(
   EntityInterface $entity,
-): ?string {
+): string|int|null {
   $importer = reliefweb_import_get_entity_importer($entity);
   if (!isset($importer)) {
     return NULL;

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/InoreaderImporter.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporter/InoreaderImporter.php
@@ -582,7 +582,7 @@ class InoreaderImporter extends ReliefWebImporterPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function forceContentLanguage(EntityInterface $entity): ?string {
+  public function forceContentLanguage(EntityInterface $entity): string|int|null {
     // Retrieve the import record and check if there is a defined language.
     $record = $this->getImportRecordForEntity($entity);
     if (empty($record)) {
@@ -599,6 +599,7 @@ class InoreaderImporter extends ReliefWebImporterPluginBase {
         return NULL;
       }
 
+      // Return the term ID matching the language code.
       return $defined_languages[$tags['language']];
     }
 

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginBase.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginBase.php
@@ -25,6 +25,7 @@ use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\ocha_content_classification\Entity\ClassificationWorkflowInterface;
+use Drupal\ocha_content_classification\Plugin\ClassifierPluginInterface;
 use Drupal\reliefweb_import\Exception\InvalidConfigurationException;
 use Drupal\reliefweb_import\Exception\ReliefwebImportException;
 use Drupal\reliefweb_import\Exception\ReliefwebImportExceptionIllegalFilename;
@@ -653,8 +654,16 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
   /**
    * {@inheritdoc}
    */
-  public function alterContentClassificationPostClassify(EntityInterface $entity, array &$updated_fields): void {
-    // Perform operations after classification.
+  public function contentClassificationPostClassify(
+    EntityInterface $entity,
+    ClassificationWorkflowInterface $workflow,
+    ClassifierPluginInterface $classifier,
+    array $updated_fields,
+    array $data,
+  ): ?array {
+    // Perform operations after classification and return a list of changed
+    // entity fields if any.
+    return NULL;
   }
 
   /**
@@ -667,7 +676,7 @@ abstract class ReliefWebImporterPluginBase extends PluginBase implements ReliefW
   /**
    * {@inheritdoc}
    */
-  public function forceContentLanguage(EntityInterface $entity): ?string {
+  public function forceContentLanguage(EntityInterface $entity): string|int|null {
     // Let AI determine the language.
     return NULL;
   }

--- a/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginInterface.php
+++ b/html/modules/custom/reliefweb_import/src/Plugin/ReliefWebImporterPluginInterface.php
@@ -7,6 +7,7 @@ namespace Drupal\reliefweb_import\Plugin;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\ocha_content_classification\Entity\ClassificationWorkflowInterface;
+use Drupal\ocha_content_classification\Plugin\ClassifierPluginInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -264,12 +265,39 @@ interface ReliefWebImporterPluginInterface {
    *
    * This hook is invoked after an entity has been classified, allowing modules
    * to perform additional operations.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity that was classified.
+   * @param \Drupal\ocha_content_classification\Entity\ClassificationWorkflowInterface $workflow
+   *   The workflow used for classification.
+   * @param \Drupal\ocha_content_classification\Plugin\ClassifierPluginInterface $classifier
+   *   The classifier plugin that performed the classification.
+   * @param array $updated_fields
+   *   Fields of the entity that were updated during the classification.
+   * @param array $data
+   *   Data used for the classification. This depends on the classifier.
+   *
+   * @return ?array
+   *   List of changed entity fields, if any.
    */
-  public function alterContentClassificationPostClassify(EntityInterface $entity, array &$updated_fields): void;
+  public function contentClassificationPostClassify(
+    EntityInterface $entity,
+    ClassificationWorkflowInterface $workflow,
+    ClassifierPluginInterface $classifier,
+    array $updated_fields,
+    array $data,
+  ): ?array;
 
   /**
    * Force content language for the entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity that is having its language field updated.
+   *
+   * @return string|int|null
+   *   The language taxonomy term ID to use for the language field or NULL to
+   *   let the existing field as is.
    */
-  public function forceContentLanguage(EntityInterface $entity): ?string;
+  public function forceContentLanguage(EntityInterface $entity): string|int|null;
 
 }


### PR DESCRIPTION
Refs: RW-1350

This fixes the implementation of the post classify hook in reliefweb_import, language force update hook and ensures the entity updated fields is a list not an associative array.