### PR TITLE
fix: Ensure the logger.drupaltodrush service is always included in the container.

### DIFF
--- a/docker/services.yml
+++ b/docker/services.yml
@@ -173,3 +173,8 @@ parameters:
 services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory
+  logger.drupaltodrush:
+    class: Drush\Log\DrushLog
+    arguments: ['@logger.log_message_parser']
+    tags:
+      - { name: logger }


### PR DESCRIPTION
This way, drush tasks will be able to log output even if the container is rebuilt via a web request.

Refs: RW-1529