### PR TITLE
fix(bug): Drop all prompt settings, so Entra ID decides how users login.

### DIFF
--- a/config/openid_connect.client.entraid.yml
+++ b/config/openid_connect.client.entraid.yml
@@ -24,11 +24,6 @@ settings:
   userinfo_graph_api_use_other_mails: false
   userinfo_update_email: true
   hide_email_address_warning: false
-  prompt:
-    none: '0'
-    login: '0'
-    consent: '0'
-    select_account: '0'
-    create: '0'
+  prompt: {}
   subject_key: sub
   front_channel_logout_url: ''


### PR DESCRIPTION
This incorrect setting causes an array of zeroes to be sent, which causes an error and prevents logins.

Refs: OPS-12019